### PR TITLE
feat: Add code coverage collection and reporting

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -122,8 +122,17 @@ jobs:
       - name: Analyze code
         run: flutter analyze --no-fatal-infos
 
-      - name: Run tests
-        run: flutter test
+      - name: Run tests with coverage
+        run: flutter test --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Build web after tests pass
   build-web:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Flutter app for browsing beers, ciders, meads, and more at the Cambridge Beer 
 
 - [Flutter SDK](https://docs.flutter.dev/get-started/install) (3.24.5 or later)
 - Android Studio, Xcode, or VS Code with Flutter extensions
+- (Optional) [mise](https://mise.jdx.dev/) for automatic tool version management
 
 ### Installation
 
@@ -34,11 +35,35 @@ A Flutter app for browsing beers, ciders, meads, and more at the Cambridge Beer 
 git clone https://github.com/richardthe3rd/cambridge-beer-festival-app.git
 cd cambridge-beer-festival-app
 
-# Get dependencies
+# Option 1: Using mise (recommended)
+mise install  # Automatically installs Flutter 3.24.5, Node 21, and other tools
+flutter pub get
+
+# Option 2: Manual setup
 flutter pub get
 
 # Run the app
 flutter run
+```
+
+### Development Tasks
+
+If using mise, you can run these convenient tasks:
+
+```bash
+mise run test      # Run all tests
+mise run coverage  # Generate code coverage report
+mise run analyze   # Analyze code for issues
+mise run dev       # Run app on web (localhost:8080)
+```
+
+Or run them directly:
+
+```bash
+flutter test                    # Run tests
+flutter test --coverage         # Run tests with coverage
+flutter analyze --no-fatal-infos # Analyze code
+flutter run -d web-server --web-port 8080  # Run on web
 ```
 
 ### Building
@@ -68,6 +93,37 @@ lib/
 ├── services/              # API and storage services
 └── widgets/               # Reusable UI components
 ```
+
+## Testing and Coverage
+
+This project uses Flutter's built-in testing framework and includes comprehensive test coverage:
+
+```bash
+# Run all tests
+flutter test
+
+# Generate coverage report
+flutter test --coverage
+
+# Or using mise
+mise run coverage
+```
+
+Code coverage is automatically collected and reported in CI. Coverage reports are uploaded to Codecov on each push/PR.
+
+### Setting up Codecov (Optional)
+
+To enable Codecov reporting:
+
+1. Sign up at [codecov.io](https://codecov.io) and link your GitHub account
+2. Add your repository to Codecov
+3. Get your upload token from Codecov
+4. Add the token as a GitHub secret:
+   - Go to Settings → Secrets and variables → Actions
+   - Add a new secret named `CODECOV_TOKEN` with your Codecov token
+5. The CI pipeline will automatically upload coverage on each run
+
+**Note:** For public repositories, Codecov works without a token, but adding one provides more features and reliability.
 
 ## Data API
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 5%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 80%
+        threshold: 10%
+
+ignore:
+  - "**/*.g.dart"
+  - "**/*.freezed.dart"
+  - "**/*.mocks.dart"
+  - "**/main.dart"
+  - "test/**"
+
+comment:
+  layout: "header, diff, files"
+  behavior: default
+  require_changes: false

--- a/mise.toml
+++ b/mise.toml
@@ -18,6 +18,14 @@ node = "21"
 [tasks.test]
 run = 'flutter test'
 
+[tasks.coverage]
+run = '''
+dart run build_runner build --delete-conflicting-outputs
+flutter test --coverage
+echo "Coverage report generated at coverage/lcov.info"
+echo "To view HTML report, install lcov and run: genhtml coverage/lcov.info -o coverage/html"
+'''
+
 [tasks.analyze]
 run = 'flutter analyze --no-fatal-infos'
 


### PR DESCRIPTION
## Summary

Adds comprehensive code coverage tracking to the project with local generation support and automatic CI reporting to Codecov.

## Changes

### CI/CD Integration
- **Modified:** `.github/workflows/build-deploy.yml`
  - Run tests with `--coverage` flag
  - Upload coverage to Codecov after test completion
  - Token-based authentication (optional for public repos)
  - Verbose output for debugging

### Coverage Configuration
- **Added:** `codecov.yml`
  - Project coverage target: 70% (with 5% threshold)
  - New code coverage target: 80% (with 10% threshold)
  - Ignore generated files (*.g.dart, *.mocks.dart, *.freezed.dart)
  - PR comment with coverage diff and file breakdown

### Developer Experience
- **Modified:** `mise.toml`
  - New task: `mise run coverage` for local coverage generation
  - Automatically generates mocks and runs tests with coverage
  - Helpful output with instructions for HTML report generation

- **Modified:** `README.md`
  - New "Testing and Coverage" section with setup instructions
  - Document mise development tasks (test, coverage, analyze, dev)
  - Codecov setup guide for maintainers
  - Note about token being optional for public repos

## Local Usage

```bash
# Generate coverage locally
mise run coverage

# Or manually
flutter test --coverage

# Generate HTML report (requires lcov)
genhtml coverage/lcov.info -o coverage/html
```

## Codecov Setup (Optional)

For enhanced features:
1. Sign up at codecov.io
2. Add repository to Codecov
3. Add `CODECOV_TOKEN` secret to GitHub repository
4. Coverage will automatically upload on each push/PR

**Note:** Codecov works for public repos without a token, but adding one enables more features.

## Test Plan

- [x] Verify coverage generation locally works
- [x] Check codecov.yml syntax is valid
- [x] Confirm mise task runs successfully
- [ ] Test CI coverage upload (will verify in this PR)
- [ ] Verify Codecov receives coverage data

🤖 Generated with [Claude Code](https://claude.com/claude-code)