### PR TITLE
fix: Prevent overflow in festival selector bottom sheet

### DIFF
--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -697,7 +697,12 @@ class _FestivalSelectorSheet extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 16),
-          if (provider.isFestivalsLoading)
+          Flexible(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (provider.isFestivalsLoading)
             const Center(
               child: Padding(
                 padding: EdgeInsets.all(16.0),
@@ -783,6 +788,10 @@ class _FestivalSelectorSheet extends StatelessWidget {
                     );
                   },
                 )),
+                ],
+              ),
+            ),
+          ),
           const SizedBox(height: 16),
         ],
       ),


### PR DESCRIPTION
## Summary

Fixes the "bottom overflowed by 46 pixels" error with yellow/black striped warning that appears when opening the festival selector dropdown.

## Problem

When clicking the festivals dropdown, a modal bottom sheet opens showing the list of available festivals. If the content (multiple festivals, error states, or descriptions) is taller than the available space, Flutter shows an overflow warning with the distinctive yellow/black diagonal stripes.

## Root Cause

The `_FestivalSelectorSheet` widget used a `Column` with `mainAxisSize: MainAxisSize.min`, which couldn't shrink below its intrinsic content height. When the festival list or error messages exceeded the available screen space, the layout overflowed.

## Solution

Wrap the scrollable content (festival cards, loading indicator, or error states) in:
1. **Flexible** - Constrains the maximum height to available space
2. **SingleChildScrollView** - Allows scrolling when content exceeds available height

The header elements (drag handle, title, description) remain outside the scroll area for better UX.

## Changes

**Modified:** `lib/screens/drinks_screen.dart:663-794`
- Wrap festival list content in `Flexible` + `SingleChildScrollView`
- Keep header elements (drag handle, title, subtitle) fixed
- Allow dynamic content (festivals, loading, errors) to scroll

## Before/After

**Before:**
```
🟨⬛ Bottom overflowed by 46 pixels
```

**After:**
✅ Content scrolls smoothly, no overflow warnings

## Testing

- [x] Code analysis passes
- [x] All 138 tests pass
- [x] Festival selector opens without overflow warnings
- [x] Content scrolls when there are multiple festivals
- [x] Error states display correctly
- [x] Loading state displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)