### PR TITLE
Examine code coverage setup in CI

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -145,6 +145,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   # Build web after tests pass


### PR DESCRIPTION
Fix Codecov badge not updating by adding required authentication token. Codecov v5 requires explicit token authentication for uploads.