### PR TITLE
Add light/dark mode toggle with theme persistence

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,25 +15,30 @@ class BeerFestivalApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => BeerProvider(),
-      child: MaterialApp(
-        title: 'Cambridge Beer Festival',
-        debugShowCheckedModeBanner: false,
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: const Color(0xFFD97706), // Amber/copper beer color
-            brightness: Brightness.light,
-          ),
-          useMaterial3: true,
-        ),
-        darkTheme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: const Color(0xFFD97706),
-            brightness: Brightness.dark,
-          ),
-          useMaterial3: true,
-        ),
-        themeMode: ThemeMode.system,
-        home: const BeerFestivalHome(),
+      child: Builder(
+        builder: (context) {
+          final themeMode = context.watch<BeerProvider>().themeMode;
+          return MaterialApp(
+            title: 'Cambridge Beer Festival',
+            debugShowCheckedModeBanner: false,
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: const Color(0xFFD97706), // Amber/copper beer color
+                brightness: Brightness.light,
+              ),
+              useMaterial3: true,
+            ),
+            darkTheme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: const Color(0xFFD97706),
+                brightness: Brightness.dark,
+              ),
+              useMaterial3: true,
+            ),
+            themeMode: themeMode,
+            home: const BeerFestivalHome(),
+          );
+        },
       ),
     );
   }

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/models.dart';
 import '../services/services.dart';
@@ -35,6 +36,7 @@ class BeerProvider extends ChangeNotifier {
   DrinkSort _currentSort = DrinkSort.nameAsc;
   String _searchQuery = '';
   bool _showFavoritesOnly = false;
+  ThemeMode _themeMode = ThemeMode.system;
 
   BeerProvider({BeerApiService? apiService, FestivalService? festivalService})
       : _apiService = apiService ?? BeerApiService(),
@@ -57,6 +59,7 @@ class BeerProvider extends ChangeNotifier {
   String get searchQuery => _searchQuery;
   bool get showFavoritesOnly => _showFavoritesOnly;
   bool get hasFestivals => _festivals.isNotEmpty;
+  ThemeMode get themeMode => _themeMode;
 
   /// Get unique categories from loaded drinks
   List<String> get availableCategories {
@@ -119,7 +122,11 @@ class BeerProvider extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     _favoritesService = FavoritesService(prefs);
     _ratingsService = RatingsService(prefs);
-    
+
+    // Load theme mode preference
+    final themeIndex = prefs.getInt('themeMode') ?? ThemeMode.system.index;
+    _themeMode = ThemeMode.values[themeIndex];
+
     // Load festivals dynamically
     await loadFestivals();
   }
@@ -292,6 +299,16 @@ class BeerProvider extends ChangeNotifier {
     _showFavoritesOnly = value;
     _applyFiltersAndSort();
     notifyListeners();
+  }
+
+  /// Set theme mode and persist preference
+  Future<void> setThemeMode(ThemeMode mode) async {
+    _themeMode = mode;
+    notifyListeners();
+
+    // Persist the preference
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('themeMode', mode.index);
   }
 
   /// Toggle favorite status for a drink

--- a/lib/widgets/drink_card.dart
+++ b/lib/widgets/drink_card.dart
@@ -146,24 +146,25 @@ class _AvailabilityChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    
+    final isDark = theme.brightness == Brightness.dark;
+
     Color color;
     String label;
     IconData icon;
-    
+
     switch (status) {
       case AvailabilityStatus.plenty:
-        color = Colors.green;
+        color = isDark ? const Color(0xFF4CAF50) : const Color(0xFF2E7D32);
         label = 'Available';
         icon = Icons.check_circle;
         break;
       case AvailabilityStatus.low:
-        color = Colors.orange;
+        color = isDark ? const Color(0xFFFF9800) : const Color(0xFFEF6C00);
         label = 'Low';
         icon = Icons.warning;
         break;
       case AvailabilityStatus.out:
-        color = Colors.red;
+        color = theme.colorScheme.error;
         label = 'Sold Out';
         icon = Icons.cancel;
         break;


### PR DESCRIPTION
Implement manual theme switching capability with the following changes:

- Add theme mode state management to BeerProvider with SharedPreferences persistence
- Update MaterialApp to use provider's theme mode instead of hardcoded ThemeMode.system
- Add theme toggle icon button in DrinksScreen app bar with modal theme selector
- Replace hardcoded status badge colors (green/blue/orange) with theme-aware colors
- Update availability chip colors in DrinkCard to adapt to light/dark themes
- Theme preference is saved and restored across app sessions
- Users can choose between Light, Dark, and System (follow device) themes