### PR TITLE
Persist selected festival to storage

### DIFF
--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -58,7 +58,7 @@ class FavoritesService {
 /// Service for managing personal ratings locally
 class RatingsService {
   static const _ratingsKey = 'ratings';
-  
+
   final SharedPreferences _prefs;
 
   RatingsService(this._prefs);
@@ -79,5 +79,29 @@ class RatingsService {
   Future<void> removeRating(String festivalId, String drinkId) async {
     final key = '${_ratingsKey}_${festivalId}_$drinkId';
     await _prefs.remove(key);
+  }
+}
+
+/// Service for managing festival selection persistence
+class FestivalStorageService {
+  static const _selectedFestivalKey = 'selected_festival_id';
+
+  final SharedPreferences _prefs;
+
+  FestivalStorageService(this._prefs);
+
+  /// Get the ID of the last selected festival
+  String? getSelectedFestivalId() {
+    return _prefs.getString(_selectedFestivalKey);
+  }
+
+  /// Save the selected festival ID
+  Future<void> setSelectedFestivalId(String festivalId) async {
+    await _prefs.setString(_selectedFestivalKey, festivalId);
+  }
+
+  /// Clear the selected festival
+  Future<void> clearSelectedFestival() async {
+    await _prefs.remove(_selectedFestivalKey);
   }
 }

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -234,4 +234,77 @@ void main() {
       expect(ratingsService.getRating('cbf2025', 'drink-c'), isNull);
     });
   });
+
+  group('FestivalStorageService', () {
+    late FestivalStorageService festivalStorageService;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('getSelectedFestivalId returns null when no festival is selected', () async {
+      final prefs = await SharedPreferences.getInstance();
+      festivalStorageService = FestivalStorageService(prefs);
+
+      final festivalId = festivalStorageService.getSelectedFestivalId();
+
+      expect(festivalId, isNull);
+    });
+
+    test('setSelectedFestivalId saves festival ID', () async {
+      final prefs = await SharedPreferences.getInstance();
+      festivalStorageService = FestivalStorageService(prefs);
+
+      await festivalStorageService.setSelectedFestivalId('cbf2025');
+
+      final festivalId = festivalStorageService.getSelectedFestivalId();
+      expect(festivalId, 'cbf2025');
+    });
+
+    test('setSelectedFestivalId overwrites previous selection', () async {
+      final prefs = await SharedPreferences.getInstance();
+      festivalStorageService = FestivalStorageService(prefs);
+
+      await festivalStorageService.setSelectedFestivalId('cbf2024');
+      await festivalStorageService.setSelectedFestivalId('cbf2025');
+
+      final festivalId = festivalStorageService.getSelectedFestivalId();
+      expect(festivalId, 'cbf2025');
+    });
+
+    test('clearSelectedFestival removes saved festival', () async {
+      final prefs = await SharedPreferences.getInstance();
+      festivalStorageService = FestivalStorageService(prefs);
+
+      await festivalStorageService.setSelectedFestivalId('cbf2025');
+      await festivalStorageService.clearSelectedFestival();
+
+      final festivalId = festivalStorageService.getSelectedFestivalId();
+      expect(festivalId, isNull);
+    });
+
+    test('clearSelectedFestival handles no saved festival gracefully', () async {
+      final prefs = await SharedPreferences.getInstance();
+      festivalStorageService = FestivalStorageService(prefs);
+
+      // Should not throw
+      await festivalStorageService.clearSelectedFestival();
+
+      final festivalId = festivalStorageService.getSelectedFestivalId();
+      expect(festivalId, isNull);
+    });
+
+    test('festival selection persists across service instances', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final service1 = FestivalStorageService(prefs);
+
+      await service1.setSelectedFestivalId('cbf2025');
+
+      // Create new instance with same prefs
+      final service2 = FestivalStorageService(prefs);
+      final festivalId = service2.getSelectedFestivalId();
+
+      expect(festivalId, 'cbf2025');
+    });
+  });
 }


### PR DESCRIPTION
- Created FestivalStorageService to save/load selected festival ID
- Updated BeerProvider to persist festival selection on change
- Updated BeerProvider initialization to restore saved festival
- Added comprehensive tests for FestivalStorageService
- Added BeerProvider integration tests for festival persistence
- Removed unnecessary flutter/foundation.dart import from BeerProvider

Fixes #64 issue where users had to reselect their festival on each app launch. The selected festival is now saved to SharedPreferences and restored automatically when the app initializes.