### PR TITLE
Add accountId to Cloudflare Worker deployment

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -98,6 +98,7 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: cloudflare-worker
           command: deploy --dry-run
 
@@ -271,6 +272,7 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: cloudflare-worker
 
   deploy-web:


### PR DESCRIPTION
Both deploy-worker and validate-worker jobs need the CLOUDFLARE_ACCOUNT_ID secret to authenticate with Cloudflare API. Without it, wrangler fails with authentication error (code: 10001).