### PR TITLE
Fix preview app worker proxy access issue

### DIFF
--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -197,7 +197,7 @@ function handleCorsPreflight(request) {
       ...getCorsHeaders(request),
       'Access-Control-Allow-Methods': 'GET, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
-      'Access-Control-Max-Age': '86400',
+      'Access-Control-Max-Age': '300', // 5 minutes - allows quick recovery from CORS issues
     },
   });
 }


### PR DESCRIPTION
Changed Access-Control-Max-Age from 86400s (24 hours) to 300s (5 minutes). This allows faster recovery when CORS issues occur with preview deployments, while still providing caching benefits to reduce OPTIONS requests.

Fixes issue where preview deployments couldn't access the worker proxy unless in a private session due to cached CORS failures.