### PR TITLE
Build release APK only on tags

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -179,43 +179,11 @@ jobs:
             --dart-define=BUILD_VERSION=${{ steps.git_version.outputs.version }} \
             --dart-define=BUILD_TIME=${{ steps.git_version.outputs.build_time }}
 
-      - name: Build release APK (unsigned)
-        run: |
-          flutter build apk --release \
-            --dart-define=GIT_TAG=${{ steps.git_version.outputs.git_tag }} \
-            --dart-define=GIT_COMMIT=${{ steps.git_version.outputs.git_commit }} \
-            --dart-define=GIT_BRANCH=${{ steps.git_version.outputs.git_branch }} \
-            --dart-define=BUILD_VERSION=${{ steps.git_version.outputs.version }} \
-            --dart-define=BUILD_TIME=${{ steps.git_version.outputs.build_time }}
-
-      - name: Build release App Bundle (unsigned)
-        run: |
-          flutter build appbundle --release \
-            --dart-define=GIT_TAG=${{ steps.git_version.outputs.git_tag }} \
-            --dart-define=GIT_COMMIT=${{ steps.git_version.outputs.git_commit }} \
-            --dart-define=GIT_BRANCH=${{ steps.git_version.outputs.git_branch }} \
-            --dart-define=BUILD_VERSION=${{ steps.git_version.outputs.version }} \
-            --dart-define=BUILD_TIME=${{ steps.git_version.outputs.build_time }}
-
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
           name: app-debug-apk
           path: build/app/outputs/flutter-apk/app-debug.apk
-          if-no-files-found: error
-
-      - name: Upload release APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: app-release-apk
-          path: build/app/outputs/flutter-apk/app-release.apk
-          if-no-files-found: error
-
-      - name: Upload release App Bundle
-        uses: actions/upload-artifact@v4
-        with:
-          name: app-release-aab
-          path: build/app/outputs/bundle/release/app-release.aab
           if-no-files-found: error
 
   deploy-web:

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Android
 
 on:
   push:


### PR DESCRIPTION
Changes:
- Remove release APK and AAB builds from build-deploy.yml CI workflow
- Keep only debug APK builds for CI testing
- Rename release.yml to release-android.yml for clarity
- Release builds now only happen via release-android.yml when tags are pushed

Rationale:
- Release builds are time-consuming and unnecessary for every PR/merge
- Debug builds are sufficient for CI validation
- Release builds should only be created when cutting actual releases
- Release builds can fail independently from debug builds due to different optimizations, code shrinking (R8/ProGuard), and release-specific configs