### PR TITLE
Style app bar to match heading colors

### DIFF
--- a/lib/screens/brewery_screen.dart
+++ b/lib/screens/brewery_screen.dart
@@ -56,7 +56,7 @@ class _BreweryScreenState extends State<BreweryScreen> {
       body: CustomScrollView(
         slivers: [
           SliverAppBar(
-            expandedHeight: 180,
+            expandedHeight: 244,
             pinned: true,
             backgroundColor: theme.colorScheme.primaryContainer,
             foregroundColor: theme.colorScheme.onPrimaryContainer,
@@ -166,7 +166,6 @@ class _BreweryScreenState extends State<BreweryScreen> {
             padding: const EdgeInsets.all(24),
             child: Column(
               mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.end,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Row(

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -49,7 +49,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
       body: CustomScrollView(
         slivers: [
           SliverAppBar(
-            expandedHeight: 180,
+            expandedHeight: 220,
             pinned: true,
             backgroundColor: theme.colorScheme.primaryContainer,
             foregroundColor: theme.colorScheme.onPrimaryContainer,
@@ -174,7 +174,6 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
             padding: const EdgeInsets.all(24),
             child: Column(
               mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.end,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(

--- a/lib/screens/style_screen.dart
+++ b/lib/screens/style_screen.dart
@@ -53,7 +53,7 @@ class _StyleScreenState extends State<StyleScreen> {
       body: CustomScrollView(
         slivers: [
           SliverAppBar(
-            expandedHeight: 140,
+            expandedHeight: 220,
             pinned: true,
             backgroundColor: theme.colorScheme.primaryContainer,
             foregroundColor: theme.colorScheme.onPrimaryContainer,
@@ -164,7 +164,6 @@ class _StyleScreenState extends State<StyleScreen> {
             padding: const EdgeInsets.all(24),
             child: Column(
               mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.end,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Row(

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -91,7 +91,7 @@ void main() {
       await tester.pumpWidget(createTestWidget('drink1'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Test Beer'), findsOneWidget);
+      expect(find.text('Test Beer'), findsNWidgets(2)); // Appears in app bar title and content
       expect(find.text('Test Brewery'), findsNWidgets(2)); // Appears in header and brewery section
       expect(find.text('Cambridge, UK'), findsNWidgets(2)); // Appears in header and brewery section
     });


### PR DESCRIPTION
Updates drink detail, brewery, and style screens with Material Design collapsing headers:
- Replace static AppBar with SliverAppBar
- Color app bar to match primaryContainer
- Show title when scrolling past the header
- Keep header content visible when expanded

This provides better visual feedback during scrolling and maintains the colored header design.