### PR TITLE
Fix screenshots.ts error in CI pipeline

### DIFF
--- a/test-e2e/screenshots.ts
+++ b/test-e2e/screenshots.ts
@@ -73,7 +73,13 @@ async function fetchFestivalData(): Promise<{ drinkId: string; breweryId: string
       return null;
     }
 
-    const data: Producer[] = await response.json();
+    const responseData = await response.json();
+
+    // API returns: { timestamp: "...", producers: [...] }
+    // Handle both object (correct) and array (defensive) formats
+    const data: Producer[] = Array.isArray(responseData)
+      ? responseData
+      : (responseData.producers || []);
 
     if (!data || data.length === 0) {
       console.warn('   ⚠️  No data returned from API, will skip detail screens');


### PR DESCRIPTION
The screenshot script incorrectly expected the API to return a direct array of producers, but the API has always returned an object with a 'producers' field:

Actual API format: { timestamp: "...", producers: [...] }
Buggy expectation: [...]

This caused the CI screenshot capture to fail with: "TypeError: data.find is not a function"

The Flutter app (beer_api_service.dart) correctly parses data['producers'] and has been working fine. This bug only affected the screenshot script.

The fix parses the response correctly while keeping defensive handling for edge cases.