### PR TITLE
chore: fix mise on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Default: normalise line endings to LF in repo, checkout as-is
+# Default: normalise line endings to LF in repo; checkout EOLs follow Git/platform settings
 * text=auto
 
 # Force LF for files that must not have CRLF (mise reads these directly

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Default: normalise line endings to LF in repo, checkout as-is
+* text=auto
+
+# Force LF for files that must not have CRLF (mise reads these directly
+# on Windows and CRLF in task scripts causes bash shebang corruption)
+*.toml text eol=lf
+*.sh   text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ node_modules/
 playwright-report/
 test-results/
 .http-server.pid
+flutter-dev.pid
 playwright/.cache/
 
 # Symbols

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,22 @@ This document provides instructions for AI coding agents (Claude, Copilot, etc.)
 
 **CRITICAL**: This project uses `mise` for task management. Always use mise commands, not raw `flutter` commands.
 
+### Platform Note: Windows
+
+**`./bin/mise` does not work on Windows** (including Git Bash / MINGW64). Use your system-installed `mise` instead:
+
+```bash
+# Windows: use system mise (e.g. installed via WinGet)
+mise tasks ls
+MISE_ENV=dev mise run dev
+
+# macOS / Linux: use the project bootstrap script
+./bin/mise tasks ls
+MISE_ENV=dev ./bin/mise run dev
+```
+
+All commands below show `./bin/mise` — on Windows, replace with `mise`.
+
 ### First Thing to Do in Every Session
 
 ```bash
@@ -21,7 +37,6 @@ MISE_ENV=dev ./bin/mise tasks ls
 | Task | Command | Notes |
 |------|---------|-------|
 | **Discover tasks** | `./bin/mise tasks ls` | Run this first! |
-| Install dependencies | `./bin/mise run install` | Required after checkout |
 | Generate code (mocks) | `./bin/mise run generate` | After model changes |
 | Analyze code | `./bin/mise run analyze` | **Must pass before commit** |
 | Run tests | `./bin/mise run test` | All unit/widget tests |
@@ -71,7 +86,7 @@ The CI pipeline (`.github/workflows/ci.yml`) runs these commands. Here's how to 
 
 | CI Command | Mise Equivalent | When to Use |
 |------------|-----------------|-------------|
-| `flutter pub get` | `./bin/mise run install` | After checkout, pubspec changes |
+| `flutter pub get` | automatic (mise prepare) | Runs automatically on `pubspec.yaml` changes |
 | `dart run build_runner build --delete-conflicting-outputs` | `./bin/mise run generate` | After model changes, before tests |
 | `flutter analyze --no-fatal-infos` | `./bin/mise run analyze` | Before committing |
 | `flutter test --coverage` | `./bin/mise run coverage` | Testing with coverage |
@@ -88,14 +103,18 @@ flutter pub get           # Bypasses version management
 flutter test              # May use wrong Flutter version
 flutter build web         # Missing mise environment setup
 mise run build:web        # Missing MISE_ENV=dev (will fail)
+./bin/mise run <anything> # ./bin/mise does not work on Windows
 ```
 
 ### ✅ Do This Instead
 ```bash
-./bin/mise run install         # Correct: uses ./bin/mise
+# macOS/Linux
 ./bin/mise run test            # Correct: proper environment
 MISE_ENV=dev ./bin/mise run build:web  # Correct: has MISE_ENV
-./bin/mise tasks ls            # Correct: discover first
+
+# Windows (Git Bash / PowerShell)
+mise run test
+MISE_ENV=dev mise run build:web
 ```
 
 ## Testing Best Practices

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,6 @@ Quick reference (always check `./bin/mise tasks ls` for latest):
 MISE_ENV=dev ./bin/mise tasks ls       # Developer tasks
 
 # Common tasks
-./bin/mise run install                 # Install dependencies
 ./bin/mise run generate                # Generate code (mocks)
 ./bin/mise run analyze                 # Code analysis (REQUIRED before commit)
 ./bin/mise run test                    # Run tests
@@ -50,9 +49,12 @@ MISE_ENV=dev ./bin/mise run build:web:prod  # Production build
 
 This project uses [Mise](https://mise.jdx.dev) for managing development tools and task running.
 
-### Important: Use ./bin/mise
+### Important: Use ./bin/mise (macOS/Linux) or mise (Windows)
 
-**Always use `./bin/mise` (not plain `mise`)** when running mise commands in this repository.
+**`./bin/mise` is a Unix-only bootstrap script — it does not work on Windows (Git Bash / MINGW64).**
+
+- **macOS / Linux**: Use `./bin/mise` (ensures the project-local mise version is used)
+- **Windows**: Use `mise` from your system PATH (e.g. installed via WinGet — `winget install jdx.mise`)
 
 ### Environment-Specific Tools
 
@@ -147,7 +149,6 @@ git clone https://github.com/mise-plugins/mise-flutter.git .mise/plugins/flutter
 MISE_ENV=dev ./bin/mise tasks ls                 # List all tasks (includes dev)
 
 # Essential tasks
-./bin/mise run install                           # Install dependencies
 ./bin/mise run generate                          # Generate code (mocks)
 ./bin/mise run analyze                           # Code analysis
 ./bin/mise run test                              # All tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,8 @@ This project uses [Mise](https://mise.jdx.dev) for managing development tools an
 **`./bin/mise` is a Unix-only bootstrap script — it does not work on Windows (Git Bash / MINGW64).**
 
 - **macOS / Linux**: Use `./bin/mise` (ensures the project-local mise version is used)
-- **Windows**: Use `mise` from your system PATH (e.g. installed via WinGet — `winget install jdx.mise`)
+- **Windows**: Use `mise` from your system PATH (e.g. installed via WinGet — `winget install jdx.mise`).  
+  **Note**: The repo’s `mise.toml` sets `windows_default_inline_shell_args = "bash -c"`, so `mise run ...` on Windows requires `bash` to be available on `PATH` (for example via Git for Windows / Git Bash, WSL, or another Bash installation).
 
 ### Environment-Specific Tools
 

--- a/mise.dev.toml
+++ b/mise.dev.toml
@@ -33,10 +33,7 @@ gh = "latest"
 
 [tasks.dev]
 description = "Start Flutter dev server on localhost:8080"
-run = '''
-echo "Starting Flutter dev server on http://localhost:8080"
-flutter run -d web-server --web-port 8080 --pid-file flutter-dev.pid
-'''
+run = 'flutter run -d web-server --web-port 8080'
 
 # Complex tasks moved to mise-tasks/ for better maintainability:
 # - setup:tunnel -> mise-tasks/setup/tunnel

--- a/mise.toml
+++ b/mise.toml
@@ -9,13 +9,19 @@
 #   Docs: https://mise.jdx.dev/tasks/task-arguments.html
 #         https://mise.jdx.dev/tasks/file-tasks.html
 
+[settings]
+# Use bash for inline task scripts on Windows (default is cmd /c which only runs one line)
+windows_default_inline_shell_args = "bash -c"
+
 [tools]
 flutter = "3.38.3"
 node = "21"  # For http_server and Playwright e2e tests
 
-[tasks.install]
-description = "Install Flutter dependencies (flutter pub get)"
+[prepare.flutter-deps]
+auto = true
 run = 'flutter pub get'
+sources = ['pubspec.yaml']
+outputs = ['pubspec.lock', '.dart_tool/package_config.json']
 
 [tasks.generate]
 description = "Generate code (mocks, build_runner)"


### PR DESCRIPTION
## Summary

- `./bin/mise` is a Unix-only bootstrap script and does not work on Windows (Git Bash / MINGW64) — AGENTS.md and CLAUDE.md updated to document using system `mise` instead
- Added `windows_default_inline_shell_args = "bash -c"` to `mise.toml` — without this, mise uses `cmd /c` on Windows which only executes the first line of any multiline task script
- Simplified `dev` task to a single-line run (avoids a separate mise bug where temp script shebangs get \`\r\` appended when spawned from a native Windows process)
- Added `[prepare.flutter-deps]` so `flutter pub get` runs automatically when `pubspec.yaml` changes, with `outputs` set so it skips when already up-to-date — removes the need for a manual `install` task
- Added `.gitattributes` forcing LF for `*.toml` and `*.sh` — CRLF in TOML breaks the `windows_default_inline_shell_args` setting and CRLF in shell scripts breaks shebangs
- Added `flutter-dev.pid` to `.gitignore`

## Test plan

- [ ] On macOS/Linux: \`./bin/mise run test\` and \`./bin/mise run analyze\` still pass
- [ ] On Windows: \`mise run test\` and \`mise run analyze\` pass
- [ ] On Windows: \`MISE_ENV=dev mise run dev\` starts the Flutter dev server (all task lines execute)
- [ ] On Windows: \`flutter pub get\` runs automatically on first \`mise run\` after a fresh checkout, but is skipped on subsequent runs when \`pubspec.yaml\` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)