### PR TITLE
Automate Android release signing and Google Play upload

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -101,16 +101,21 @@ jobs:
           generate-mocks: 'true'
 
       - name: Decode upload keystore
-        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/upload-keystore.jks
+        run: |
+          if [ -z "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 secret is not set. See docs/tooling/github-secrets.md"
+            exit 1
+          fi
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/upload-keystore.jks
 
       - name: Create key.properties
         run: |
-          cat > android/key.properties <<EOF
-          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
-          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
-          storeFile=../upload-keystore.jks
-          EOF
+          printf 'storePassword=%s\nkeyPassword=%s\nkeyAlias=%s\nstoreFile=%s\n' \
+            "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
+            "${{ secrets.ANDROID_KEY_PASSWORD }}" \
+            "${{ secrets.ANDROID_KEY_ALIAS }}" \
+            "../upload-keystore.jks" \
+            > android/key.properties
 
       - name: Build release ${{ matrix.build-type.name }}
         run: |

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -100,6 +100,18 @@ jobs:
           google-services-json: ${{ secrets.GOOGLE_SERVICES_JSON }}
           generate-mocks: 'true'
 
+      - name: Decode upload keystore
+        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/upload-keystore.jks
+
+      - name: Create key.properties
+        run: |
+          cat > android/key.properties <<EOF
+          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          storeFile=../upload-keystore.jks
+          EOF
+
       - name: Build release ${{ matrix.build-type.name }}
         run: |
           flutter build ${{ matrix.build-type.flutter-command }} --release \
@@ -138,8 +150,8 @@ jobs:
         run: |
           VERSION="${{ needs.version-info.outputs.version_number }}"
           mkdir -p release-artifacts
-          cp artifacts/apk/app-release.apk "release-artifacts/cambridge-beer-festival-${VERSION}-unsigned.apk"
-          cp artifacts/aab/app-release.aab "release-artifacts/cambridge-beer-festival-${VERSION}-unsigned.aab"
+          cp artifacts/apk/app-release.apk "release-artifacts/cambridge-beer-festival-${VERSION}.apk"
+          cp artifacts/aab/app-release.aab "release-artifacts/cambridge-beer-festival-${VERSION}.aab"
 
       - name: Generate checksums
         working-directory: release-artifacts
@@ -162,19 +174,16 @@ jobs:
             ### 📦 Installation Files
 
             **For Android devices:**
-            - **APK (unsigned)**: `cambridge-beer-festival-${{ needs.version-info.outputs.version_number }}-unsigned.apk`
+            - **APK**: `cambridge-beer-festival-${{ needs.version-info.outputs.version_number }}.apk`
               - Direct installation on Android devices (requires "Install from unknown sources")
 
             **For Google Play Store:**
-            - **AAB (unsigned)**: `cambridge-beer-festival-${{ needs.version-info.outputs.version_number }}-unsigned.aab`
-              - For uploading to Google Play Console (requires signing with Play App Signing)
+            - **AAB**: `cambridge-beer-festival-${{ needs.version-info.outputs.version_number }}.aab`
+              - Signed with upload key; Google Play re-signs with the app signing key (Play App Signing)
 
             ### 🔒 Signing Information
 
-            These are **unsigned** release builds.
-
-            - **APK**: Can be installed directly on Android devices with "Install from unknown sources" enabled
-            - **AAB**: Must be uploaded to Google Play Console where it will be automatically signed with Play App Signing
+            Builds are signed with the upload key. Google Play re-signs the AAB with the app signing key before distributing to users (Play App Signing).
 
             ### 📋 App Information
 
@@ -197,3 +206,22 @@ jobs:
             release-artifacts/*.apk
             release-artifacts/*.aab
             release-artifacts/checksums.txt
+
+  publish-google-play:
+    needs: [version-info, build-artifacts]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download AAB artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-aab
+          path: artifacts/aab
+
+      - name: Upload to Google Play (Internal track)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ralcock.cbf
+          releaseFiles: artifacts/aab/app-release.aab
+          track: internal
+          status: completed

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -101,21 +101,30 @@ jobs:
           generate-mocks: 'true'
 
       - name: Decode upload keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         run: |
           missing=0
-          [ -z "${{ secrets.ANDROID_KEYSTORE_BASE64 }}"      ] && echo "::error::ANDROID_KEYSTORE_BASE64 secret is not set. See docs/tooling/github-secrets.md"      && missing=1
-          [ -z "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"    ] && echo "::error::ANDROID_KEYSTORE_PASSWORD secret is not set. See docs/tooling/github-secrets.md"    && missing=1
-          [ -z "${{ secrets.ANDROID_KEY_PASSWORD }}"         ] && echo "::error::ANDROID_KEY_PASSWORD secret is not set. See docs/tooling/github-secrets.md"         && missing=1
-          [ -z "${{ secrets.ANDROID_KEY_ALIAS }}"            ] && echo "::error::ANDROID_KEY_ALIAS secret is not set. See docs/tooling/github-secrets.md"            && missing=1
+          [ -z "$ANDROID_KEYSTORE_BASE64"      ] && echo "::error::ANDROID_KEYSTORE_BASE64 secret is not set. See docs/tooling/github-secrets.md"      && missing=1
+          [ -z "$ANDROID_KEYSTORE_PASSWORD"    ] && echo "::error::ANDROID_KEYSTORE_PASSWORD secret is not set. See docs/tooling/github-secrets.md"    && missing=1
+          [ -z "$ANDROID_KEY_PASSWORD"         ] && echo "::error::ANDROID_KEY_PASSWORD secret is not set. See docs/tooling/github-secrets.md"         && missing=1
+          [ -z "$ANDROID_KEY_ALIAS"            ] && echo "::error::ANDROID_KEY_ALIAS secret is not set. See docs/tooling/github-secrets.md"            && missing=1
           [ "$missing" -eq 1 ] && exit 1
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/upload-keystore.jks
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android/upload-keystore.jks
 
       - name: Create key.properties
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         run: |
           printf 'storePassword=%s\nkeyPassword=%s\nkeyAlias=%s\nstoreFile=%s\n' \
-            "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
-            "${{ secrets.ANDROID_KEY_PASSWORD }}" \
-            "${{ secrets.ANDROID_KEY_ALIAS }}" \
+            "$ANDROID_KEYSTORE_PASSWORD" \
+            "$ANDROID_KEY_PASSWORD" \
+            "$ANDROID_KEY_ALIAS" \
             "../upload-keystore.jks" \
             > android/key.properties
 

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -102,10 +102,12 @@ jobs:
 
       - name: Decode upload keystore
         run: |
-          if [ -z "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" ]; then
-            echo "::error::ANDROID_KEYSTORE_BASE64 secret is not set. See docs/tooling/github-secrets.md"
-            exit 1
-          fi
+          missing=0
+          [ -z "${{ secrets.ANDROID_KEYSTORE_BASE64 }}"      ] && echo "::error::ANDROID_KEYSTORE_BASE64 secret is not set. See docs/tooling/github-secrets.md"      && missing=1
+          [ -z "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"    ] && echo "::error::ANDROID_KEYSTORE_PASSWORD secret is not set. See docs/tooling/github-secrets.md"    && missing=1
+          [ -z "${{ secrets.ANDROID_KEY_PASSWORD }}"         ] && echo "::error::ANDROID_KEY_PASSWORD secret is not set. See docs/tooling/github-secrets.md"         && missing=1
+          [ -z "${{ secrets.ANDROID_KEY_ALIAS }}"            ] && echo "::error::ANDROID_KEY_ALIAS secret is not set. See docs/tooling/github-secrets.md"            && missing=1
+          [ "$missing" -eq 1 ] && exit 1
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/upload-keystore.jks
 
       - name: Create key.properties
@@ -214,6 +216,10 @@ jobs:
 
   publish-google-play:
     needs: [version-info, build-artifacts]
+    # Only upload on real tag pushes — not workflow_dispatch, which is used for test builds
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Allow the workflow to succeed even if Play upload fails (e.g. before first manual upload)
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: Download AAB artifact

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,6 +5,12 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace = "ralcock.cbf"
     compileSdk = flutter.compileSdkVersion
@@ -27,10 +33,21 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                keyAlias = keystoreProperties['keyAlias']
+                keyPassword = keystoreProperties['keyPassword']
+                storeFile = file(keystoreProperties['storeFile'])
+                storePassword = keystoreProperties['storePassword']
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // Unsigned release builds (no signing configuration)
-            // For signed builds, configure signingConfigs and set signingConfig here
+            // Uses upload keystore when key.properties exists (CI), debug signing otherwise (local dev)
+            signingConfig = keystorePropertiesFile.exists() ? signingConfigs.release : signingConfigs.debug
             minifyEnabled = false
             shrinkResources = false
         }

--- a/docs/processes/ci-cd.md
+++ b/docs/processes/ci-cd.md
@@ -4,13 +4,14 @@ This document describes all GitHub Actions workflows used for continuous integra
 
 ## Overview
 
-The project uses **3 separate workflows** to handle different aspects of the CI/CD pipeline:
+The project uses **4 separate workflows** to handle different aspects of the CI/CD pipeline:
 
 | Workflow | File | Purpose | Triggers |
 |----------|------|---------|----------|
 | **CI** | `ci.yml` | Build, test, and deploy Flutter app | Push to `main`, PRs to `main` |
 | **Cloudflare Worker** | `deploy-worker.yml` | Deploy API proxy worker and festivals data | Push to `main`, PRs (when worker/festivals.json changes) |
 | **Release Web** | `release-web.yml` | Production web releases to Cloudflare Pages | Version tags (`v*`) |
+| **Release Android** | `release-android.yml` | Build signed APK/AAB, create GitHub Release, upload to Google Play Internal track | Version tags (`v*`), manual |
 
 ---
 
@@ -328,10 +329,15 @@ All workflows require the following secrets (set in repository Settings → Secr
 |--------|---------|-------------|
 | `CLOUDFLARE_API_TOKEN` | Worker, Release Web, App CI/CD | API token with Workers + Pages permissions |
 | `CLOUDFLARE_ACCOUNT_ID` | Worker, Release Web, App CI/CD | Cloudflare account ID |
-| `GOOGLE_SERVICES_JSON` | App CI/CD, Release Web | Firebase Android configuration |
+| `GOOGLE_SERVICES_JSON` | App CI/CD, Release Web, Release Android | Firebase Android configuration |
 | `CODECOV_TOKEN` | App CI/CD | Codecov upload token (optional) |
+| `ANDROID_KEYSTORE_BASE64` | Release Android | Base64-encoded upload keystore |
+| `ANDROID_KEY_ALIAS` | Release Android | Key alias inside the upload keystore |
+| `ANDROID_KEY_PASSWORD` | Release Android | Key password |
+| `ANDROID_KEYSTORE_PASSWORD` | Release Android | Keystore (store) password |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Release Android | Service account JSON for Google Play upload |
 
-See [GITHUB_SECRETS.md](GITHUB_SECRETS.md) for setup instructions.
+See [github-secrets.md](../tooling/github-secrets.md) for full setup instructions including how to create the upload keystore and Google Play service account.
 
 ---
 
@@ -384,10 +390,16 @@ See [GITHUB_SECRETS.md](GITHUB_SECRETS.md) for setup instructions.
 2. **Automatic production deployment**
    - GitHub Actions automatically:
      - Runs tests (must pass)
-     - Builds web app
-     - Deploys to `cambeerfestival.app`
+     - Builds web app and deploys to `cambeerfestival.app`
+     - Builds signed Android APK and AAB
+     - Creates a GitHub Release with APK, AAB, and checksums
+     - Uploads the signed AAB to Google Play **Internal track**
 
-3. **Verify production**
+3. **Promote Android release (manual)**
+   - Open [Google Play Console](https://play.google.com/console) → your app → Internal testing
+   - Promote to Alpha/Beta/Production as appropriate
+
+4. **Verify production**
    - Visit `https://cambeerfestival.app`
    - Check functionality
 
@@ -730,11 +742,12 @@ on:
 
 ## Summary
 
-The Cambridge Beer Festival app uses **3 specialized workflows**:
+The Cambridge Beer Festival app uses **4 specialized workflows**:
 
 1. **Flutter App CI/CD** - Comprehensive app testing, building, and deployment
 2. **Cloudflare Worker** - API proxy and festivals data deployment
 3. **Release Web** - Production releases to custom domain
+4. **Release Android** - Signed APK/AAB builds, GitHub Release, and Google Play upload
 
 This separation provides:
 - **Clear responsibilities** - Each workflow has a specific purpose

--- a/docs/tooling/android-release.md
+++ b/docs/tooling/android-release.md
@@ -647,24 +647,21 @@ If your upload key is ever compromised, you can rotate it in Play Console withou
 In CI, the workflow writes `key.properties` from secrets before building. Locally, if `key.properties`
 is absent the build falls back to debug signing (fine for development, not uploadable to Play).
 
-### One-Time Setup: Create the Upload Keystore
+### One-Time Setup: Identify the Keystore
 
-Run this once locally and store the `.jks` file somewhere safe (password manager, etc.):
+> **This app replaces an existing Play Store app.** Use the **original signing keystore**
+> (the one used to sign all previous releases of `ralcock.cbf`), not a newly generated one.
+> Generating a new keystore would produce a different certificate and break the upgrade path
+> for existing users. See the migration steps above for enrolling it in Play App Signing.
 
-```bash
-keytool -genkey -v -keystore upload-keystore.jks \
-  -keyalg RSA -keysize 2048 -validity 10000 \
-  -alias upload
-```
-
-Then base64-encode it for the GitHub secret:
+Base64-encode the original keystore for the GitHub secret:
 
 ```bash
 # Linux/Mac
-base64 -i upload-keystore.jks | tr -d '\n'
+base64 -i original-signing.jks | tr -d '\n'
 
 # Windows (PowerShell)
-[Convert]::ToBase64String([IO.File]::ReadAllBytes("upload-keystore.jks"))
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("original-signing.jks"))
 ```
 
 ### Required GitHub Secrets

--- a/docs/tooling/android-release.md
+++ b/docs/tooling/android-release.md
@@ -347,7 +347,7 @@ When uploading to Google Play Console, you'll need to provide the following meta
 | Field | Value |
 |-------|-------|
 | **App Name** | Cambridge Beer Festival |
-| **Package Name** | `com.example.cambridge_beer_festival` |
+| **Package Name** | `ralcock.cbf` |
 | **Category** | Food & Drink |
 | **Content Rating** | 18+ (alcohol-related content) |
 | **Target Audience** | Adults 18+ |
@@ -534,71 +534,101 @@ Before submitting to Play Store, ensure you have:
 - [ ] Contact email address
 - [ ] Target audience set (18+)
 
-## Google Play Console Upload Process
+## Replacing the Existing Play Store App (Seamless Upgrade)
 
-### First-Time Setup
+The Flutter app replaces an existing self-signed APK app with package name `ralcock.cbf`.
+For existing users to receive it as an automatic update (not a reinstall), two things must hold:
 
-1. **Create Developer Account**
-   - Sign up at [Google Play Console](https://play.google.com/console)
-   - Pay one-time $25 registration fee
-   - Verify identity
+1. **Package name matches** — `applicationId = "ralcock.cbf"` in `build.gradle` ✅ already correct
+2. **Signing certificate matches** — requires migrating to Play App Signing using the original keystore
 
-2. **Create App**
-   - Click "Create app"
-   - App name: "Cambridge Beer Festival"
-   - Default language: English (United Kingdom)
-   - App/Game: App
-   - Free/Paid: Free
+### Why migration is required
 
-3. **Set Up Play App Signing**
-   - Go to **Release** → **Setup** → **App signing**
-   - Enroll in Play App Signing (recommended)
-   - Google will manage your signing keys
+Google Play requires AABs to be distributed via **Play App Signing**. During migration you upload
+your original signing key to Google; it becomes the *app signing key* that Google uses when
+delivering APKs to users. Devices that already have the app installed with the old certificate
+accept the update seamlessly because the distribution certificate hasn't changed.
 
-### Uploading a Release
+Your original keystore also becomes the *upload key* used in CI — so there is nothing new to
+generate for the initial migration.
 
-1. **Navigate to Production Track**
-   - Go to **Release** → **Production**
-   - Click **Create new release**
+### One-time migration steps (do this before the first CI release)
 
-2. **Upload AAB**
-   - Click **Upload** and select the `cambridge-beer-festival-YYYY.MM.PATCH-unsigned.aab` file
-   - Google Play will automatically sign it
+#### Step 1: Check your version code
 
-3. **Add Release Notes**
+The new release's `versionCode` **must be higher** than whatever is currently live in Play Store.
+Check `pubspec.yaml` — the build number after `+` is the version code (e.g. `2025.12.0+20251200`
+→ `versionCode = 20251200`). If the existing app's version code is higher, update `pubspec.yaml`
+before tagging.
+
+#### Step 2: Enroll in Play App Signing
+
+1. Open [Google Play Console](https://play.google.com/console) → your app
+2. Go to **Release** → **Setup** → **App integrity** (or **App signing** in older UI)
+3. Click **App signing** → **Upgrade your app signing key** (if present) or find the
+   "App signing key" section
+4. Choose **"Use a key exported from Java Keystore"**
+5. Play Console provides a tool to encrypt and export your key — run it locally:
+   ```bash
+   # Play Console shows you this exact command with the right parameters
+   java -jar pepk.jar \
+     --keystore=your-original.jks \
+     --alias=your-key-alias \
+     --output=encrypted-key.zip \
+     --include-cert \
+     --encryptionkey=<hex-key-from-play-console>
    ```
-   Version YYYY.MM.PATCH
+6. Upload the resulting `encrypted-key.zip` to Play Console
+7. Your original key is now enrolled as the **app signing key** — Google holds it and uses it
+   to sign APKs delivered to users
 
-   [Copy the "What's Changed" section from GitHub Release notes]
+> **You do not need to create a new keystore.** Your original keystore becomes the upload key.
+> If you ever need to rotate the upload key you can do so in Play Console without affecting users.
 
-   Features:
-   • Browse festival drinks
-   • Search and filter
-   • Save favorites
-   • Rate drinks
-   • View festival info
-   ```
+#### Step 3: Configure GitHub secrets
 
-4. **Review and Rollout**
-   - Review the release details
-   - Click **Save** → **Review release** → **Start rollout to Production**
+Set `ANDROID_KEYSTORE_BASE64` to your **original signing keystore** (the same one you just
+enrolled as the app signing key). CI will sign the AAB with it; Google will verify the signature
+and re-sign the distributed APK/AAB with the same certificate existing users already have.
 
-### Updating an Existing App
+See [github-secrets.md](github-secrets.md) for the full secrets setup.
 
-Since this replaces an existing Java/XML app:
+#### Step 4: First AAB upload (manual)
 
-1. **Ensure Package Name Matches**
-   - Current: `com.example.cambridge_beer_festival`
-   - Must match the existing app's package name in Play Console
+The Google Play API cannot upload to an app that has never had an AAB submitted. After completing
+the migration above:
 
-2. **Version Code Must Increase**
-   - CalVer ensures this: `20251200` > previous version code
-   - Play Store will reject if version code doesn't increase
+1. Push a tag to trigger the `Release Android` workflow
+2. When it completes, download the AAB from the GitHub Release
+3. In Play Console → **Internal testing** → **Create new release** → upload the AAB
+4. Complete and roll out the release
+5. From this point on, **all future releases are uploaded automatically by CI**
 
-3. **Update Process**
-   - Upload new AAB as described above
-   - Google Play recognizes it as an update (same package name)
-   - Users will receive an automatic update notification
+### Subsequent releases (fully automated)
+
+```bash
+# 1. Update version in pubspec.yaml
+version: 2026.5.0+20260500
+
+# 2. Commit and tag
+git add pubspec.yaml
+git commit -m "Bump version to v2026.5.0"
+git tag -a v2026.5.0 -m "Release v2026.5.0"
+git push origin main --follow-tags
+```
+
+CI builds → signs → uploads to Internal track. Promote to Production in Play Console.
+
+### Add release notes
+
+When promoting a release in Play Console, paste the "What's Changed" section from the
+corresponding GitHub Release. For the English (UK) locale:
+
+```
+Version YYYY.MM.PATCH
+
+[paste What's Changed from GitHub Release]
+```
 
 ## Signing Configuration
 

--- a/docs/tooling/android-release.md
+++ b/docs/tooling/android-release.md
@@ -73,13 +73,14 @@ git push origin v2025.12.0
 
 The release workflow will automatically:
 1. Run tests
-2. Build unsigned APK and AAB
+2. Build signed APK and AAB (using upload keystore)
 3. Generate SHA256 checksums
 4. Create a GitHub Release with:
    - Release notes (auto-generated from commits)
    - APK file for direct installation
    - AAB file for Play Store upload
    - Checksums file
+5. Upload the signed AAB to Google Play **Internal track** automatically
 
 ### 5. Manual Release (Alternative)
 
@@ -313,18 +314,18 @@ org.gradle.parallel=true     # Parallel execution
 
 Each release produces three files:
 
-### 1. Unsigned APK
-- **Filename**: `cambridge-beer-festival-YYYY.MM.PATCH-unsigned.apk`
+### 1. APK
+- **Filename**: `cambridge-beer-festival-YYYY.MM.PATCH.apk`
 - **Size**: ~15-25 MB
 - **Use**: Direct installation on Android devices
 - **Installation**: Requires "Install from unknown sources" enabled
-- **Signing**: Unsigned (or debug signed for testing)
+- **Signing**: Signed with upload keystore in CI
 
-### 2. Unsigned AAB (Android App Bundle)
-- **Filename**: `cambridge-beer-festival-YYYY.MM.PATCH-unsigned.aab`
+### 2. AAB (Android App Bundle)
+- **Filename**: `cambridge-beer-festival-YYYY.MM.PATCH.aab`
 - **Size**: ~10-15 MB (smaller than APK)
-- **Use**: Upload to Google Play Console
-- **Signing**: Will be signed by Google Play App Signing automatically
+- **Use**: Uploaded automatically to Google Play Internal track by CI
+- **Signing**: Signed with upload key; Google Play re-signs with the app signing key (Play App Signing)
 
 ### 3. Checksums File
 - **Filename**: `checksums.txt`
@@ -593,123 +594,67 @@ Since this replaces an existing Java/XML app:
    - Google Play recognizes it as an update (same package name)
    - Users will receive an automatic update notification
 
-## Signing Configuration (Future)
+## Signing Configuration
 
-Currently, the app produces **unsigned** releases. For the Play Store, Google Play App Signing handles this automatically.
+Releases are signed with an **upload keystore**. This is the standard Play App Signing model:
 
-If you need to sign APKs manually in the future:
+| Key | Held by | Purpose |
+|-----|---------|---------|
+| **App signing key** | Google (Play App Signing) | Signs APKs delivered to users |
+| **Upload key** | You (GitHub secret) | Signs the AAB you submit; Google verifies then re-signs |
 
-### 1. Generate Upload Key
+If your upload key is ever compromised, you can rotate it in Play Console without affecting users.
+
+### How It Works in CI
+
+`android/app/build.gradle` reads signing config from `android/key.properties` if that file exists.
+In CI, the workflow writes `key.properties` from secrets before building. Locally, if `key.properties`
+is absent the build falls back to debug signing (fine for development, not uploadable to Play).
+
+### One-Time Setup: Create the Upload Keystore
+
+Run this once locally and store the `.jks` file somewhere safe (password manager, etc.):
 
 ```bash
-keytool -genkey -v -keystore ~/upload-keystore.jks \
+keytool -genkey -v -keystore upload-keystore.jks \
   -keyalg RSA -keysize 2048 -validity 10000 \
   -alias upload
 ```
 
-### 2. Create key.properties
+Then base64-encode it for the GitHub secret:
 
-Create `android/key.properties`:
+```bash
+# Linux/Mac
+base64 -i upload-keystore.jks | tr -d '\n'
+
+# Windows (PowerShell)
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("upload-keystore.jks"))
+```
+
+### Required GitHub Secrets
+
+Add these in **Repository Settings → Secrets and variables → Actions**:
+
+| Secret | Value |
+|--------|-------|
+| `ANDROID_KEYSTORE_BASE64` | Base64-encoded `.jks` content (from command above) |
+| `ANDROID_KEY_ALIAS` | Alias used when creating the keystore (e.g. `upload`) |
+| `ANDROID_KEY_PASSWORD` | Key password |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore password |
+
+See [github-secrets.md](github-secrets.md) for full secrets setup including Google Play.
+
+### Local Development
+
+`android/key.properties` and `*.jks` are gitignored. For local release builds with signing:
 
 ```properties
+# android/key.properties  (never commit this file)
 storePassword=<password>
 keyPassword=<password>
 keyAlias=upload
-storeFile=<path-to-keystore>/upload-keystore.jks
+storeFile=../../upload-keystore.jks
 ```
-
-### 3. Update build.gradle
-
-```gradle
-def keystoreProperties = new Properties()
-def keystorePropertiesFile = rootProject.file('key.properties')
-if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
-}
-
-android {
-    // ...
-
-    signingConfigs {
-        release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
-            storePassword keystoreProperties['storePassword']
-        }
-    }
-
-    buildTypes {
-        release {
-            signingConfig signingConfigs.release
-            minifyEnabled false
-            shrinkResources false
-        }
-    }
-}
-```
-
-### 4. Add to .gitignore
-
-```
-# Signing files
-android/key.properties
-*.jks
-*.keystore
-```
-
-### 5. GitHub Secrets for CI/CD Signing
-
-To sign APKs/AABs automatically in GitHub Actions, you need to configure these secrets:
-
-**Go to**: Repository Settings → Secrets and variables → Actions → New repository secret
-
-| Secret Name | Description | How to Get |
-|-------------|-------------|------------|
-| `KEYSTORE_BASE64` | Base64-encoded keystore file | `base64 -i upload-keystore.jks \| tr -d '\n'` |
-| `KEYSTORE_PASSWORD` | Keystore password | The password you used when creating the keystore |
-| `KEY_ALIAS` | Key alias | Usually `upload` (or whatever you specified) |
-| `KEY_PASSWORD` | Key password | Usually same as keystore password |
-
-**Example: Creating KEYSTORE_BASE64**
-
-```bash
-# On Linux/Mac
-base64 -i upload-keystore.jks | tr -d '\n' | pbcopy  # Copies to clipboard
-
-# On Windows (PowerShell)
-[Convert]::ToBase64String([IO.File]::ReadAllBytes("upload-keystore.jks")) | Set-Clipboard
-```
-
-### 6. Update GitHub Workflow for Signed Releases
-
-Modify `.github/workflows/release.yml` to decode and use the keystore:
-
-```yaml
-- name: Decode keystore
-  run: |
-    echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
-
-- name: Create key.properties
-  run: |
-    cat > android/key.properties <<EOF
-    storePassword=${{ secrets.KEYSTORE_PASSWORD }}
-    keyPassword=${{ secrets.KEY_PASSWORD }}
-    keyAlias=${{ secrets.KEY_ALIAS }}
-    storeFile=upload-keystore.jks
-    EOF
-
-- name: Build release APK (signed)
-  run: flutter build apk --release
-
-- name: Build release App Bundle (signed)
-  run: flutter build appbundle --release
-```
-
-**Security Notes:**
-- Never commit `key.properties` or `*.jks` files to git
-- GitHub Secrets are encrypted and only accessible to workflows
-- The keystore is decoded temporarily during the build and not persisted
 
 ## Code Obfuscation & Optimization (ProGuard/R8)
 

--- a/docs/tooling/android-release.md
+++ b/docs/tooling/android-release.md
@@ -82,6 +82,12 @@ The release workflow will automatically:
    - Checksums file
 5. Upload the signed AAB to Google Play **Internal track** automatically
 
+> **First release only**: The Google Play API cannot create a new app listing.
+> Before CI upload will work, you must upload the **first** AAB manually through
+> Play Console and complete the app listing setup (store page, content rating,
+> privacy policy). After that, all future releases are fully automated.
+> See [play-store.md](play-store.md) for the first-time setup checklist.
+
 ### 5. Manual Release (Alternative)
 
 You can also trigger a release manually via GitHub Actions:

--- a/docs/tooling/github-secrets.md
+++ b/docs/tooling/github-secrets.md
@@ -475,9 +475,14 @@ Or via the web interface: paste the entire JSON file content as the secret value
 ### What happens when it's configured
 
 Every push of a `v*` tag will automatically:
-1. Build the signed AAB
-2. Upload it to the **Internal track** in Play Console
-3. The release appears immediately for internal testers
+1. Build the signed AAB and create a GitHub Release
+2. Attempt to upload the AAB to the **Internal track** in Play Console
+
+> **First release only**: The Play upload step will be skipped until the app has been
+> submitted to Play Console at least once manually (the API cannot create a new listing).
+> The workflow will still succeed — the GitHub Release with the signed AAB is always created.
+> See the first-upload steps in [android-release.md](android-release.md).
+> From the second release onwards, the AAB appears in Internal testing automatically.
 
 From there you manually promote to Alpha → Beta → Production in Play Console.
 

--- a/docs/tooling/github-secrets.md
+++ b/docs/tooling/github-secrets.md
@@ -385,9 +385,16 @@ with the upload keystore before uploading to Google Play.
 Storing only the upload key in CI means the real distribution key is never exposed. If the upload
 key is compromised you can rotate it in Play Console without affecting users.
 
-### Step 1: Create the upload keystore (once)
+### Step 1: Identify the correct keystore
 
-Run this locally and store the resulting `.jks` file safely (password manager, etc.):
+> **Replacing an existing Play Store app?**
+> Use the **original signing keystore** — the same one that was used to sign previous releases.
+> Do NOT generate a new keystore. The original keystore must first be enrolled in Play App Signing
+> (see [android-release.md](android-release.md#replacing-the-existing-play-store-app-seamless-upgrade)).
+> Enrolling it as the app signing key is what ensures existing users receive the update seamlessly.
+> After enrollment, the same keystore serves as the upload key in CI.
+
+For a **brand new app with no existing Play Store history**, generate a keystore:
 
 ```bash
 keytool -genkey -v -keystore upload-keystore.jks \

--- a/docs/tooling/github-secrets.md
+++ b/docs/tooling/github-secrets.md
@@ -1,17 +1,30 @@
-# GitHub Secrets Setup for Firebase CI/CD
+# GitHub Secrets Setup
 
-This guide explains how to set up GitHub Secrets so that CI/CD builds can access Firebase configuration files securely.
+This guide explains how to set up all GitHub Secrets required by CI/CD workflows.
 
 ## Overview
 
-Firebase configuration files (`google-services.json` and `firebase_options.dart`) are excluded from version control for security. GitHub Secrets allow CI/CD workflows to recreate these files during builds.
+Several configuration files are excluded from version control for security. GitHub Secrets allow
+CI/CD workflows to recreate these files at build time.
 
 ## Required Secrets
 
-You need to add **2 secrets** to your GitHub repository:
+You need to add **7 secrets** to your GitHub repository:
 
+**Firebase (existing):**
 1. `GOOGLE_SERVICES_JSON` - Android Firebase configuration
 2. `FIREBASE_OPTIONS_DART` - Flutter Firebase configuration
+
+**Android signing (new):**
+
+3. `ANDROID_KEYSTORE_BASE64` - Base64-encoded upload keystore
+4. `ANDROID_KEY_ALIAS` - Key alias inside the keystore
+5. `ANDROID_KEY_PASSWORD` - Key password
+6. `ANDROID_KEYSTORE_PASSWORD` - Keystore (store) password
+
+**Google Play (new):**
+
+7. `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` - Service account JSON for automated Play uploads
 
 ---
 
@@ -354,3 +367,122 @@ If you encounter issues:
 3. Check GitHub Actions logs for specific error messages
 4. Ensure local Firebase setup works before adding to CI/CD
 5. Review this guide's troubleshooting section
+
+---
+
+## Android Signing Secrets
+
+These secrets are required by `.github/workflows/release-android.yml` to sign the APK and AAB
+with the upload keystore before uploading to Google Play.
+
+### How Play App Signing works
+
+| Key | Held by | Purpose |
+|-----|---------|---------|
+| **App signing key** | Google | Signs APKs delivered to users |
+| **Upload key** | You (these secrets) | Signs the AAB you submit; Google verifies then re-signs |
+
+Storing only the upload key in CI means the real distribution key is never exposed. If the upload
+key is compromised you can rotate it in Play Console without affecting users.
+
+### Step 1: Create the upload keystore (once)
+
+Run this locally and store the resulting `.jks` file safely (password manager, etc.):
+
+```bash
+keytool -genkey -v -keystore upload-keystore.jks \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -alias upload
+```
+
+### Step 2: Base64-encode the keystore
+
+```bash
+# Linux/Mac
+base64 -i upload-keystore.jks | tr -d '\n'
+
+# Windows (PowerShell)
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("upload-keystore.jks"))
+```
+
+### Step 3: Add the four secrets
+
+**Go to**: Repository Settings → Secrets and variables → Actions → New repository secret
+
+| Secret | Value |
+|--------|-------|
+| `ANDROID_KEYSTORE_BASE64` | The full base64 string from step 2 |
+| `ANDROID_KEY_ALIAS` | The alias used in `keytool` (e.g. `upload`) |
+| `ANDROID_KEY_PASSWORD` | The key password entered in `keytool` |
+| `ANDROID_KEYSTORE_PASSWORD` | The keystore password entered in `keytool` |
+
+Via GitHub CLI:
+
+```bash
+# Encode and set in one step
+base64 -i upload-keystore.jks | tr -d '\n' | gh secret set ANDROID_KEYSTORE_BASE64
+echo -n "your-key-alias"    | gh secret set ANDROID_KEY_ALIAS
+echo -n "your-key-password" | gh secret set ANDROID_KEY_PASSWORD
+echo -n "your-store-password" | gh secret set ANDROID_KEYSTORE_PASSWORD
+```
+
+---
+
+## Google Play Service Account Secret
+
+This secret is required by the `publish-google-play` job in `release-android.yml` to upload
+the signed AAB to the Internal track automatically on every release.
+
+### Step 1: Enable the Google Play API
+
+1. Open [Google Cloud Console](https://console.cloud.google.com/) and select (or create) the
+   project linked to your Play Console account
+2. Go to **APIs & Services → Library**
+3. Search for **Google Play Android Developer API** and click **Enable**
+
+### Step 2: Create a service account
+
+1. Go to **APIs & Services → Credentials → Create Credentials → Service account**
+2. Name it (e.g. `github-play-publisher`), click **Create and continue**
+3. Skip optional role assignment, click **Done**
+4. Click the service account → **Keys** tab → **Add key → Create new key → JSON**
+5. Download the JSON file — this is your secret value
+
+### Step 3: Grant Play Console access
+
+1. Open [Google Play Console](https://play.google.com/console)
+2. Go to **Setup → API access**
+3. Click **Link** next to the Google Cloud project from step 1 (if not already linked)
+4. Under **Service accounts**, find the account you created and click **Grant access**
+5. Set permissions to **Release manager** (or at minimum **Release to Internal testing**)
+6. Click **Apply** and **Invite user**
+
+### Step 4: Add the secret
+
+```bash
+gh secret set GOOGLE_PLAY_SERVICE_ACCOUNT_JSON < path/to/service-account.json
+```
+
+Or via the web interface: paste the entire JSON file content as the secret value.
+
+### What happens when it's configured
+
+Every push of a `v*` tag will automatically:
+1. Build the signed AAB
+2. Upload it to the **Internal track** in Play Console
+3. The release appears immediately for internal testers
+
+From there you manually promote to Alpha → Beta → Production in Play Console.
+
+### Troubleshooting
+
+**"Permission denied" or "403 Forbidden"**
+- Verify the service account was granted access in Play Console (step 3)
+- Check the app is published at least once manually before the API can upload updates
+
+**"Package not found"**
+- Ensure the `packageName` in the workflow (`ralcock.cbf`) matches the app in Play Console exactly
+
+**"Upload key certificate does not match"**
+- The upload keystore registered in Play Console must match the one in `ANDROID_KEYSTORE_BASE64`
+- On first upload, Play Console registers your upload certificate automatically

--- a/docs/tooling/play-store.md
+++ b/docs/tooling/play-store.md
@@ -296,10 +296,17 @@ git tag -a v2025.12.0 -m "Release v2025.12.0"
 git push origin v2025.12.0
 ```
 
-### 5. CI uploads to Internal track automatically (~10 min)
-- The `Release Android` GitHub Actions workflow runs automatically
-- Builds the signed AAB and uploads it to Google Play **Internal track**
-- No manual download/upload needed
+### 5. First release: upload AAB manually, then CI takes over
+
+> **One-time step**: The Google Play Developer API cannot create a new app listing.
+> For the **very first** release you must:
+> 1. Download the AAB from the GitHub Release created in step 4
+> 2. Upload it manually in Play Console → Internal testing → Create new release
+> 3. Complete the store listing (see checklist below)
+> 4. Submit and wait for the first review to pass
+>
+> From the **second release onwards**, CI uploads to Internal track automatically
+> with no manual intervention needed.
 
 ### 6. Promote to Production in Play Console (5 min)
 - Open [Google Play Console](https://play.google.com/console) → Internal testing

--- a/docs/tooling/play-store.md
+++ b/docs/tooling/play-store.md
@@ -7,7 +7,7 @@ This document provides the exact metadata needed for the Google Play Store listi
 | Field | Value |
 |-------|-------|
 | **App Name** | Cambridge Beer Festival |
-| **Package Name** | `[REPLACE_WITH_YOUR_PACKAGE_NAME]`<br/><sub>e.g. <code>com.cambridgebeerfestival.cambridge_beer_festival</code></sub> |
+| **Package Name** | `ralcock.cbf` |
 | **Developer Name** | [YOUR NAME/ORGANIZATION] |
 | **Contact Email** | [YOUR EMAIL] |
 | **Website** | [YOUR WEBSITE or GitHub repo URL] |
@@ -271,54 +271,60 @@ Use this checklist when preparing your Play Store submission:
   - [ ] Countries/regions selected
   - [ ] Pricing set (Free)
 
-## 🚀 Quick Start: First Release
+## 🚀 Quick Start: Replacing the Existing App
 
-If this is your first time, follow these steps:
+This Flutter app replaces an existing self-signed APK app (`ralcock.cbf`) already on the Play Store.
+The goal is a **seamless upgrade** — existing users get an automatic update, not a new install.
+
+### Before you start — migration checklist
+
+- [ ] Locate the **original signing keystore** (.jks or .keystore) used for all previous releases
+- [ ] Know (or recover) the keystore password, key alias, and key password
+- [ ] Complete Play App Signing migration (see [android-release.md](android-release.md#replacing-the-existing-play-store-app-seamless-upgrade))
+- [ ] Configure all 5 Android/Play secrets in GitHub (see [github-secrets.md](github-secrets.md))
 
 ### 1. Prepare Assets (1-2 hours)
 - Create feature graphic
-- Take 2-8 screenshots
-- Write/host privacy policy
+- Take 2-8 screenshots of the Flutter app
+- Update/confirm privacy policy is live
 
-### 2. Create Google Play Developer Account (30 min)
-- Sign up at [play.google.com/console](https://play.google.com/console)
-- Pay $25 registration fee
-- Verify identity
+### 2. Verify version code is higher (5 min)
 
-### 3. Create App Listing (30 min)
-- Create new app in Play Console
-- Fill in all metadata from this document
-- Upload visual assets
+Check the current version code in Play Console (Dashboard → App releases → version number).
+The Flutter app's version code is the number after `+` in `pubspec.yaml`:
+```
+version: 2025.12.0+20251200   ← version code is 20251200
+```
+If the existing app's version code is ≥ 20251200, bump `pubspec.yaml` before tagging.
 
-### 4. Generate Release (5 min)
+### 3. Generate Release (5 min)
 ```bash
 git tag -a v2025.12.0 -m "Release v2025.12.0"
 git push origin v2025.12.0
 ```
 
-### 5. First release: upload AAB manually, then CI takes over
+### 4. First AAB upload: manual (one-time only)
 
-> **One-time step**: The Google Play Developer API cannot create a new app listing.
-> For the **very first** release you must:
-> 1. Download the AAB from the GitHub Release created in step 4
-> 2. Upload it manually in Play Console → Internal testing → Create new release
-> 3. Complete the store listing (see checklist below)
-> 4. Submit and wait for the first review to pass
+> The Google Play API cannot upload to an app that has never had an AAB submitted.
+> For the **very first Flutter release** you must upload manually:
+> 1. Wait for the GitHub Actions `Release Android` workflow to complete
+> 2. Download the AAB from the GitHub Release
+> 3. In Play Console → **Internal testing** → **Create new release** → upload the AAB
+> 4. Submit and confirm testers can install
 >
-> From the **second release onwards**, CI uploads to Internal track automatically
-> with no manual intervention needed.
+> From the **second release onwards**, CI uploads to Internal track automatically.
 
-### 6. Promote to Production in Play Console (5 min)
+### 5. Promote to Production in Play Console (5 min)
 - Open [Google Play Console](https://play.google.com/console) → Internal testing
 - Click **Promote release** → Production
-- Fill in release notes
+- Add release notes
 - Submit for review
 
-### 7. Wait for Review (1-7 days)
+### 6. Wait for Review (1-7 days)
 - Google reviews the app
 - You'll receive email notification
 - Fix any issues if rejected
-- Once approved, app goes live!
+- Once approved, existing users receive the update automatically
 
 ## 📞 Support Contacts
 

--- a/docs/tooling/play-store.md
+++ b/docs/tooling/play-store.md
@@ -256,7 +256,9 @@ Use this checklist when preparing your Play Store submission:
   - [ ] Package name matches existing app (if updating)
   - [ ] Version code increased from previous version
   - [ ] Enrolled in Play App Signing
-  - [ ] AAB uploaded successfully
+  - [ ] Android signing secrets configured in GitHub (`ANDROID_KEYSTORE_BASE64`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`, `ANDROID_KEYSTORE_PASSWORD`)
+  - [ ] Google Play service account secret configured in GitHub (`GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`)
+  - [ ] **First upload done manually** (CI upload only works after the app exists in Play Console)
 
 - [ ] **Contact Information**
   - [ ] Developer email set
@@ -294,13 +296,18 @@ git tag -a v2025.12.0 -m "Release v2025.12.0"
 git push origin v2025.12.0
 ```
 
-### 5. Upload to Play Console (15 min)
-- Download AAB from GitHub Release
-- Upload to Production track
+### 5. CI uploads to Internal track automatically (~10 min)
+- The `Release Android` GitHub Actions workflow runs automatically
+- Builds the signed AAB and uploads it to Google Play **Internal track**
+- No manual download/upload needed
+
+### 6. Promote to Production in Play Console (5 min)
+- Open [Google Play Console](https://play.google.com/console) → Internal testing
+- Click **Promote release** → Production
 - Fill in release notes
 - Submit for review
 
-### 6. Wait for Review (1-7 days)
+### 7. Wait for Review (1-7 days)
 - Google reviews the app
 - You'll receive email notification
 - Fix any issues if rejected

--- a/docs/tooling/play-store.md
+++ b/docs/tooling/play-store.md
@@ -305,14 +305,18 @@ git push origin v2025.12.0
 
 ### 4. First AAB upload: manual (one-time only)
 
-> The Google Play API cannot upload to an app that has never had an AAB submitted.
-> For the **very first Flutter release** you must upload manually:
-> 1. Wait for the GitHub Actions `Release Android` workflow to complete
-> 2. Download the AAB from the GitHub Release
-> 3. In Play Console → **Internal testing** → **Create new release** → upload the AAB
-> 4. Submit and confirm testers can install
->
-> From the **second release onwards**, CI uploads to Internal track automatically.
+The Google Play API cannot upload to an app that has never had an AAB submitted.
+On the first tag push the `Release Android` workflow will:
+- ✅ Build the signed APK and AAB
+- ✅ Create the GitHub Release with all artifacts
+- ⚠️ Skip the Play upload (expected — no listing exists yet; workflow still succeeds)
+
+You must then upload manually:
+1. Download the AAB from the GitHub Release
+2. In Play Console → **Internal testing** → **Create new release** → upload the AAB
+3. Submit and confirm testers can install
+
+From the **second release onwards**, CI uploads to Internal track automatically.
 
 ### 5. Promote to Production in Play Console (5 min)
 - Open [Google Play Console](https://play.google.com/console) → Internal testing


### PR DESCRIPTION
- Add upload keystore signing to build.gradle via key.properties pattern
  (falls back to debug signing locally when key.properties is absent)
- Inject ANDROID_KEYSTORE_BASE64 / key.properties in CI before the build
- Add publish-google-play job that uploads the signed AAB to Internal track
  using r0adkll/upload-google-play and a Google Play service account secret
- Drop "unsigned" suffix from release artifact filenames
- Update release notes to reflect Play App Signing model

Required new secrets: ANDROID_KEYSTORE_BASE64, ANDROID_KEYSTORE_PASSWORD,
ANDROID_KEY_PASSWORD, ANDROID_KEY_ALIAS, GOOGLE_PLAY_SERVICE_ACCOUNT_JSON

https://claude.ai/code/session_01LRvsZuXFafSSFLZrcB53fz