### PR TITLE
Release v2026.5.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cambridge_beer_festival
 description: A Flutter app for Cambridge Beer Festival - browse beers, ciders, meads, and more.
 publish_to: 'none'
-version: 2025.12.0+20251200
+version: 2026.5.0+20260500
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
## Release v2026.5.0

Bumps version to `2026.5.0+20260500` for the first Android release.

## Checklist

- [x] Version code `20260500` is higher than existing Play Store version code (`27`)
- [x] Android signing secrets configured in GitHub
- [x] Play App Signing migration completed (original keystore enrolled)

## After merging

1. Tag `v2026.5.0` on main to trigger the `Release Android` workflow
2. Download the AAB from the GitHub Release
3. Upload manually to Play Console → Internal testing (first upload must be manual)
4. From the second release onwards, CI uploads automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)