### PR TITLE
feat: add charity partner donate button to festival info screen

### DIFF
--- a/data/festivals.json
+++ b/data/festivals.json
@@ -31,7 +31,9 @@
         "low-no"
       ],
       "data_base_url": "/cbf2026",
-      "is_active": true
+      "is_active": true,
+      "charity_partner_name": "Cambridge Samaritans",
+      "charity_donation_url": "https://samaritanscommunity.enthuse.com/cf/cambridge-samaritans-at-the-cambridge-beer-festiva"
     },
     {
       "id": "cbf2025",

--- a/lib/models/festival.dart
+++ b/lib/models/festival.dart
@@ -27,6 +27,8 @@ class Festival {
   final List<String> availableBeverageTypes;
   final String dataBaseUrl;
   final bool isActive;
+  final String? charityPartnerName;
+  final String? charityDonationUrl;
 
   const Festival({
     required this.id,
@@ -44,6 +46,8 @@ class Festival {
     this.availableBeverageTypes = const ['beer'],
     required this.dataBaseUrl,
     this.isActive = false,
+    this.charityPartnerName,
+    this.charityDonationUrl,
   });
 
   factory Festival.fromJson(Map<String, dynamic> json) {
@@ -71,6 +75,8 @@ class Festival {
           const ['beer'],
       dataBaseUrl: json['data_base_url'] as String,
       isActive: json['is_active'] as bool? ?? false,
+      charityPartnerName: json['charity_partner_name'] as String?,
+      charityDonationUrl: json['charity_donation_url'] as String?,
     );
   }
 
@@ -91,6 +97,8 @@ class Festival {
       'available_beverage_types': availableBeverageTypes,
       'data_base_url': dataBaseUrl,
       'is_active': isActive,
+      if (charityPartnerName != null) 'charity_partner_name': charityPartnerName,
+      if (charityDonationUrl != null) 'charity_donation_url': charityDonationUrl,
     };
   }
 

--- a/lib/screens/festival_info_screen.dart
+++ b/lib/screens/festival_info_screen.dart
@@ -224,6 +224,19 @@ class FestivalInfoScreen extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          if (festival.charityPartnerName != null && festival.charityDonationUrl != null) ...[
+            Semantics(
+              label: 'Donate to ${festival.charityPartnerName}',
+              hint: 'Double tap to open donation page in browser',
+              button: true,
+              child: FilledButton.icon(
+                onPressed: () => _openDonation(context, festival),
+                icon: const Icon(Icons.favorite),
+                label: Text('Donate to ${festival.charityPartnerName}'),
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
           if (festival.websiteUrl != null)
             Semantics(
               label: 'Visit festival website',
@@ -248,6 +261,15 @@ class FestivalInfoScreen extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+
+  void _openDonation(BuildContext context, Festival festival) async {
+    if (festival.charityDonationUrl == null) return;
+    await UrlLauncherHelper.launchURL(
+      context,
+      festival.charityDonationUrl!,
+      errorMessage: 'Could not open donation page',
     );
   }
 


### PR DESCRIPTION
## Summary

- Adds `charity_partner_name` and `charity_donation_url` fields to the `Festival` model and `festivals.json`
- When set, a prominent **FilledButton** with a heart icon appears at the top of the actions section on the Festival Info screen
- For cbf2026, links to Cambridge Samaritans at the Cambridge Beer Festival

## cbf2026 charity partner

**Cambridge Samaritans** — the 2026 official charity partner. Festival-goers can donate via the app or by donating their glass deposit at the event.

## Generic feature

Works for any future festival — just set `charity_partner_name` and `charity_donation_url` in `festivals.json`. If not set, no button appears (existing behaviour preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)