### PR TITLE
test: add missing coverage for charity donate button (#229 follow-up)

### DIFF
--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -882,6 +882,23 @@ void main() {
         expect(festival.hours, isNull);
         expect(festival.availableBeverageTypes, ['beer']);
         expect(festival.isActive, isFalse);
+        expect(festival.charityPartnerName, isNull);
+        expect(festival.charityDonationUrl, isNull);
+      });
+
+      test('parses charity partner fields', () {
+        final json = {
+          'id': 'test',
+          'name': 'Test Festival',
+          'data_base_url': 'https://example.com/test',
+          'charity_partner_name': 'Test Charity',
+          'charity_donation_url': 'https://charity.example.com/donate',
+        };
+
+        final festival = Festival.fromJson(json);
+
+        expect(festival.charityPartnerName, 'Test Charity');
+        expect(festival.charityDonationUrl, 'https://charity.example.com/donate');
       });
 
       test('handles latitude and longitude as int', () {
@@ -958,6 +975,23 @@ void main() {
         expect(json.containsKey('description'), isFalse);
         expect(json.containsKey('website_url'), isFalse);
         expect(json.containsKey('hours'), isFalse);
+        expect(json.containsKey('charity_partner_name'), isFalse);
+        expect(json.containsKey('charity_donation_url'), isFalse);
+      });
+
+      test('includes charity fields when set', () {
+        const festival = Festival(
+          id: 'test',
+          name: 'Test Festival',
+          dataBaseUrl: 'https://example.com/test',
+          charityPartnerName: 'Test Charity',
+          charityDonationUrl: 'https://charity.example.com/donate',
+        );
+
+        final json = festival.toJson();
+
+        expect(json['charity_partner_name'], 'Test Charity');
+        expect(json['charity_donation_url'], 'https://charity.example.com/donate');
       });
     });
 

--- a/test/screens_test.dart
+++ b/test/screens_test.dart
@@ -258,7 +258,7 @@ void main() {
         await provider.setFestival(testFestival);
         await tester.pumpWidget(createTestWidget());
 
-        expect(find.text('Donate to'), findsNothing);
+        expect(find.textContaining('Donate to'), findsNothing);
       });
 
       testWidgets('successfully launches donation URL',

--- a/test/screens_test.dart
+++ b/test/screens_test.dart
@@ -225,6 +225,82 @@ void main() {
       expect(find.text('Could not open maps'), findsNothing);
       expect(find.text('Error opening maps'), findsNothing);
     });
+
+    group('donate button', () {
+      late Festival charityFestival;
+
+      setUp(() async {
+        charityFestival = Festival(
+          id: 'test-charity-festival',
+          name: 'Test Festival',
+          dataBaseUrl: 'https://example.com',
+          startDate: DateTime(2025, 5, 1),
+          endDate: DateTime(2025, 5, 3),
+          websiteUrl: 'https://testfestival.com',
+          latitude: 52.2053,
+          longitude: 0.1218,
+          location: 'Test Location',
+          charityPartnerName: 'Test Charity',
+          charityDonationUrl: 'https://charity.example.com/donate',
+        );
+        await provider.setFestival(charityFestival);
+      });
+
+      testWidgets('renders donate button when charity fields are set',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Donate to Test Charity'), findsOneWidget);
+      });
+
+      testWidgets('does not render donate button when charity fields are absent',
+          (WidgetTester tester) async {
+        await provider.setFestival(testFestival);
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Donate to'), findsNothing);
+      });
+
+      testWidgets('successfully launches donation URL',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        final donateButton = find.text('Donate to Test Charity');
+        await tester.tap(donateButton);
+        await tester.pumpAndSettle();
+
+        expect(mockUrlLauncher.lastLaunchedUrl,
+            'https://charity.example.com/donate');
+        expect(find.text('Could not open donation page'), findsNothing);
+      });
+
+      testWidgets('shows error SnackBar when donation URL cannot be launched',
+          (WidgetTester tester) async {
+        mockUrlLauncher.canLaunchResult = false;
+
+        await tester.pumpWidget(createTestWidget());
+
+        final donateButton = find.text('Donate to Test Charity');
+        await tester.tap(donateButton);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Could not open donation page'), findsOneWidget);
+      });
+
+      testWidgets(
+          'shows error SnackBar when donation URL launch throws exception',
+          (WidgetTester tester) async {
+        mockUrlLauncher.shouldThrowOnLaunch = true;
+
+        await tester.pumpWidget(createTestWidget());
+
+        final donateButton = find.text('Donate to Test Charity');
+        await tester.tap(donateButton);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Could not open donation page'), findsOneWidget);
+      });
+    });
   });
 
   group('AboutScreen', () {


### PR DESCRIPTION
## Summary

- Adds widget tests for the donate button introduced in #229: renders when charity fields are set, absent when not set, successful launch, error SnackBar on `canLaunch=false`, error SnackBar on thrown exception
- Adds `Festival.fromJson`/`toJson` model tests for the new `charityPartnerName` and `charityDonationUrl` fields
- Fixes the `codecov/patch` failure from #229 which was merged before these tests were pushed

## Test plan
- [x] `flutter test test/screens_test.dart` — all donate button tests pass
- [x] `flutter test test/models_test.dart` — all Festival charity field tests pass
- [x] Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)