### PR TITLE
Release v2026.5.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cambridge_beer_festival
 description: A Flutter app for Cambridge Beer Festival - browse beers, ciders, meads, and more.
 publish_to: 'none'
-version: 2026.5.0+20260500
+version: 2026.5.1+20260501
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
## Release v2026.5.1

Bumps version to `2026.5.1+20260501`.

## What's included since v2026.5.0

- **#228** fix(data): correct cbf2026 closing times and drink counts
- **#229** feat: add charity partner donate button (Cambridge Samaritans)
- **#230** fix(nav): add home button to festival info and about screens; use `canPopNavigation()` instead of `context.canPop()`

## After merging

Tag `v2026.5.1` on main to trigger the `Release Android` workflow — CI will build and upload the AAB to Play Console automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)