### PR TITLE
chore: bump version to 2026.5.2, add release process docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  lint-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Detect which files have changed
   changes:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -723,6 +723,24 @@ void setMyField(String? value) {
 }
 ```
 
+## Release Process
+
+This project uses **CalVer** (`YYYY.M.patch`). See [docs/processes/release.md](docs/processes/release.md) for the full guide.
+
+Quick reference:
+
+```bash
+# 1. Bump version in pubspec.yaml on main
+#    version: 2026.5.2+20260509  (build number = YYYYMMDD)
+git add pubspec.yaml && git commit -m "chore: bump version to 2026.5.2"
+git push origin main
+
+# 2. Tag to trigger deployment
+git tag v2026.5.2 && git push origin v2026.5.2
+```
+
+Pushing the tag triggers `release-web.yml` (web → cambeerfestival.app) and `release-android.yml` (signed APK/AAB → Google Play Internal track) automatically.
+
 ## Validation Workflow
 
 **📖 See [AGENTS.md](AGENTS.md) for complete workflow guide.**

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Technical documentation is available in the [docs](docs/) directory - see [docs/
 
 ### Development & Setup
 - [Development Guide](docs/processes/development.md) - Complete development setup and workflows
+- [Release Guide](docs/processes/release.md) - Version bumping, branching, and tagging for releases
 - [Firebase Setup](docs/tooling/firebase.md) - Firebase integration for Crashlytics and Analytics
 - [GitHub Secrets](docs/tooling/github-secrets.md) - Required secrets for CI/CD
 
@@ -193,6 +194,8 @@ The app is deployed to multiple environments:
 1. **Development changes**: Push to `main` → Staging (Cloudflare Pages)
 2. **PR reviews**: Open PR → Unique Cloudflare Pages preview created
 3. **Production releases**: Create tag (e.g., `v2025.12.0`) → Production deployment to cambeerfestival.app
+
+For the full release process (version bumping, branching, tagging), see the [Release Guide](docs/processes/release.md).
 
 For deployment setup and configuration, see [Cloudflare Pages Setup Guide](docs/tooling/cloudflare-pages.md).
 

--- a/docs/processes/release.md
+++ b/docs/processes/release.md
@@ -1,0 +1,83 @@
+# Release Process
+
+This project uses **CalVer** (`YYYY.M.patch`) for versioning. Releases are triggered by pushing a `v*` tag, which kicks off automatic web and Android deployments.
+
+## Version Format
+
+| Component | Format | Example |
+|-----------|--------|---------|
+| Version name | `YYYY.M.patch` | `2026.5.2` |
+| Build number | `YYYYMMDD` (release date) | `20260509` |
+| pubspec.yaml | `version: YYYY.M.patch+YYYYMMDD` | `2026.5.2+20260509` |
+| Git tag | `vYYYY.M.patch` | `v2026.5.2` |
+
+Patch number resets to `1` each month. Increment for each release within a month (`2026.5.1`, `2026.5.2`, …).
+
+## Step-by-Step Release
+
+### 1. Bump version in pubspec.yaml
+
+On `main`, edit the `version` line:
+
+```yaml
+version: 2026.5.2+20260509
+```
+
+Replace `20260509` with today's date (`YYYYMMDD`).
+
+### 2. Commit and push
+
+```bash
+git add pubspec.yaml
+git commit -m "chore: bump version to 2026.5.2"
+git push origin main
+```
+
+### 3. Tag and push
+
+```bash
+git tag v2026.5.2
+git push origin v2026.5.2
+```
+
+That's it. Pushing the tag triggers the release workflows automatically.
+
+## What happens next (automated)
+
+| Workflow | Action |
+|----------|--------|
+| `release-web.yml` | Runs tests, builds, and deploys web app to `cambeerfestival.app` |
+| `release-android.yml` | Builds signed APK/AAB, creates GitHub Release, uploads to Google Play Internal track |
+
+Monitor progress in the [Actions tab](https://github.com/richardthe3rd/cambridge-beer-festival-app/actions).
+
+## Promote Android release (manual)
+
+Once the Internal track build is available:
+
+1. Open [Google Play Console](https://play.google.com/console)
+2. Navigate to your app → Internal testing
+3. Promote to Alpha / Beta / Production as appropriate
+
+## Verify production
+
+Visit [cambeerfestival.app](https://cambeerfestival.app) and confirm the release is live.
+
+## Hotfix releases
+
+Branch from the release tag rather than `main`:
+
+```bash
+git checkout v2026.5.2
+git checkout -b hotfix/2026.5.3
+# fix, bump version, commit
+git tag v2026.5.3
+git push origin v2026.5.3
+```
+
+Then backport the fix to `main` via a normal PR.
+
+## See also
+
+- [CI/CD Workflows](ci-cd.md) — full workflow documentation
+- [GitHub Secrets](../tooling/github-secrets.md) — secrets required for release workflows

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -357,6 +357,15 @@ No version history tracking for users/developers.
 
 ---
 
+### 14. Automate releases with release-please
+**Files:** `.github/workflows/`, `pubspec.yaml`
+
+Now that PRs enforce conventional commits, [release-please](https://github.com/googleapis/release-please) could automate the manual version bump step entirely. It watches conventional commits on `main`, maintains a `CHANGELOG.md`, and opens a "Release PR" that bumps `pubspec.yaml` — merging that PR is all that's needed to ship.
+
+**Consideration:** release-please uses SemVer by default; CalVer requires a custom manifest. Worth evaluating if the manual bump step becomes friction.
+
+---
+
 ### 9. Add Performance Monitoring
 **Files:** App-wide
 Consider Firebase Performance or custom metrics for tracking performance regressions.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cambridge_beer_festival
 description: A Flutter app for Cambridge Beer Festival - browse beers, ciders, meads, and more.
 publish_to: 'none'
-version: 2026.5.1+20260501
+version: 2026.5.2+20260509
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
This pull request introduces a formalized release process for the project, including documentation and workflow automation for versioning and deployments. It adds a comprehensive release guide, updates the documentation to reference this process, and bumps the app version.

**Release process documentation and workflow:**

* Added a new `docs/processes/release.md` file detailing the step-by-step release process, including versioning scheme (CalVer), tagging, and deployment automation for web and Android.
* Updated `README.md` to reference the new Release Guide in both the Development & Setup section and the deployment workflow section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R198-R199)
* Added a "Release Process" section to `CLAUDE.md` summarizing the release workflow and automation triggers.

**Version bump:**

* Updated `pubspec.yaml` to bump the version to `2026.5.2+20260509` as part of the documented release process.