### PR TITLE
chore: bump version to 2026.5.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cambridge_beer_festival
 description: A Flutter app for Cambridge Beer Festival - browse beers, ciders, meads, and more.
 publish_to: 'none'
-version: 2026.5.2+20260509
+version: 2026.5.3+20260510
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
## Release 2026.5.3

Version bump for the 2026.5.3 release.

### Fixes included (since 2026.5.2)

- **fix(festival-selector)**: avoid `GoRouterState.of()` inside gesture callback — fixes ANR/complete freeze when switching festivals while data is loading (#241)

### Pending

- **fix: use `context.push()` for sub-page navigation** (#240) — merge that PR into main and then `git merge main` this branch before tagging

### Release steps

After merging this PR:
```bash
git tag v2026.5.3
git push origin v2026.5.3
```