### PR TITLE
chore: bump version to 2026.5.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cambridge_beer_festival
 description: A Flutter app for Cambridge Beer Festival - browse beers, ciders, meads, and more.
 publish_to: 'none'
-version: 2026.5.3+20260510
+version: 2026.5.4+20260511
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
## Summary

- Bumps \`pubspec.yaml\` version from \`2026.5.3+20260510\` to \`2026.5.4+20260511\`

## Release steps after merge

1. Merge this PR
2. Tag the merge commit: \`git tag v2026.5.4 && git push origin v2026.5.4\`
3. This triggers \`release-web.yml\` and \`release-android.yml\` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)