### PR TITLE
ci: add dedicated PR lint workflow using pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  lint-pr:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # Detect which files have changed
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,19 @@
+name: PR Lint
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,7 +1,7 @@
 name: PR Lint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,6 +444,16 @@ Fixed some issues with the router and added validation for festival IDs and also
 [... 50 more lines ...]
 ```
 
+### PR Title Rules
+
+PR titles must also follow conventional commits format — the CI `PR Lint` check enforces this via `amannn/action-semantic-pull-request`. Use the same `<type>(<scope>): <subject>` pattern as commit messages.
+
+```
+feat(drinks): add low-alcohol filter
+fix(router): handle missing festival ID
+chore: bump Flutter to 3.38.3
+```
+
 ### Commit Message Rules
 
 ✅ **DO:**
@@ -774,7 +784,7 @@ Always test and handle:
 4. **Handle null**: API data may have missing fields
 5. **Theme colors**: Use `Theme.of(context)` for consistent colors
 6. **Test coverage**: Unit + Integration + Manual = Complete
-7. **Commit messages**: Use conventional commits, keep concise
+7. **Commit messages & PR titles**: Both must use conventional commits format
 8. **Documentation**: Concise is better than comprehensive
 9. **Abstraction**: Only if used 3+ times or prevents errors
 10. **Error handling**: Guard all external interactions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,7 +446,7 @@ Fixed some issues with the router and added validation for festival IDs and also
 
 ### PR Title Rules
 
-PR titles must also follow conventional commits format — the CI `PR Lint` check enforces this via `amannn/action-semantic-pull-request`. Use the same `<type>(<scope>): <subject>` pattern as commit messages.
+PR titles must also follow conventional commits format. CI will reject PRs with non-conforming titles via the `PR Lint` check. Use the same `<type>(<scope>): <subject>` pattern as commit messages.
 
 ```
 feat(drinks): add low-alcohol filter


### PR DESCRIPTION
Moves semantic PR title check out of ci.yml into a standalone
pr-lint.yml triggered on opened, edited, and reopened so the
check re-runs when the PR title is changed.

https://claude.ai/code/session_01LMQtXBZsnSAajpW7VW7j2y