### PR TITLE
fix(release): remove labels from create-pull-request — label did not …

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -87,5 +87,4 @@ jobs:
           title: 'Release ${{ steps.version.outputs.version }}'
           body-path: release-notes.md
           commit-message: 'chore: prepare release ${{ steps.version.outputs.version }}'
-          labels: release
           delete-branch: false


### PR DESCRIPTION
…exist

The 'release' label was not present in the repository, causing the create-pull-request action to fail. The PR is identifiable by its release/next branch name and Release X.Y.Z title without needing a label.

https://claude.ai/code/session_01JDVdCKNUcJfnKCaZZipMWW