### PR TITLE
fix(provider): discard stale drinks responses on rapid festival switch

### DIFF
--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -42,6 +42,9 @@ class BeerProvider extends ChangeNotifier {
   static const Duration _drinksStalenessThreshold = Duration(hours: 1);
   static const Duration _festivalsStalenessThreshold = Duration(hours: 24);
 
+  // Token incremented on every new drinks load; stale responses check against it
+  int _drinksLoadToken = 0;
+
   BeerProvider({
     AnalyticsService? analyticsService,
     DrinkFilterService? filterService,
@@ -275,15 +278,19 @@ class BeerProvider extends ChangeNotifier {
 
     _isLoading = true;
     _error = null;
+    final token = ++_drinksLoadToken;
     notifyListeners();
 
     try {
       // Repository returns drinks with favorites and ratings already populated
-      _allDrinks = await _drinkRepository!.getDrinks(currentFestival);
+      final drinks = await _drinkRepository!.getDrinks(currentFestival);
+      if (token != _drinksLoadToken) return;
+      _allDrinks = drinks;
       _applyFiltersAndSort();
       _error = null;
       _lastDrinksRefresh = DateTime.now();
     } catch (e, stackTrace) {
+      if (token != _drinksLoadToken) return;
       _error = _getUserFriendlyErrorMessage(e);
       _allDrinks = [];
       _filteredDrinks = [];
@@ -294,8 +301,10 @@ class BeerProvider extends ChangeNotifier {
         reason: 'Failed to load drinks for festival: ${currentFestival.id}',
       );
     } finally {
-      _isLoading = false;
-      notifyListeners();
+      if (token == _drinksLoadToken) {
+        _isLoading = false;
+        notifyListeners();
+      }
     }
   }
 
@@ -314,6 +323,7 @@ class BeerProvider extends ChangeNotifier {
     _filteredDrinks = [];
     _isLoading = true;
     _error = null;
+    final token = ++_drinksLoadToken;
     notifyListeners();
 
     await _analyticsService.logFestivalSelected(festival);
@@ -322,18 +332,23 @@ class BeerProvider extends ChangeNotifier {
       await _festivalRepository?.setSelectedFestivalId(festival.id);
     }
 
-    await _loadDrinksInternal();
+    await _loadDrinksInternal(token);
   }
 
-  /// Internal method to load drinks without setting initial loading state
-  Future<void> _loadDrinksInternal() async {
+  /// Internal method to load drinks without setting initial loading state.
+  /// [token] must match [_drinksLoadToken] for results to be applied; a
+  /// mismatch means a newer load has started and this response is stale.
+  Future<void> _loadDrinksInternal(int token) async {
     try {
       // Repository returns drinks with favorites and ratings already populated
-      _allDrinks = await _drinkRepository!.getDrinks(currentFestival);
+      final drinks = await _drinkRepository!.getDrinks(currentFestival);
+      if (token != _drinksLoadToken) return;
+      _allDrinks = drinks;
       _applyFiltersAndSort();
       _error = null;
       _lastDrinksRefresh = DateTime.now();
     } catch (e, stackTrace) {
+      if (token != _drinksLoadToken) return;
       _error = _getUserFriendlyErrorMessage(e);
       _allDrinks = [];
       _filteredDrinks = [];
@@ -344,8 +359,10 @@ class BeerProvider extends ChangeNotifier {
         reason: 'Failed to load drinks internally for festival: ${currentFestival.id}',
       );
     } finally {
-      _isLoading = false;
-      notifyListeners();
+      if (token == _drinksLoadToken) {
+        _isLoading = false;
+        notifyListeners();
+      }
     }
   }
 

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -332,16 +332,18 @@ class BeerProvider extends ChangeNotifier {
       await _festivalRepository?.setSelectedFestivalId(festival.id);
     }
 
-    await _loadDrinksInternal(token);
+    await _loadDrinksInternal(token, festival);
   }
 
   /// Internal method to load drinks without setting initial loading state.
   /// [token] must match [_drinksLoadToken] for results to be applied; a
   /// mismatch means a newer load has started and this response is stale.
-  Future<void> _loadDrinksInternal(int token) async {
+  /// [festival] is captured at call time to avoid reading the live
+  /// [currentFestival] getter after intervening awaits may have changed it.
+  Future<void> _loadDrinksInternal(int token, Festival festival) async {
     try {
       // Repository returns drinks with favorites and ratings already populated
-      final drinks = await _drinkRepository!.getDrinks(currentFestival);
+      final drinks = await _drinkRepository!.getDrinks(festival);
       if (token != _drinksLoadToken) return;
       _allDrinks = drinks;
       _applyFiltersAndSort();
@@ -356,7 +358,7 @@ class BeerProvider extends ChangeNotifier {
       await _analyticsService.logError(
         e,
         stackTrace,
-        reason: 'Failed to load drinks internally for festival: ${currentFestival.id}',
+        reason: 'Failed to load drinks internally for festival: ${festival.id}',
       );
     } finally {
       if (token == _drinksLoadToken) {

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -1415,11 +1415,19 @@ void main() {
           name: 'Cambridge 2025',
           dataBaseUrl: 'https://example.com/cbf2025',
         );
+        // festivalC is the default so that setFestival(A) doesn't hit the
+        // early-return guard (_currentFestival?.id == festival.id) and both
+        // race competitors actually initiate a getDrinks call.
+        const festivalC = Festival(
+          id: 'cbf2023',
+          name: 'Cambridge 2023',
+          dataBaseUrl: 'https://example.com/cbf2023',
+        );
 
         when(mockFestivalRepository.getFestivals()).thenAnswer(
           (_) async => FestivalsResponse(
-            festivals: [festivalA, festivalB],
-            defaultFestivalId: 'cbf2024',
+            festivals: [festivalA, festivalB, festivalC],
+            defaultFestivalId: 'cbf2023',
             baseUrl: 'https://example.com',
             version: '1.0.0',
           ),

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -1397,6 +1397,95 @@ void main() {
       });
     });
 
+    group('festival switch race condition', () {
+      test('rapid festival switches show only last-selected festival drinks', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+
+        const festivalA = Festival(
+          id: 'cbf2024',
+          name: 'Cambridge 2024',
+          dataBaseUrl: 'https://example.com/cbf2024',
+        );
+        const festivalB = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge 2025',
+          dataBaseUrl: 'https://example.com/cbf2025',
+        );
+
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: [festivalA, festivalB],
+            defaultFestivalId: 'cbf2024',
+            baseUrl: 'https://example.com',
+            version: '1.0.0',
+          ),
+        );
+        when(mockFestivalRepository.getSelectedFestivalId()).thenAnswer((_) async => null);
+
+        final producerA = Producer.fromJson({
+          'id': 'brewery-a',
+          'name': 'Brewery A',
+          'location': 'City',
+          'products': [],
+        });
+        final producerB = Producer.fromJson({
+          'id': 'brewery-b',
+          'name': 'Brewery B',
+          'location': 'City',
+          'products': [],
+        });
+        final drinkA = Drink(
+          product: Product.fromJson({
+            'id': 'drink-a',
+            'name': 'Ale A',
+            'category': 'beer',
+            'dispense': 'cask',
+            'abv': '4.0',
+          }),
+          producer: producerA,
+          festivalId: 'cbf2024',
+        );
+        final drinkB = Drink(
+          product: Product.fromJson({
+            'id': 'drink-b',
+            'name': 'Ale B',
+            'category': 'beer',
+            'dispense': 'cask',
+            'abv': '5.0',
+          }),
+          producer: producerB,
+          festivalId: 'cbf2025',
+        );
+
+        // Festival A's load is slow; B's is instant
+        when(mockDrinkRepository.getDrinks(any)).thenAnswer((invocation) async {
+          final festival = invocation.positionalArguments[0] as Festival;
+          if (festival.id == 'cbf2024') {
+            await Future.delayed(const Duration(milliseconds: 100));
+            return [drinkA];
+          }
+          return [drinkB];
+        });
+
+        await provider.initialize();
+
+        // Switch to A (slow), then immediately to B (fast) — don't await A
+        final futureA = provider.setFestival(festivalA);
+        final futureB = provider.setFestival(festivalB);
+        await Future.wait([futureA, futureB]);
+
+        // B's result must win; A's stale response must be discarded
+        expect(provider.currentFestival.id, 'cbf2025');
+        expect(provider.drinks.length, 1);
+        expect(provider.drinks.first.name, 'Ale B');
+        expect(provider.isLoading, isFalse);
+      });
+    });
+
     group('automatic refresh', () {
       test('isDrinksDataStale returns true when no data loaded', () {
         provider = BeerProvider(


### PR DESCRIPTION
Rapid festival switches could result in the slower first request
overwriting the faster second request's results, showing the wrong
festival's drinks. Fix by incrementing a load token on every new
drinks load (setFestival, loadDrinks) and discarding any response
whose token no longer matches the current one.

Adds a test that verifies the last-selected festival always wins when
two setFestival calls race and the first is slower.

https://claude.ai/code/session_01P4MUavTmHYCgaCTKVhEFf4