### PR TITLE
chore(mise): move human-only tools to mise.human.toml

### DIFF
--- a/mise.dev.toml
+++ b/mise.dev.toml
@@ -1,6 +1,8 @@
-# Developer-specific mise configuration
+# Developer-specific mise configuration (e2e tools, tasks)
 # Load with: MISE_ENV=dev mise install
 # Or set permanently: export MISE_ENV=dev in your shell rc file
+#
+# For human-only tools (Claude, gh, cloudflared), also add: MISE_ENV=dev,human
 #
 # Note: Node.js is now in base mise.toml since it's needed for e2e tests in all environments
 #
@@ -13,21 +15,6 @@
 #         https://mise.jdx.dev/tasks/file-tasks.html
 
 [tools]
-claude = { version = "latest", bin = "claude", platforms = """
-[linux-arm64]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/linux-arm64/claude"
-
-[linux-x64]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/linux-x64/claude"
-
-[macos-arm64]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-arm64/claude"
-
-[macos-x64]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-x64/claude"
-""", version_list_url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/stable" }
-cloudflared = "latest"
-gh = "latest"
 "npm:firebase-tools" = "14.26.0"  # Pin to a stable version for reproducibility
 "npm:playwright" = "1.48.2"  # Pin to match @playwright/test version for reproducibility
 

--- a/mise.human.toml
+++ b/mise.human.toml
@@ -1,0 +1,20 @@
+# Human developer tools — not loaded in cloud/agent sessions (CLAUDE_CODE_REMOTE=true)
+# Load with: MISE_ENV=dev,human mise install
+# Or set permanently: export MISE_ENV=dev,human in your shell rc file
+
+[tools]
+claude = { version = "latest", bin = "claude", platforms = """
+[linux-arm64]
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/linux-arm64/claude"
+
+[linux-x64]
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/linux-x64/claude"
+
+[macos-arm64]
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-arm64/claude"
+
+[macos-x64]
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-x64/claude"
+""", version_list_url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/stable" }
+cloudflared = "latest"
+gh = "latest"


### PR DESCRIPTION
claude, gh, and cloudflared are not needed in cloud/agent sessions
(CLAUDE_CODE_REMOTE=true). Moving them to a separate mise.human.toml
keeps the dev environment lean and avoids pointless install attempts.

Human devs: MISE_ENV=dev,human
Agent/CI:   MISE_ENV=dev,sandboxed (unchanged)