### PR TITLE
fix(mise): add bash shebang to analyze and test task scripts

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -34,6 +34,7 @@ outputs = ['test/**/*.mocks.dart']
 description = "Run all Flutter tests (output saved to $TEST_LOG, or set TEST_LOG to reuse a path)"
 depends = ['generate']
 run = '''
+#!/usr/bin/env bash
 set -o pipefail
 TEST_LOG="${TEST_LOG:-$(mktemp /tmp/test-XXXXXX.log)}"
 echo "TEST_LOG=$TEST_LOG"
@@ -67,6 +68,7 @@ echo "To view HTML report, install lcov and run: genhtml coverage/lcov.info -o c
 description = "Run Flutter code analysis (output saved to $ANALYZE_LOG, or set ANALYZE_LOG to reuse a path)"
 depends = ['generate']
 run = '''
+#!/usr/bin/env bash
 set -o pipefail
 ANALYZE_LOG="${ANALYZE_LOG:-$(mktemp /tmp/analyze-XXXXXX.log)}"
 echo "ANALYZE_LOG=$ANALYZE_LOG"


### PR DESCRIPTION
The analyze and test tasks use set -o pipefail, which is bash-specific.
On systems where /bin/sh is dash or another POSIX shell (not bash), mise
was invoking these scripts with sh and failing immediately with
"Illegal option -o pipefail".

Adding #!/usr/bin/env bash as the first line of each multiline run block
causes mise to execute them with bash, matching the scripts' requirements.