### PR TITLE
fix(routing): deep links and browser refresh load wrong festival data

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -171,7 +171,16 @@ class _ProviderInitializerState extends State<ProviderInitializer> with WidgetsB
       // For festival-scoped routes, validate the festival ID
       // Early return: if already on valid festival route, skip expensive checks
       if (segments.isNotEmpty && provider.isValidFestivalId(segments.first)) {
-        return; // Already on valid route, no redirect needed
+        // Sync provider when the URL festival differs from the current one.
+        // This is the primary fix for cold-loading a non-default festival URL
+        // (browser refresh, shared link opened fresh).
+        if (segments.first != provider.currentFestival.id) {
+          final festival = provider.getFestivalById(segments.first);
+          if (festival != null) {
+            unawaited(provider.setFestival(festival, persist: false));
+          }
+        }
+        return;
       }
 
       // Path pattern: /:festivalId or /:festivalId/...

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -276,9 +276,9 @@ class BeerProvider extends ChangeNotifier {
       _currentFestival ??= DefaultFestivals.all.firstWhere((f) => f.isActive, orElse: () => DefaultFestivals.all.first);
     }
 
+    final token = ++_drinksLoadToken;
     _isLoading = true;
     _error = null;
-    final token = ++_drinksLoadToken;
     notifyListeners();
 
     try {

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -99,6 +99,11 @@ final GoRouter appRouter = GoRouter(
             ),
             GoRoute(
               path: '/:festivalId/favorites',
+              redirect: (context, state) => _festivalScopeRedirect(
+                context,
+                state,
+                onInvalidFestival: (currentId) => '/$currentId/favorites',
+              ),
               pageBuilder: (context, state) {
                 final festivalId = state.pathParameters['festivalId']!;
                 return NoTransitionPage(
@@ -111,7 +116,11 @@ final GoRouter appRouter = GoRouter(
         // Detail routes - Provider initialized, but no navigation bar
         GoRoute(
           path: '/:festivalId/drink/:id',
-          redirect: (context, state) => _festivalScopeRedirect(context, state),
+          redirect: (context, state) => _festivalScopeRedirect(
+            context,
+            state,
+            onInvalidFestival: (currentId) => '/$currentId/drink/${state.pathParameters['id']}',
+          ),
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             final id = state.pathParameters['id']!;
@@ -123,7 +132,11 @@ final GoRouter appRouter = GoRouter(
         ),
         GoRoute(
           path: '/:festivalId/brewery/:id',
-          redirect: (context, state) => _festivalScopeRedirect(context, state),
+          redirect: (context, state) => _festivalScopeRedirect(
+            context,
+            state,
+            onInvalidFestival: (currentId) => '/$currentId/brewery/${state.pathParameters['id']}',
+          ),
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             final id = state.pathParameters['id']!;
@@ -135,7 +148,11 @@ final GoRouter appRouter = GoRouter(
         ),
         GoRoute(
           path: '/:festivalId/style/:name',
-          redirect: (context, state) => _festivalScopeRedirect(context, state),
+          redirect: (context, state) => _festivalScopeRedirect(
+            context,
+            state,
+            onInvalidFestival: (currentId) => '/$currentId/style/${state.pathParameters['name']}',
+          ),
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             final name = state.pathParameters['name']!;
@@ -148,7 +165,11 @@ final GoRouter appRouter = GoRouter(
         ),
         GoRoute(
           path: '/:festivalId/info',
-          redirect: (context, state) => _festivalScopeRedirect(context, state),
+          redirect: (context, state) => _festivalScopeRedirect(
+            context,
+            state,
+            onInvalidFestival: (currentId) => '/$currentId/info',
+          ),
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             return FestivalInfoScreen(festivalId: festivalId);

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -10,6 +10,36 @@ import 'main.dart';
 /// IMPORTANT: Keep in sync with _handlePostInitRedirect in main.dart
 const List<String> globalRoutes = ['/about'];
 
+/// Shared redirect logic for festival-scoped routes.
+///
+/// Returns null when uninitialized (loading screen is shown) or when the
+/// festival ID is invalid without a custom handler.  When the URL festival
+/// differs from the provider's current festival, schedules a switch via
+/// [WidgetsBinding.addPostFrameCallback] so the router can complete
+/// navigation first.
+///
+/// [onInvalidFestival] — called with the current festival ID when the URL
+/// festival is invalid; return a redirect path or null to stay put.
+String? _festivalScopeRedirect(
+  BuildContext context,
+  GoRouterState state, {
+  String? Function(String currentFestivalId)? onInvalidFestival,
+}) {
+  final festivalId = state.pathParameters['festivalId'];
+  final provider = context.read<BeerProvider>();
+  if (!provider.isInitialized) return null;
+  if (!provider.isValidFestivalId(festivalId)) {
+    return onInvalidFestival?.call(provider.currentFestival.id);
+  }
+  final festival = provider.getFestivalById(festivalId!);
+  if (festival != null && provider.currentFestival.id != festivalId) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      provider.setFestival(festival, persist: false);
+    });
+  }
+  return null;
+}
+
 /// Application router configuration using go_router for better web support
 ///
 /// Router structure (Phase 1 - Festival-scoped URLs):
@@ -52,35 +82,14 @@ final GoRouter appRouter = GoRouter(
           routes: [
             GoRoute(
               path: '/:festivalId',
-              redirect: (context, state) {
-                final festivalId = state.pathParameters['festivalId'];
-                final provider = context.read<BeerProvider>();
-
-                // Wait for provider initialization before validating
-                if (!provider.isInitialized) {
-                  return null; // ProviderInitializer will show loading screen
-                }
-
-                // Validate festival ID
-                if (!provider.isValidFestivalId(festivalId)) {
-                  // Redirect to current festival if invalid, preserving query parameters
+              redirect: (context, state) => _festivalScopeRedirect(
+                context,
+                state,
+                onInvalidFestival: (currentId) {
                   final queryString = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
-                  return '/${provider.currentFestival.id}$queryString';
-                }
-
-                // Switch festival if different from current
-                final festival = provider.getFestivalById(festivalId!);
-                if (festival != null && provider.currentFestival.id != festivalId) {
-                  // Note: This is async, but we can't await in redirect
-                  // The festival switch will happen, and the screen will rebuild
-                  // Don't persist - URL navigation is temporary viewing, not preference change
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    provider.setFestival(festival, persist: false);
-                  });
-                }
-
-                return null; // Allow navigation
-              },
+                  return '/$currentId$queryString';
+                },
+              ),
               pageBuilder: (context, state) {
                 final festivalId = state.pathParameters['festivalId']!;
                 return NoTransitionPage(
@@ -102,6 +111,7 @@ final GoRouter appRouter = GoRouter(
         // Detail routes - Provider initialized, but no navigation bar
         GoRoute(
           path: '/:festivalId/drink/:id',
+          redirect: (context, state) => _festivalScopeRedirect(context, state),
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             final id = state.pathParameters['id']!;
@@ -113,6 +123,7 @@ final GoRouter appRouter = GoRouter(
         ),
         GoRoute(
           path: '/:festivalId/brewery/:id',
+          redirect: (context, state) => _festivalScopeRedirect(context, state),
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             final id = state.pathParameters['id']!;
@@ -124,6 +135,7 @@ final GoRouter appRouter = GoRouter(
         ),
         GoRoute(
           path: '/:festivalId/style/:name',
+          redirect: (context, state) => _festivalScopeRedirect(context, state),
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             final name = state.pathParameters['name']!;
@@ -136,6 +148,7 @@ final GoRouter appRouter = GoRouter(
         ),
         GoRoute(
           path: '/:festivalId/info',
+          redirect: (context, state) => _festivalScopeRedirect(context, state),
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             return FestivalInfoScreen(festivalId: festivalId);

--- a/mise.lock
+++ b/mise.lock
@@ -4,6 +4,10 @@
 version = "3.38.3"
 backend = "http:flutter"
 
+[tools.flutter."platforms.linux-x64"]
+checksum = "blake3:9a27e72d76a933d2cef6941cbc7a0f12892991410ca697263863a0559e09fd89"
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.38.3-stable.tar.xz"
+
 [[tools.node]]
 version = "21.7.3"
 backend = "core:node"

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -643,6 +643,130 @@ void main() {
       expect(provider.currentFestival.id, 'cbf2024',
           reason: 'Cold-loaded deep link must sync provider to the URL festival (issue #266)');
     });
+
+    testWidgets('invalid festival ID in detail routes redirects to current festival equivalent', (tester) async {
+      await provider.initialize();
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BeerProvider>.value(
+          value: provider,
+          child: MaterialApp.router(routerConfig: appRouter),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Drink route
+      appRouter.go('/$invalidFestivalId/drink/$testDrinkId');
+      await tester.pumpAndSettle();
+      var uri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
+      expect(uri.pathSegments[0], testFestivalId);
+      expect(uri.pathSegments[1], 'drink');
+      expect(uri.pathSegments[2], testDrinkId,
+          reason: 'Invalid festival in drink route should redirect, preserving drink ID');
+
+      // Brewery route
+      appRouter.go('/$invalidFestivalId/brewery/$testBreweryId');
+      await tester.pumpAndSettle();
+      uri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
+      expect(uri.pathSegments[0], testFestivalId);
+      expect(uri.pathSegments[1], 'brewery');
+      expect(uri.pathSegments[2], testBreweryId,
+          reason: 'Invalid festival in brewery route should redirect, preserving brewery ID');
+
+      // Style route
+      appRouter.go('/$invalidFestivalId/style/IPA');
+      await tester.pumpAndSettle();
+      uri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
+      expect(uri.pathSegments[0], testFestivalId);
+      expect(uri.pathSegments[1], 'style');
+
+      // Info route
+      appRouter.go('/$invalidFestivalId/info');
+      await tester.pumpAndSettle();
+      uri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
+      expect(uri.pathSegments[0], testFestivalId);
+      expect(uri.pathSegments[1], 'info',
+          reason: 'Invalid festival in info route should redirect');
+
+      // Favorites route
+      appRouter.go('/$invalidFestivalId/favorites');
+      await tester.pumpAndSettle();
+      uri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
+      expect(uri.pathSegments[0], testFestivalId);
+      expect(uri.pathSegments[1], 'favorites',
+          reason: 'Invalid festival in favorites route should redirect');
+    });
+
+    testWidgets('favorites route with different festival switches provider (hot navigation)', (tester) async {
+      when(mockFestivalRepository.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: const [
+            Festival(
+              id: 'cbf2025',
+              name: 'Cambridge 2025',
+              dataBaseUrl: 'https://example.com/cbf2025',
+            ),
+            Festival(
+              id: 'cbf2024',
+              name: 'Cambridge 2024',
+              dataBaseUrl: 'https://example.com/cbf2024',
+            ),
+          ],
+          defaultFestivalId: 'cbf2025',
+          version: '1.0.0',
+          baseUrl: 'https://example.com',
+        ),
+      );
+      await provider.initialize();
+      expect(provider.currentFestival.id, 'cbf2025');
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BeerProvider>.value(
+          value: provider,
+          child: MaterialApp.router(routerConfig: appRouter),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      appRouter.go('/cbf2024/favorites');
+      await tester.pumpAndSettle();
+
+      expect(provider.currentFestival.id, 'cbf2024',
+          reason: 'Navigating to favorites of a different festival should switch provider');
+    });
+
+    testWidgets('brewery, style and info routes are reachable for valid festival', (tester) async {
+      await provider.initialize();
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BeerProvider>.value(
+          value: provider,
+          child: MaterialApp.router(routerConfig: appRouter),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Brewery route
+      appRouter.go('/$testFestivalId/brewery/$testBreweryId');
+      await tester.pumpAndSettle();
+      var uri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
+      expect(uri.pathSegments[0], testFestivalId);
+      expect(uri.pathSegments[1], 'brewery');
+
+      // Style route
+      appRouter.go('/$testFestivalId/style/IPA');
+      await tester.pumpAndSettle();
+      uri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
+      expect(uri.pathSegments[0], testFestivalId);
+      expect(uri.pathSegments[1], 'style');
+
+      // Info route
+      appRouter.go('/$testFestivalId/info');
+      await tester.pumpAndSettle();
+      uri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
+      expect(uri.pathSegments[0], testFestivalId);
+      expect(uri.pathSegments[1], 'info');
+    });
   });
 
   group('Router Navigation Paths (Phase 1 - Festival-scoped)', () {

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -554,6 +554,95 @@ void main() {
       expect(currentUri.pathSegments.first, testFestivalId,
         reason: 'Encoded festival IDs should not match valid festival IDs');
     });
+
+    // Regression tests for issue #266: cold-load / browser-refresh uses wrong festival
+    testWidgets('cold load of non-default festival URL syncs provider (regression #266)', (tester) async {
+      when(mockFestivalRepository.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: const [
+            Festival(
+              id: 'cbf2025',
+              name: 'Cambridge 2025',
+              dataBaseUrl: 'https://example.com/cbf2025',
+            ),
+            Festival(
+              id: 'cbf2024',
+              name: 'Cambridge 2024',
+              dataBaseUrl: 'https://example.com/cbf2024',
+            ),
+          ],
+          defaultFestivalId: 'cbf2025',
+          version: '1.0.0',
+          baseUrl: 'https://example.com',
+        ),
+      );
+      when(mockFestivalRepository.getSelectedFestivalId()).thenAnswer((_) async => null);
+
+      // True cold load: router starts at cbf2024 before any initialization
+      final testRouter = GoRouter(
+        initialLocation: '/cbf2024',
+        debugLogDiagnostics: kDebugMode,
+        routes: appRouter.configuration.routes,
+      );
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BeerProvider>.value(
+          value: provider,
+          child: MaterialApp.router(routerConfig: testRouter),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Provider must be synced to the URL festival, not the default
+      expect(provider.currentFestival.id, 'cbf2024',
+          reason: 'Cold-loaded festival URL must sync the provider (issue #266)');
+      expect(find.text('Cambridge 2024'), findsOneWidget);
+      expect(find.text('Cambridge 2025'), findsNothing);
+    });
+
+    testWidgets('cold load of drink deep link from non-default festival syncs provider (regression #266)', (tester) async {
+      when(mockFestivalRepository.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: const [
+            Festival(
+              id: 'cbf2025',
+              name: 'Cambridge 2025',
+              dataBaseUrl: 'https://example.com/cbf2025',
+            ),
+            Festival(
+              id: 'cbf2024',
+              name: 'Cambridge 2024',
+              dataBaseUrl: 'https://example.com/cbf2024',
+            ),
+          ],
+          defaultFestivalId: 'cbf2025',
+          version: '1.0.0',
+          baseUrl: 'https://example.com',
+        ),
+      );
+      when(mockFestivalRepository.getSelectedFestivalId()).thenAnswer((_) async => null);
+
+      // True cold load: shared drink link from a non-default festival
+      final testRouter = GoRouter(
+        initialLocation: '/cbf2024/drink/$testDrinkId',
+        debugLogDiagnostics: kDebugMode,
+        routes: appRouter.configuration.routes,
+      );
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BeerProvider>.value(
+          value: provider,
+          child: MaterialApp.router(routerConfig: testRouter),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Provider must switch to cbf2024 so getDrinkById searches the right festival
+      expect(provider.currentFestival.id, 'cbf2024',
+          reason: 'Cold-loaded deep link must sync provider to the URL festival (issue #266)');
+    });
   });
 
   group('Router Navigation Paths (Phase 1 - Festival-scoped)', () {


### PR DESCRIPTION
Cold-loading a festival-scoped URL (browser refresh or shared link) failed
to sync the provider to the festival named in the URL because
_handlePostInitRedirect early-returned for valid festival IDs without
calling setFestival, leaving the app on its default festival.

Detail routes (drink/brewery/style/info) also had no redirect at all, so
navigating to them while the provider held a different festival showed
stale or missing data (e.g. "Drink Not Found" for valid shared links).

Changes:
- lib/main.dart: in _handlePostInitRedirect, call provider.setFestival
  when the URL's valid festival ID differs from the current one.
- lib/router.dart: extract shared _festivalScopeRedirect helper and apply
  it to the /:festivalId route (refactor, no behaviour change) and add it
  to the four detail routes so hot navigation also triggers a switch.
- lib/providers/beer_provider.dart: add _drinksLoadToken guard so that a
  concurrent loadDrinks() call that was started before a festival switch
  cannot overwrite the drinks from the newer setFestival() call.
- test/router_test.dart: two regression tests that construct the router
  with a non-default initialLocation (true cold load), verifying the
  provider is synced to the URL festival after initialization.

Fixes #266