### PR TITLE
fix(release): remove GITHUB_REPO from git-cliff action env

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -53,7 +53,6 @@ jobs:
           args: --unreleased --tag ${{ steps.version.outputs.tag }}
         env:
           OUTPUT: release-notes.md
-          GITHUB_REPO: ${{ github.repository }}
 
       - name: Check for releasable content
         id: check


### PR DESCRIPTION
git-cliff-action@v4.8.0 "Improve GitHub Token handling" now properly
passes --github-repo to git-cliff when GITHUB_REPO is set. git-cliff
2.13.1 then tries to fetch GitHub API metadata; when that call fails
(network error, auth issue) the process panics with exit 101, causing
the entire step to fail and leaving CHANGELOG.md unupdated.

Our cliff.toml template only uses commit.message and commit.scope —
no GitHub-specific variables — so the GitHub API enrichment adds no
value. PR numbers are already present in commit subjects via GitHub's
squash-merge format.

Removing GITHUB_REPO disables the API integration and brings the exit
code back to 0.