### PR TITLE
feat(sharing): include deep link URL in drink share message

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -444,7 +444,7 @@ class FavoritesScreen extends StatelessWidget {
                 return DrinkCard(
                   key: ValueKey(drink.id),
                   drink: drink,
-                  onTap: () => context.push(buildDrinkDetailPath(festivalId, drink.id)),
+                  onTap: () => context.push(buildDrinkDetailPath(festivalId, drink.category, drink.id)),
                   onFavoriteTap: () => provider.toggleFavorite(drink),
                 );
               },

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -263,18 +263,25 @@ class Drink {
   bool get isAllergenFree => product.isAllergenFree;
 
   /// Generate a share message for this drink.
-  /// 
+  ///
   /// The [hashtag] parameter should be a valid social media hashtag including
   /// the # symbol (e.g., '#cbf2025').
-  /// 
+  ///
+  /// The optional [url] parameter, when provided, is appended on a new line
+  /// so recipients can tap through to the drink directly.
+  ///
   /// Returns a message in the format:
   /// - Without rating: "Drinking {name} from {brewery} at {hashtag}"
   /// - With rating: "Drinking {name} from {brewery} at {hashtag} - {n} stars"
-  String getShareMessage(String hashtag) {
+  /// - With url: above + "\n{url}"
+  String getShareMessage(String hashtag, {String? url}) {
     final buffer = StringBuffer();
     buffer.write('Drinking $name from $breweryName at $hashtag');
     if (rating != null) {
       buffer.write(' - $rating stars');
+    }
+    if (url != null) {
+      buffer.write('\n$url');
     }
     return buffer.toString();
   }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -115,11 +115,12 @@ final GoRouter appRouter = GoRouter(
         ),
         // Detail routes - Provider initialized, but no navigation bar
         GoRoute(
-          path: '/:festivalId/drink/:id',
+          path: '/:festivalId/drink/:category/:id',
           redirect: (context, state) => _festivalScopeRedirect(
             context,
             state,
-            onInvalidFestival: (currentId) => '/$currentId/drink/${state.pathParameters['id']}',
+            onInvalidFestival: (currentId) =>
+                '/$currentId/drink/${state.pathParameters['category']}/${state.pathParameters['id']}',
           ),
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -464,7 +464,8 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
 
   void _shareDrink(BuildContext context, Drink drink, Festival festival) {
     final hashtag = festival.hashtag ?? '#${festival.id.replaceAll(_hashtagSafeRegex, '')}';
-    Share.share(drink.getShareMessage(hashtag));
+    final url = 'https://cambeerfestival.app${buildDrinkDetailPath(festival.id, drink.id)}';
+    Share.share(drink.getShareMessage(hashtag, url: url));
     // Log share event (fire and forget)
     final provider = context.read<BeerProvider>();
     unawaited(provider.analyticsService.logDrinkShared(drink));

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -418,7 +418,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
         ActionButton(
           icon: Icons.share,
           label: 'Share',
-          onPressed: () => _shareDrink(context, drink, provider.currentFestival),
+          onPressed: () => _shareDrink(context, drink),
           semanticLabel: 'Share ${drink.name}',
         ),
       ],
@@ -462,12 +462,14 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
     );
   }
 
-  void _shareDrink(BuildContext context, Drink drink, Festival festival) {
-    final hashtag = festival.hashtag ?? '#${festival.id.replaceAll(_hashtagSafeRegex, '')}';
-    final url = 'https://cambeerfestival.app${buildDrinkDetailPath(festival.id, drink.category, drink.id)}';
-    Share.share(drink.getShareMessage(hashtag, url: url));
-    // Log share event (fire and forget)
+  void _shareDrink(BuildContext context, Drink drink) {
     final provider = context.read<BeerProvider>();
+    // Use the drink's own festivalId rather than provider.currentFestival, which
+    // can lag on deep-link entry before the provider catches up to the route.
+    final festival = provider.getFestivalById(drink.festivalId) ?? provider.currentFestival;
+    final hashtag = festival.hashtag ?? '#${festival.id.replaceAll(_hashtagSafeRegex, '')}';
+    final url = 'https://cambeerfestival.app${buildDrinkDetailPath(drink.festivalId, drink.category, drink.id)}';
+    Share.share(drink.getShareMessage(hashtag, url: url));
     unawaited(provider.analyticsService.logDrinkShared(drink));
   }
 }

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -464,7 +464,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
 
   void _shareDrink(BuildContext context, Drink drink, Festival festival) {
     final hashtag = festival.hashtag ?? '#${festival.id.replaceAll(_hashtagSafeRegex, '')}';
-    final url = 'https://cambeerfestival.app${buildDrinkDetailPath(festival.id, drink.id)}';
+    final url = 'https://cambeerfestival.app${buildDrinkDetailPath(festival.id, drink.category, drink.id)}';
     Share.share(drink.getShareMessage(hashtag, url: url));
     // Log share event (fire and forget)
     final provider = context.read<BeerProvider>();

--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -476,7 +476,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
             return DrinkCard(
               key: ValueKey(drink.id),
               drink: drink,
-              onTap: () => _navigateToDetail(context, drink.id),
+              onTap: () => _navigateToDetail(context, drink.id, drink.category),
               onFavoriteTap: () => provider.toggleFavorite(drink),
             );
           },
@@ -486,8 +486,8 @@ class _DrinksScreenState extends State<DrinksScreen> {
     );
   }
 
-  void _navigateToDetail(BuildContext context, String drinkId) {
-    context.push(buildDrinkDetailPath(widget.festivalId, drinkId));
+  void _navigateToDetail(BuildContext context, String drinkId, String category) {
+    context.push(buildDrinkDetailPath(widget.festivalId, category, drinkId));
   }
 
   void _showCategoryFilter(BuildContext context, BeerProvider provider) {

--- a/lib/utils/navigation_helpers.dart
+++ b/lib/utils/navigation_helpers.dart
@@ -80,17 +80,20 @@ String buildFestivalInfoPath(String festivalId) {
 
 /// Builds a drink detail URL.
 ///
-/// The [drinkId] is URL-encoded to handle special characters safely.
+/// Both [category] and [drinkId] are URL-encoded to handle special characters
+/// safely. Category is included in the path to aid SEO and App Links matching.
 ///
 /// Example:
 /// ```dart
-/// buildDrinkDetailPath('cbf2025', 'drink-123') // Returns: '/cbf2025/drink/drink-123'
-/// buildDrinkDetailPath('cbf2025', 'drink 456') // Returns: '/cbf2025/drink/drink%20456'
+/// buildDrinkDetailPath('cbf2025', 'beer', 'drink-123') // Returns: '/cbf2025/drink/beer/drink-123'
+/// buildDrinkDetailPath('cbf2025', 'foreign beer', 'drink-456') // Returns: '/cbf2025/drink/foreign%20beer/drink-456'
 /// ```
-String buildDrinkDetailPath(String festivalId, String drinkId) {
+String buildDrinkDetailPath(String festivalId, String category, String drinkId) {
+  assert(category.isNotEmpty, 'Category cannot be empty');
   assert(drinkId.isNotEmpty, 'Drink ID cannot be empty');
+  final encodedCategory = Uri.encodeComponent(category);
   final encodedId = Uri.encodeComponent(drinkId);
-  return buildFestivalPath(festivalId, '/drink/$encodedId');
+  return buildFestivalPath(festivalId, '/drink/$encodedCategory/$encodedId');
 }
 
 /// Builds a brewery detail URL.

--- a/lib/widgets/drink_list_section.dart
+++ b/lib/widgets/drink_list_section.dart
@@ -68,7 +68,7 @@ class DrinkListSection {
             return DrinkCard(
               key: ValueKey(drink.id),
               drink: drink,
-              onTap: () => context.push(buildDrinkDetailPath(festivalId, drink.id)),
+              onTap: () => context.push(buildDrinkDetailPath(festivalId, drink.category, drink.id)),
               onFavoriteTap: () => provider.toggleFavorite(drink),
             );
           },
@@ -119,7 +119,7 @@ class DrinkListSection {
               key: ValueKey(drink.id),
               drink: drink,
               subtitle: subtitle,
-              onTap: () => context.push(buildDrinkDetailPath(festivalId, drink.id)),
+              onTap: () => context.push(buildDrinkDetailPath(festivalId, drink.category, drink.id)),
               onFavoriteTap: () => provider.toggleFavorite(drink),
             );
           },

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -930,12 +930,12 @@ void main() {
 
         final message = drink.getShareMessage(
           '#cbf2025',
-          url: 'https://cambeerfestival.app/cbf2025/drink/abc123',
+          url: 'https://cambeerfestival.app/cbf2025/drink/beer/abc123',
         );
 
         expect(
           message,
-          'Drinking Test IPA from Test Brewery at #cbf2025\nhttps://cambeerfestival.app/cbf2025/drink/abc123',
+          'Drinking Test IPA from Test Brewery at #cbf2025\nhttps://cambeerfestival.app/cbf2025/drink/beer/abc123',
         );
       });
 
@@ -949,12 +949,12 @@ void main() {
 
         final message = drink.getShareMessage(
           '#cbf2025',
-          url: 'https://cambeerfestival.app/cbf2025/drink/abc123',
+          url: 'https://cambeerfestival.app/cbf2025/drink/beer/abc123',
         );
 
         expect(
           message,
-          'Drinking Test IPA from Test Brewery at #cbf2025 - 4 stars\nhttps://cambeerfestival.app/cbf2025/drink/abc123',
+          'Drinking Test IPA from Test Brewery at #cbf2025 - 4 stars\nhttps://cambeerfestival.app/cbf2025/drink/beer/abc123',
         );
       });
     });

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -920,6 +920,43 @@ void main() {
 
         expect(message, 'Drinking Test IPA from Test Brewery at #cbfw2025');
       });
+
+      test('appends url on new line when provided', () {
+        final drink = Drink(
+          product: testProduct,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+        );
+
+        final message = drink.getShareMessage(
+          '#cbf2025',
+          url: 'https://cambeerfestival.app/cbf2025/drink/abc123',
+        );
+
+        expect(
+          message,
+          'Drinking Test IPA from Test Brewery at #cbf2025\nhttps://cambeerfestival.app/cbf2025/drink/abc123',
+        );
+      });
+
+      test('appends url after rating', () {
+        final drink = Drink(
+          product: testProduct,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+          rating: 4,
+        );
+
+        final message = drink.getShareMessage(
+          '#cbf2025',
+          url: 'https://cambeerfestival.app/cbf2025/drink/abc123',
+        );
+
+        expect(
+          message,
+          'Drinking Test IPA from Test Brewery at #cbf2025 - 4 stars\nhttps://cambeerfestival.app/cbf2025/drink/abc123',
+        );
+      });
     });
   });
 

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -242,7 +242,7 @@ void main() {
       );
 
       // Navigate to drink detail immediately (before init)
-      appRouter.go('/$testFestivalId/drink/$testDrinkId');
+      appRouter.go('/$testFestivalId/drink/beer/$testDrinkId');
       await tester.pump();
 
       // Pump frames to allow async initialization to complete
@@ -250,10 +250,11 @@ void main() {
 
       // Should stay on drink detail route (valid festival ID)
       final currentUri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(currentUri.pathSegments.length, 3);
+      expect(currentUri.pathSegments.length, 4);
       expect(currentUri.pathSegments[0], testFestivalId);
       expect(currentUri.pathSegments[1], 'drink');
-      expect(currentUri.pathSegments[2], testDrinkId);
+      expect(currentUri.pathSegments[2], 'beer');
+      expect(currentUri.pathSegments[3], testDrinkId);
     });
 
     testWidgets('global /about route NOT redirected after async initialization', (tester) async {
@@ -428,7 +429,7 @@ void main() {
       await tester.pump();
 
       // User navigates to drink detail DURING initialization
-      appRouter.go('/cbf2025/drink/test-drink-123');
+      appRouter.go('/cbf2025/drink/beer/test-drink-123');
       await tester.pump();
 
       // Now complete initialization
@@ -449,13 +450,13 @@ void main() {
 
       // Should STAY at drink detail (not redirect to /cbf2025)
       final currentUri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(currentUri.path, '/cbf2025/drink/test-drink-123',
+      expect(currentUri.path, '/cbf2025/drink/beer/test-drink-123',
         reason: 'Should not redirect when already on valid route');
     });
 
     // KNOWN LIMITATION: Deep links with invalid festival IDs in subpaths
     // See lib/main.dart _handlePostInitRedirect() for full documentation
-    // Example: /invalid-fest/drink/abc stays at /invalid-fest/drink/abc
+    // Example: /invalid-fest/drink/beer/abc stays at /invalid-fest/drink/beer/abc
     // Reason: Matches route pattern directly, bypassing redirect logic
     // Fix: Requires adding festival ID validation to ALL route builders
 
@@ -625,7 +626,7 @@ void main() {
 
       // True cold load: shared drink link from a non-default festival
       final testRouter = GoRouter(
-        initialLocation: '/cbf2024/drink/$testDrinkId',
+        initialLocation: '/cbf2024/drink/beer/$testDrinkId',
         debugLogDiagnostics: kDebugMode,
         routes: appRouter.configuration.routes,
       );
@@ -656,13 +657,14 @@ void main() {
       await tester.pumpAndSettle();
 
       // Drink route
-      appRouter.go('/$invalidFestivalId/drink/$testDrinkId');
+      appRouter.go('/$invalidFestivalId/drink/beer/$testDrinkId');
       await tester.pumpAndSettle();
       var uri = Uri.parse(appRouter.routerDelegate.currentConfiguration.uri.toString());
       expect(uri.pathSegments[0], testFestivalId);
       expect(uri.pathSegments[1], 'drink');
-      expect(uri.pathSegments[2], testDrinkId,
-          reason: 'Invalid festival in drink route should redirect, preserving drink ID');
+      expect(uri.pathSegments[2], 'beer');
+      expect(uri.pathSegments[3], testDrinkId,
+          reason: 'Invalid festival in drink route should redirect, preserving category and drink ID');
 
       // Brewery route
       appRouter.go('/$invalidFestivalId/brewery/$testBreweryId');
@@ -772,12 +774,13 @@ void main() {
   group('Router Navigation Paths (Phase 1 - Festival-scoped)', () {
     const festivalId = 'cbf2025';
 
-    test('drink detail route parses ID correctly', () {
-      final uri = Uri.parse('/$festivalId/drink/test-drink-123');
-      expect(uri.pathSegments.length, 3);
+    test('drink detail route parses category and ID correctly', () {
+      final uri = Uri.parse('/$festivalId/drink/beer/test-drink-123');
+      expect(uri.pathSegments.length, 4);
       expect(uri.pathSegments[0], festivalId);
       expect(uri.pathSegments[1], 'drink');
-      expect(uri.pathSegments[2], 'test-drink-123');
+      expect(uri.pathSegments[2], 'beer');
+      expect(uri.pathSegments[3], 'test-drink-123');
     });
 
     test('brewery route parses ID correctly', () {
@@ -834,10 +837,11 @@ void main() {
     });
 
     test('drink detail path is festival-scoped', () {
-      final uri = Uri.parse('/$festivalId/drink/abc123');
-      expect(uri.path, '/$festivalId/drink/abc123');
+      final uri = Uri.parse('/$festivalId/drink/beer/abc123');
+      expect(uri.path, '/$festivalId/drink/beer/abc123');
       expect(uri.pathSegments[0], festivalId);
-      expect(uri.pathSegments[2], 'abc123');
+      expect(uri.pathSegments[2], 'beer');
+      expect(uri.pathSegments[3], 'abc123');
     });
 
     test('brewery detail path is festival-scoped', () {

--- a/test/utils/navigation_helpers_test.dart
+++ b/test/utils/navigation_helpers_test.dart
@@ -80,15 +80,22 @@ void main() {
     group('buildDrinkDetailPath', () {
       test('builds drink detail path', () {
         expect(
-          buildDrinkDetailPath('cbf2025', 'drink-123'),
-          equals('/cbf2025/drink/drink-123'),
+          buildDrinkDetailPath('cbf2025', 'beer', 'drink-123'),
+          equals('/cbf2025/drink/beer/drink-123'),
         );
       });
 
       test('handles drink IDs with special characters', () {
         expect(
-          buildDrinkDetailPath('cbf2025', 'drink-123-abc'),
-          equals('/cbf2025/drink/drink-123-abc'),
+          buildDrinkDetailPath('cbf2025', 'beer', 'drink-123-abc'),
+          equals('/cbf2025/drink/beer/drink-123-abc'),
+        );
+      });
+
+      test('URL-encodes category with spaces', () {
+        expect(
+          buildDrinkDetailPath('cbf2025', 'foreign beer', 'drink-123'),
+          equals('/cbf2025/drink/foreign%20beer/drink-123'),
         );
       });
     });
@@ -201,15 +208,15 @@ void main() {
     group('URL encoding edge cases', () {
       test('encodes drink IDs with spaces', () {
         expect(
-          buildDrinkDetailPath('cbf2025', 'drink 123'),
-          equals('/cbf2025/drink/drink%20123'),
+          buildDrinkDetailPath('cbf2025', 'beer', 'drink 123'),
+          equals('/cbf2025/drink/beer/drink%20123'),
         );
       });
 
       test('encodes drink IDs with special characters', () {
         expect(
-          buildDrinkDetailPath('cbf2025', 'drink/456'),
-          equals('/cbf2025/drink/drink%2F456'),
+          buildDrinkDetailPath('cbf2025', 'beer', 'drink/456'),
+          equals('/cbf2025/drink/beer/drink%2F456'),
         );
       });
 
@@ -259,7 +266,7 @@ void main() {
 
       test('buildDrinkDetailPath asserts on empty drink ID', () {
         expect(
-          () => buildDrinkDetailPath('cbf2025', ''),
+          () => buildDrinkDetailPath('cbf2025', 'beer', ''),
           throwsAssertionError,
         );
       });
@@ -311,8 +318,8 @@ void main() {
 
       test('handles URL-encoded characters in IDs', () {
         expect(
-          buildDrinkDetailPath('cbf2025', 'test%20drink'),
-          equals('/cbf2025/drink/test%2520drink'),
+          buildDrinkDetailPath('cbf2025', 'beer', 'test%20drink'),
+          equals('/cbf2025/drink/beer/test%2520drink'),
         );
       });
     });

--- a/web/_redirects
+++ b/web/_redirects
@@ -1,1 +1,5 @@
+# Old drink URL format (pre-category): /{festivalId}/drink/{id}
+# Redirect to festival drinks list — these URLs were never shared publicly
+/:festivalId/drink/:id /:festivalId 302
+
 /* /index.html 200


### PR DESCRIPTION
Appends https://cambeerfestival.app/{festivalId}/drink/{id} on a new
line in the share message so recipients can tap through to the drink
directly. URL is always production regardless of the sharing user's
environment.