### PR TITLE
chore(ci): bump Node.js to v22 and fix CI change-filter gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Download web build artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,11 @@ jobs:
 
   # Build web after tests pass
   build-web:
-    needs: test
+    needs: [changes, test]
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.app == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       app: ${{ steps.filter.outputs.app }}
+      functions: ${{ steps.filter.outputs.functions }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,7 +36,6 @@ jobs:
             app:
               - 'lib/**'
               - 'web/**'
-              - 'functions/**'
               - 'pubspec.yaml'
               - 'test/**'
               - 'test-e2e/**'
@@ -44,6 +44,8 @@ jobs:
               - 'android/**'
               - '.github/workflows/build-deploy.yml'
               - 'mise.toml'
+            functions:
+              - 'functions/**'
 
   # Run tests once before building
   test:
@@ -51,7 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      needs.changes.outputs.app == 'true'
+      needs.changes.outputs.app == 'true' ||
+      needs.changes.outputs.functions == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -187,8 +190,11 @@ jobs:
 
   # Build Android after tests pass
   build-android:
-    needs: test
+    needs: [changes, test]
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.app == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -242,7 +248,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      needs.changes.outputs.app == 'true'
+      needs.changes.outputs.app == 'true' ||
+      needs.changes.outputs.functions == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: scripts/package-lock.json
 
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: cloudflare-worker/package-lock.json
 
@@ -109,7 +109,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: cloudflare-worker/package-lock.json
 
@@ -144,7 +144,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,7 @@ _.path = ["./bin"]
 
 [tools]
 flutter = "3.38.3"
-node = "21"  # For http_server and Playwright e2e tests
+node = "22"  # For http_server and Playwright e2e tests
 
 [deps.flutter]
 auto = true


### PR DESCRIPTION
## Summary

- **Node.js v22**: Bumps Node from v20/v21 to v22 in `mise.toml`, `ci.yml` (E2E job), and all four jobs in `deploy-worker.yml`
- **CI change-filter split**: Separates `functions/**` into its own `functions` output so changes to `functions/` no longer incorrectly trigger the Flutter build and Android APK jobs
- **`build-android` guard**: Adds `needs: [changes, test]` and an `if: app == 'true'` condition so Android builds only run when Flutter/app files change (prevents failures on Dependabot PRs where `GOOGLE_SERVICES_JSON` is unavailable)
- **`build-web` guard**: Adds `needs: [changes, test]` and `if: app == 'true'` so the web build is skipped for functions-only or docs-only changes, and doesn't spuriously trigger when `test` runs for functions-only changes
- **`deploy-web-preview` / `test` extended**: Both now also trigger on `functions` changes so Pages Functions are still tested and deployed when changed

Part of #242 (slice 1 — Node version and CI gating; slices 2–3 cover `@cloudflare/vitest-pool-workers` upgrade).