### PR TITLE
fix(og): map 'foreign beer' category to international-beer API endpoint

### DIFF
--- a/functions/_lib/drink-preview.js
+++ b/functions/_lib/drink-preview.js
@@ -64,7 +64,7 @@ export function buildOgTags(product, producer, canonicalUrl) {
 }
 
 export async function fetchDrinkData(festivalId, category) {
-  const endpoint = CATEGORY_TO_ENDPOINT[category] ?? category;
+  const endpoint = Object.hasOwn(CATEGORY_TO_ENDPOINT, category) ? CATEGORY_TO_ENDPOINT[category] : category;
   const url = `${DATA_BASE_URL}/${encodeURIComponent(festivalId)}/${encodeURIComponent(endpoint)}.json`;
   const response = await fetch(url);
   if (!response.ok) return null;

--- a/functions/_lib/drink-preview.js
+++ b/functions/_lib/drink-preview.js
@@ -12,6 +12,11 @@ const CRAWLER_UA_PATTERNS = [
 const DATA_BASE_URL = 'https://data.cambeerfestival.app';
 const OG_IMAGE_URL = 'https://cambeerfestival.app/icons/Icon-512.png';
 
+// Product category field values don't always match their API endpoint names.
+const CATEGORY_TO_ENDPOINT = {
+  'foreign beer': 'international-beer',
+};
+
 export function isCrawler(userAgent) {
   if (!userAgent) return false;
   const ua = userAgent.toLowerCase();
@@ -59,7 +64,8 @@ export function buildOgTags(product, producer, canonicalUrl) {
 }
 
 export async function fetchDrinkData(festivalId, category) {
-  const url = `${DATA_BASE_URL}/${encodeURIComponent(festivalId)}/${encodeURIComponent(category)}.json`;
+  const endpoint = CATEGORY_TO_ENDPOINT[category] ?? category;
+  const url = `${DATA_BASE_URL}/${encodeURIComponent(festivalId)}/${encodeURIComponent(endpoint)}.json`;
   const response = await fetch(url);
   if (!response.ok) return null;
   const data = await response.json();

--- a/functions/test/drink-preview.test.js
+++ b/functions/test/drink-preview.test.js
@@ -275,5 +275,17 @@ describe('fetchDrinkData', () => {
       'https://data.cambeerfestival.app/cbf2026/international-beer.json',
     );
   });
+
+  it('does not treat inherited property names as endpoint remaps', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ producers: [] }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+    await fetchDrinkData('cbf2026', 'constructor');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://data.cambeerfestival.app/cbf2026/constructor.json',
+    );
+  });
 });
 

--- a/functions/test/drink-preview.test.js
+++ b/functions/test/drink-preview.test.js
@@ -263,5 +263,17 @@ describe('fetchDrinkData', () => {
       'https://data.cambeerfestival.app/cbf2025/beer.json',
     );
   });
+
+  it('maps "foreign beer" category to "international-beer" endpoint', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ producers: [] }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+    await fetchDrinkData('cbf2026', 'foreign beer');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://data.cambeerfestival.app/cbf2026/international-beer.json',
+    );
+  });
 });
 

--- a/mise.lock
+++ b/mise.lock
@@ -9,31 +9,31 @@ checksum = "blake3:9a27e72d76a933d2cef6941cbc7a0f12892991410ca697263863a0559e09f
 url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.38.3-stable.tar.xz"
 
 [[tools.node]]
-version = "21.7.3"
+version = "22.22.3"
 backend = "core:node"
 
 [tools.node."platforms.linux-arm64"]
-checksum = "sha256:15390ba8509b71c0051e61f75a6fdb0a2eb38318c03a01bf60c93d33d414d138"
-url = "https://nodejs.org/dist/v21.7.3/node-v21.7.3-linux-arm64.tar.gz"
+checksum = "sha256:cc8bc82b2dd0b595c3b95a4c3c9c8c350907cff011afbdee3d1379e812e1e3e3"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
-url = "https://unofficial-builds.nodejs.org/download/release/v21.7.3/node-v21.7.3-linux-arm64-musl.tar.gz"
+url = "https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:a64cbb12282cb60d35743ef4f51561f8d89946a5f0a484f99168f4de602d7c3d"
-url = "https://nodejs.org/dist/v21.7.3/node-v21.7.3-linux-x64.tar.gz"
+checksum = "sha256:c7a10d6816da8eaaa7534dd73c71c6e2b2c391dbbf845e364902d156615dd1b8"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
-url = "https://unofficial-builds.nodejs.org/download/release/v21.7.3/node-v21.7.3-linux-x64-musl.tar.gz"
+url = "https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:165d3ba3500cfc8708f85d3815aaaa21ce418164c933d5419c30825ccad3a99c"
-url = "https://nodejs.org/dist/v21.7.3/node-v21.7.3-darwin-arm64.tar.gz"
+checksum = "sha256:0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-darwin-arm64.tar.gz"
 
 [tools.node."platforms.macos-x64"]
-checksum = "sha256:58d0212e169764c3424d2d5bec73e8a098d34b4e82fca6e1dd54083ea3049c5f"
-url = "https://nodejs.org/dist/v21.7.3/node-v21.7.3-darwin-x64.tar.gz"
+checksum = "sha256:45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-darwin-x64.tar.gz"
 
 [tools.node."platforms.windows-x64"]
-checksum = "sha256:d2314f496782b53ad2fe5fa82fca6ff7f39f07fe59dd007116404ad92179c78e"
-url = "https://nodejs.org/dist/v21.7.3/node-v21.7.3-win-x64.zip"
+checksum = "sha256:6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-win-x64.zip"


### PR DESCRIPTION
The OG preview handler derives the API endpoint name directly from the
URL's category param. For foreign beer drinks the category field value
is 'foreign beer' (with a space) but the API endpoint is
'international-beer', so the handler fetched a non-existent URL and
silently fell back to the plain SPA — no OG metadata was injected.

Add a CATEGORY_TO_ENDPOINT lookup in fetchDrinkData so 'foreign beer'
resolves to 'international-beer.json', matching what the Flutter app
uses when loading these drinks.