### PR TITLE
fix(router): handle illegal percent encoding in style route

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'providers/beer_provider.dart';
 import 'screens/screens.dart';
+import 'utils/navigation_helpers.dart';
 import 'main.dart';
 
 /// Global routes that exist outside festival scope
@@ -38,19 +39,6 @@ String? _festivalScopeRedirect(
     });
   }
   return null;
-}
-
-/// Decodes a percent-encoded path segment, returning the raw value if it
-/// contains an illegal percent encoding.
-///
-/// Malformed URLs (e.g. an old bookmark or shared link with a stray `%`)
-/// would otherwise cause [Uri.decodeComponent] to throw and crash the build.
-String _safeDecodeComponent(String value) {
-  try {
-    return Uri.decodeComponent(value);
-  } on ArgumentError {
-    return value;
-  }
 }
 
 /// Application router configuration using go_router for better web support
@@ -175,7 +163,7 @@ final GoRouter appRouter = GoRouter(
             final name = state.pathParameters['name']!;
             return StyleScreen(
               festivalId: festivalId,
-              style: _safeDecodeComponent(name),
+              style: safeDecodeComponent(name),
             );
           },
         ),

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -40,6 +40,19 @@ String? _festivalScopeRedirect(
   return null;
 }
 
+/// Decodes a percent-encoded path segment, returning the raw value if it
+/// contains an illegal percent encoding.
+///
+/// Malformed URLs (e.g. an old bookmark or shared link with a stray `%`)
+/// would otherwise cause [Uri.decodeComponent] to throw and crash the build.
+String _safeDecodeComponent(String value) {
+  try {
+    return Uri.decodeComponent(value);
+  } on ArgumentError {
+    return value;
+  }
+}
+
 /// Application router configuration using go_router for better web support
 ///
 /// Router structure (Phase 1 - Festival-scoped URLs):
@@ -160,10 +173,9 @@ final GoRouter appRouter = GoRouter(
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             final name = state.pathParameters['name']!;
-            final decodedName = Uri.decodeComponent(name);
             return StyleScreen(
               festivalId: festivalId,
-              style: decodedName,
+              style: _safeDecodeComponent(name),
             );
           },
         ),

--- a/lib/utils/navigation_helpers.dart
+++ b/lib/utils/navigation_helpers.dart
@@ -235,3 +235,25 @@ void navigateToRoute(BuildContext context, String path) {
     context.push(path);
   }
 }
+
+/// Decodes a percent-encoded URI component, returning the raw value if it
+/// contains an illegal percent-encoding sequence.
+///
+/// [Uri.decodeComponent] throws an [ArgumentError] when a `%` is not followed
+/// by two hex digits (e.g. a stray `%` in an old bookmark or shared link).
+/// This wrapper catches that case so callers get a usable string instead of a
+/// crash.
+///
+/// Example:
+/// ```dart
+/// safeDecodeComponent('IPA%20American')  // Returns: 'IPA American'
+/// safeDecodeComponent('50%')             // Returns: '50%' (malformed — fallback)
+/// safeDecodeComponent('normal')          // Returns: 'normal'
+/// ```
+String safeDecodeComponent(String value) {
+  try {
+    return Uri.decodeComponent(value);
+  } on ArgumentError {
+    return value;
+  }
+}

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cambridge_beer_festival/router.dart';
 import 'package:cambridge_beer_festival/providers/beer_provider.dart';
+import 'package:cambridge_beer_festival/screens/screens.dart';
 import 'package:cambridge_beer_festival/services/services.dart';
 import 'package:cambridge_beer_festival/models/models.dart';
 import 'package:provider/provider.dart';
@@ -842,6 +843,28 @@ void main() {
           appRouter.routerDelegate.currentConfiguration.uri.toString());
       expect(uri.pathSegments[0], testFestivalId);
       expect(uri.pathSegments[1], 'info');
+    });
+
+    testWidgets(
+        'style route with illegal percent encoding does not crash the build',
+        (tester) async {
+      await provider.initialize();
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BeerProvider>.value(
+          value: provider,
+          child: MaterialApp.router(routerConfig: appRouter),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // A malformed URL (e.g. an old bookmark with a stray `%`) previously
+      // crashed the build via Uri.decodeComponent throwing.
+      appRouter.go('/$testFestivalId/style/50%');
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(StyleScreen), findsOneWidget);
     });
 
     testWidgets(

--- a/test/utils/navigation_helpers_test.dart
+++ b/test/utils/navigation_helpers_test.dart
@@ -386,5 +386,39 @@ void main() {
         expect(find.text('Can pop: false'), findsOneWidget);
       });
     });
+
+    group('safeDecodeComponent', () {
+      test('decodes a valid percent-encoded string', () {
+        expect(safeDecodeComponent('IPA%20American'), equals('IPA American'));
+      });
+
+      test('decodes unicode percent-encoding', () {
+        expect(safeDecodeComponent('Bi%C3%A8re%20de%20Garde'), equals('Bière de Garde'));
+      });
+
+      test('returns unmodified string with no encoding', () {
+        expect(safeDecodeComponent('IPA'), equals('IPA'));
+      });
+
+      test('returns raw value for stray percent (illegal encoding)', () {
+        expect(safeDecodeComponent('50%'), equals('50%'));
+      });
+
+      test('returns raw value for truncated percent sequence', () {
+        expect(safeDecodeComponent('foo%2'), equals('foo%2'));
+      });
+
+      test('returns raw value for percent followed by non-hex', () {
+        expect(safeDecodeComponent('foo%ZZ'), equals('foo%ZZ'));
+      });
+
+      test('handles empty string', () {
+        expect(safeDecodeComponent(''), equals(''));
+      });
+
+      test('handles string with multiple valid encodings', () {
+        expect(safeDecodeComponent('IPA%20-%20American%20Pale'), equals('IPA - American Pale'));
+      });
+    });
   });
 }

--- a/test/utils/navigation_helpers_test.dart
+++ b/test/utils/navigation_helpers_test.dart
@@ -393,7 +393,8 @@ void main() {
       });
 
       test('decodes unicode percent-encoding', () {
-        expect(safeDecodeComponent('Bi%C3%A8re%20de%20Garde'), equals('Bière de Garde'));
+        expect(safeDecodeComponent('Bi%C3%A8re%20de%20Garde'),
+            equals('Bière de Garde'));
       });
 
       test('returns unmodified string with no encoding', () {
@@ -417,7 +418,8 @@ void main() {
       });
 
       test('handles string with multiple valid encodings', () {
-        expect(safeDecodeComponent('IPA%20-%20American%20Pale'), equals('IPA - American Pale'));
+        expect(safeDecodeComponent('IPA%20-%20American%20Pale'),
+            equals('IPA - American Pale'));
       });
     });
   });


### PR DESCRIPTION
Navigating to a style URL with a malformed percent-encoding (e.g. an
old bookmark or shared link containing a stray `%`) caused
Uri.decodeComponent to throw an ArgumentError, crashing the widget
build. Decode the path segment safely, falling back to the raw value
when decoding fails.

https://claude.ai/code/session_01BBXUxMtenctm7JQoLpwzmY