### PR TITLE
feat(offline): cache drinks & festivals for instant stale-while-revalidate startup

### DIFF
--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -10,30 +10,48 @@ class ApiDrinkRepository implements DrinkRepository {
   final FavoritesService _favoritesService;
   final RatingsService _ratingsService;
   final TastingLogService _tastingLogService;
+  final DrinkCacheService _cacheService;
 
   ApiDrinkRepository({
     required BeerApiService apiService,
     required FavoritesService favoritesService,
     required RatingsService ratingsService,
     required TastingLogService tastingLogService,
+    required DrinkCacheService cacheService,
   })  : _apiService = apiService,
         _favoritesService = favoritesService,
         _ratingsService = ratingsService,
-        _tastingLogService = tastingLogService;
+        _tastingLogService = tastingLogService,
+        _cacheService = cacheService;
 
   @override
   Future<List<Drink>> getDrinks(Festival festival) async {
     final drinks = await _apiService.fetchAllDrinks(festival);
 
-    // Populate favorite status, ratings, and tasted status in a single pass
-    final favorites = _favoritesService.getFavorites(festival.id);
+    // Persist the last-good data so it can be shown instantly next launch.
+    await _cacheService.save(festival.id, drinks);
+
+    _applyUserState(drinks, festival.id);
+    return drinks;
+  }
+
+  @override
+  Future<List<Drink>?> getCachedDrinks(Festival festival) async {
+    final drinks = _cacheService.read(festival.id);
+    if (drinks == null) return null;
+
+    _applyUserState(drinks, festival.id);
+    return drinks;
+  }
+
+  /// Populate favorite status, ratings, and tasted status in a single pass.
+  void _applyUserState(List<Drink> drinks, String festivalId) {
+    final favorites = _favoritesService.getFavorites(festivalId);
     for (final drink in drinks) {
       drink.isFavorite = favorites.contains(drink.id);
-      drink.rating = _ratingsService.getRating(festival.id, drink.id);
-      drink.isTasted = _tastingLogService.hasTasted(festival.id, drink.id);
+      drink.rating = _ratingsService.getRating(festivalId, drink.id);
+      drink.isTasted = _tastingLogService.hasTasted(festivalId, drink.id);
     }
-
-    return drinks;
   }
 
   @override

--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import '../../models/models.dart';
 import '../../services/services.dart';
 import 'drink_repository.dart';
@@ -26,13 +28,20 @@ class ApiDrinkRepository implements DrinkRepository {
 
   @override
   Future<List<Drink>> getDrinks(Festival festival) async {
-    final drinks = await _apiService.fetchAllDrinks(festival);
+    final result = await _apiService.fetchDrinksByType(festival);
 
-    // Persist the last-good data so it can be shown instantly next launch.
-    await _cacheService.save(festival.id, drinks);
+    // Nothing loaded at all — surface the error so the provider can keep
+    // showing cached data or display an error.
+    result.throwIfCompleteFailure();
 
-    _applyUserState(drinks, festival.id);
-    return drinks;
+    // Merge the types that succeeded over the cached snapshot, keeping the
+    // last-good data for any type that failed to refresh this time. The cache
+    // write happens in the background so it stays off the load critical path.
+    final update = _cacheService.merge(festival.id, result.drinksByType);
+    unawaited(update.written);
+
+    _applyUserState(update.drinks, festival.id);
+    return update.drinks;
   }
 
   @override

--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -13,6 +13,7 @@ class ApiDrinkRepository implements DrinkRepository {
   final RatingsService _ratingsService;
   final TastingLogService _tastingLogService;
   final DrinkCacheService _cacheService;
+  final AnalyticsService _analyticsService;
 
   ApiDrinkRepository({
     required BeerApiService apiService,
@@ -20,11 +21,13 @@ class ApiDrinkRepository implements DrinkRepository {
     required RatingsService ratingsService,
     required TastingLogService tastingLogService,
     required DrinkCacheService cacheService,
+    required AnalyticsService analyticsService,
   })  : _apiService = apiService,
         _favoritesService = favoritesService,
         _ratingsService = ratingsService,
         _tastingLogService = tastingLogService,
-        _cacheService = cacheService;
+        _cacheService = cacheService,
+        _analyticsService = analyticsService;
 
   @override
   Future<List<Drink>> getDrinks(Festival festival) async {
@@ -36,9 +39,17 @@ class ApiDrinkRepository implements DrinkRepository {
 
     // Merge the types that succeeded over the cached snapshot, keeping the
     // last-good data for any type that failed to refresh this time. The cache
-    // write happens in the background so it stays off the load critical path.
+    // write happens in the background so it stays off the load critical path;
+    // route persistence failures through analytics rather than letting them
+    // surface as unhandled async errors.
     final update = _cacheService.merge(festival.id, result.drinksByType);
-    unawaited(update.written);
+    unawaited(update.written.catchError((Object e, StackTrace s) {
+      return _analyticsService.logError(
+        e,
+        s,
+        reason: 'Drink cache write failed for festival: ${festival.id}',
+      );
+    }));
 
     _applyUserState(update.drinks, festival.id);
     return update.drinks;

--- a/lib/domain/repositories/api_festival_repository.dart
+++ b/lib/domain/repositories/api_festival_repository.dart
@@ -7,16 +7,26 @@ import 'festival_repository.dart';
 class ApiFestivalRepository implements FestivalRepository {
   final FestivalService _festivalService;
   final FestivalStorageService _festivalStorageService;
+  final FestivalCacheService _cacheService;
 
   ApiFestivalRepository({
     required FestivalService festivalService,
     required FestivalStorageService festivalStorageService,
+    required FestivalCacheService cacheService,
   })  : _festivalService = festivalService,
-        _festivalStorageService = festivalStorageService;
+        _festivalStorageService = festivalStorageService,
+        _cacheService = cacheService;
 
   @override
   Future<FestivalsResponse> getFestivals() async {
-    return await _festivalService.fetchFestivals();
+    final response = await _festivalService.fetchFestivals();
+    await _cacheService.save(response);
+    return response;
+  }
+
+  @override
+  Future<FestivalsResponse?> getCachedFestivals() async {
+    return _cacheService.read();
   }
 
   @override

--- a/lib/domain/repositories/api_festival_repository.dart
+++ b/lib/domain/repositories/api_festival_repository.dart
@@ -10,20 +10,31 @@ class ApiFestivalRepository implements FestivalRepository {
   final FestivalService _festivalService;
   final FestivalStorageService _festivalStorageService;
   final FestivalCacheService _cacheService;
+  final AnalyticsService _analyticsService;
 
   ApiFestivalRepository({
     required FestivalService festivalService,
     required FestivalStorageService festivalStorageService,
     required FestivalCacheService cacheService,
+    required AnalyticsService analyticsService,
   })  : _festivalService = festivalService,
         _festivalStorageService = festivalStorageService,
-        _cacheService = cacheService;
+        _cacheService = cacheService,
+        _analyticsService = analyticsService;
 
   @override
   Future<FestivalsResponse> getFestivals() async {
     final response = await _festivalService.fetchFestivals();
-    // Persist in the background so caching stays off the load critical path.
-    unawaited(_cacheService.save(response));
+    // Persist in the background so caching stays off the load critical path;
+    // surface persistence failures via analytics rather than letting them
+    // become unhandled async errors.
+    unawaited(_cacheService.save(response).catchError((Object e, StackTrace s) {
+      return _analyticsService.logError(
+        e,
+        s,
+        reason: 'Festival cache write failed',
+      );
+    }));
     return response;
   }
 

--- a/lib/domain/repositories/api_festival_repository.dart
+++ b/lib/domain/repositories/api_festival_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import '../../services/services.dart';
 import 'festival_repository.dart';
 
@@ -20,7 +22,8 @@ class ApiFestivalRepository implements FestivalRepository {
   @override
   Future<FestivalsResponse> getFestivals() async {
     final response = await _festivalService.fetchFestivals();
-    await _cacheService.save(response);
+    // Persist in the background so caching stays off the load critical path.
+    unawaited(_cacheService.save(response));
     return response;
   }
 

--- a/lib/domain/repositories/drink_repository.dart
+++ b/lib/domain/repositories/drink_repository.dart
@@ -10,6 +10,13 @@ abstract class DrinkRepository {
   /// Returns drinks with favorite, rating, and tasting status already populated.
   Future<List<Drink>> getDrinks(Festival festival);
 
+  /// Return locally cached drinks for a festival, or null if none are cached.
+  ///
+  /// Used to render last-good data immediately on launch while a fresh fetch
+  /// runs in the background. Returned drinks have favorite, rating, and tasting
+  /// status populated, just like [getDrinks].
+  Future<List<Drink>?> getCachedDrinks(Festival festival);
+
   /// Get list of favorited drink IDs for a festival
   Future<List<String>> getFavorites(String festivalId);
 

--- a/lib/domain/repositories/festival_repository.dart
+++ b/lib/domain/repositories/festival_repository.dart
@@ -9,6 +9,12 @@ abstract class FestivalRepository {
   /// Returns a response containing the list of festivals and the default festival.
   Future<FestivalsResponse> getFestivals();
 
+  /// Return the locally cached festivals response, or null if none is cached.
+  ///
+  /// Used to populate the festival switcher and resolve a saved selection
+  /// immediately on launch, before the network fetch completes.
+  Future<FestivalsResponse?> getCachedFestivals();
+
   /// Get the ID of the previously selected festival (from local storage)
   ///
   /// Returns null if no festival has been selected before.

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -369,13 +369,17 @@ class BeerProvider extends ChangeNotifier {
     _selectedCategory = null;
     _selectedStyles = {};
     _searchQuery = '';
-    // Clear existing drinks; the new festival's cached drinks (if any) replace
-    // them immediately below, otherwise a loading spinner is shown.
+    // Clear existing drinks and signal the switch immediately so the UI rebuilds
+    // against the new festival id; the new festival's cached drinks (if any)
+    // replace them below, otherwise the spinner stays up.
     _allDrinks = [];
     _filteredDrinks = [];
     _error = null;
     _refreshNotice = null;
+    _isLoading = true;
+    _isRefreshing = true;
     final token = ++_drinksLoadToken;
+    notifyListeners();
 
     final cached = await _drinkRepository?.getCachedDrinks(festival);
     if (token != _drinksLoadToken) return;
@@ -383,11 +387,8 @@ class BeerProvider extends ChangeNotifier {
       _allDrinks = cached;
       _applyFiltersAndSort();
       _isLoading = false;
-    } else {
-      _isLoading = true;
+      notifyListeners();
     }
-    _isRefreshing = true;
-    notifyListeners();
 
     await _analyticsService.logFestivalSelected(festival);
 
@@ -422,7 +423,7 @@ class BeerProvider extends ChangeNotifier {
       final haveData = _allDrinks.isNotEmpty;
       if (haveData) {
         // Keep showing cached data; surface a quiet, dismissible notice.
-        _refreshNotice = "Showing saved data — couldn't refresh.";
+        _refreshNotice = 'Showing saved data — couldn\'t refresh.';
         _error = null;
       } else {
         _error = _getUserFriendlyErrorMessage(e);

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -258,15 +258,18 @@ class BeerProvider extends ChangeNotifier {
       await loadFestivals();
     }
 
-    // Restore previously selected festival if available, matching against the
-    // (cached or freshly loaded) registry first, then the built-in defaults.
+    // Restore previously selected festival if it still exists in the (cached
+    // or freshly loaded) registry. We deliberately do NOT fall back to the
+    // hard-coded DefaultFestivals here: an id that has been retired from the
+    // registry should let the registry's defaultFestival take over rather
+    // than resurrect a defunct selection whose dataBaseUrl would 404. Only
+    // overwrite _currentFestival when the saved id matches an active entry
+    // so we don't clobber a default already set by loadFestivals above.
     final savedFestivalId = await _festivalRepository!.getSelectedFestivalId();
     if (savedFestivalId != null) {
-      _currentFestival =
-          _festivals.where((f) => f.id == savedFestivalId).firstOrNull ??
-              DefaultFestivals.all
-                  .where((f) => f.id == savedFestivalId)
-                  .firstOrNull;
+      final saved =
+          _festivals.where((f) => f.id == savedFestivalId).firstOrNull;
+      if (saved != null) _currentFestival = saved;
     }
     if (_currentFestival == null && cachedFestivals?.defaultFestival != null) {
       _currentFestival = cachedFestivals!.defaultFestival;
@@ -351,7 +354,9 @@ class BeerProvider extends ChangeNotifier {
         _isLoading = true;
       }
     }
-    _refreshNotice = null;
+    // Keep any pre-existing _refreshNotice in place — it'll be cleared on a
+    // successful refresh, so the banner doesn't flicker on every resume when
+    // refreshes keep failing.
     _isRefreshing = true;
     notifyListeners();
 
@@ -364,7 +369,13 @@ class BeerProvider extends ChangeNotifier {
   /// If [persist] is true (default), saves the festival selection to local storage.
   /// Set to false for temporary festival viewing (e.g., deep links to old festivals).
   Future<void> setFestival(Festival festival, {bool persist = true}) async {
-    if (_currentFestival?.id == festival.id) return;
+    // Tapping the current festival is a no-op unless a refresh notice is
+    // up — in which case treat it as a retry so the switcher offers an
+    // obvious way back to a fresh load.
+    if (_currentFestival?.id == festival.id) {
+      if (_refreshNotice != null) await loadDrinks();
+      return;
+    }
     _currentFestival = festival;
     _selectedCategory = null;
     _selectedStyles = {};
@@ -470,8 +481,10 @@ class BeerProvider extends ChangeNotifier {
 
   /// Refresh data if it's stale (called when app resumes from background)
   Future<void> refreshIfStale() async {
-    // Don't refresh if already loading
-    if (_isLoading || _isFestivalsLoading) return;
+    // Don't refresh if a load (foreground spinner or background SWR refresh)
+    // is already in flight; otherwise a resume could kick a duplicate fetch
+    // and the older response gets discarded via the token.
+    if (_isLoading || _isRefreshing || _isFestivalsLoading) return;
 
     // Refresh festivals if stale
     if (isFestivalsDataStale) {

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -21,9 +21,11 @@ class BeerProvider extends ChangeNotifier {
   List<Festival> _festivals = [];
   Festival? _currentFestival;
   bool _isLoading = false;
+  bool _isRefreshing = false;
   bool _isFestivalsLoading = false;
   bool _isInitialized = false;
   String? _error;
+  String? _refreshNotice;
   String? _festivalsError;
   String? _selectedCategory;
   Set<String> _selectedStyles = {};
@@ -69,9 +71,15 @@ class BeerProvider extends ChangeNotifier {
       DefaultFestivals.all.firstWhere((f) => f.isActive,
           orElse: () => DefaultFestivals.all.first);
   bool get isLoading => _isLoading;
+
+  /// True while a background refresh runs with data already on screen.
+  bool get isRefreshing => _isRefreshing;
   bool get isFestivalsLoading => _isFestivalsLoading;
   bool get isInitialized => _isInitialized;
   String? get error => _error;
+
+  /// Non-null when a background refresh failed but cached drinks remain shown.
+  String? get refreshNotice => _refreshNotice;
   String? get festivalsError => _festivalsError;
   String? get selectedCategory => _selectedCategory;
   Set<String> get selectedStyles => _selectedStyles;
@@ -191,20 +199,24 @@ class BeerProvider extends ChangeNotifier {
       final ratingsService = RatingsService(prefs);
       final tastingLogService = TastingLogService(prefs);
       final apiService = BeerApiService();
+      final drinkCacheService = DrinkCacheService(prefs);
       _drinkRepository = ApiDrinkRepository(
         apiService: apiService,
         favoritesService: favoritesService,
         ratingsService: ratingsService,
         tastingLogService: tastingLogService,
+        cacheService: drinkCacheService,
       );
     }
 
     if (_festivalRepository == null) {
       final festivalService = FestivalService();
       final festivalStorageService = FestivalStorageService(prefs);
+      final festivalCacheService = FestivalCacheService(prefs);
       _festivalRepository = ApiFestivalRepository(
         festivalService: festivalService,
         festivalStorageService: festivalStorageService,
+        cacheService: festivalCacheService,
       );
     }
 
@@ -233,21 +245,39 @@ class BeerProvider extends ChangeNotifier {
     _excludedAllergens =
         Set.from(prefs.getStringList('excludedAllergens') ?? []);
 
-    // Load festivals dynamically
-    await loadFestivals();
+    // Populate festivals from cache so the switcher works offline and we can
+    // resolve the saved selection without waiting on the network.
+    final cachedFestivals = await _festivalRepository!.getCachedFestivals();
+    if (cachedFestivals != null) {
+      _festivals = cachedFestivals.festivals;
+    } else {
+      // First launch (nothing cached): we have nothing to show until the
+      // registry loads, so block on it as before.
+      await loadFestivals();
+    }
 
-    // Restore previously selected festival if available
+    // Restore previously selected festival if available, matching against the
+    // (cached or freshly loaded) registry first, then the built-in defaults.
     final savedFestivalId = await _festivalRepository!.getSelectedFestivalId();
     if (savedFestivalId != null) {
-      final savedFestival =
-          _festivals.where((f) => f.id == savedFestivalId).firstOrNull;
-      if (savedFestival != null) {
-        _currentFestival = savedFestival;
-      }
+      _currentFestival =
+          _festivals.where((f) => f.id == savedFestivalId).firstOrNull ??
+              DefaultFestivals.all
+                  .where((f) => f.id == savedFestivalId)
+                  .firstOrNull;
+    }
+    if (_currentFestival == null && cachedFestivals?.defaultFestival != null) {
+      _currentFestival = cachedFestivals!.defaultFestival;
     }
 
     _isInitialized = true;
     notifyListeners();
+
+    // When cached festivals were shown, refresh the registry in the background
+    // so drinks loading is never blocked on the network.
+    if (cachedFestivals != null) {
+      unawaited(loadFestivals());
+    }
   }
 
   /// Load festivals from the API
@@ -268,16 +298,31 @@ class BeerProvider extends ChangeNotifier {
       _festivalsError = null;
       _lastFestivalsRefresh = DateTime.now();
     } catch (e) {
-      _festivalsError = _getUserFriendlyErrorMessage(e);
-      // Don't fall back to hardcoded festivals - show error to user
-      _festivals = [];
+      // Fall back to cached festivals so the switcher keeps working offline
+      // instead of emptying the list and blocking the app.
+      final cached = await _festivalRepository?.getCachedFestivals();
+      if (cached != null && cached.festivals.isNotEmpty) {
+        _festivals = cached.festivals;
+        if (_currentFestival == null && cached.defaultFestival != null) {
+          _currentFestival = cached.defaultFestival;
+        }
+        _festivalsError = null;
+      } else {
+        _festivalsError = _getUserFriendlyErrorMessage(e);
+        _festivals = [];
+      }
     } finally {
       _isFestivalsLoading = false;
       notifyListeners();
     }
   }
 
-  /// Load drinks from the current festival
+  /// Load drinks for the current festival.
+  ///
+  /// Stale-while-revalidate: if nothing is loaded yet, cached drinks are shown
+  /// immediately, then a fresh copy is fetched from the network in the
+  /// background. A failed refresh keeps any cached data on screen rather than
+  /// blanking to an error.
   Future<void> loadDrinks() async {
     if (_currentFestival == null) {
       // Wait for festivals to be loaded first
@@ -288,36 +333,28 @@ class BeerProvider extends ChangeNotifier {
           orElse: () => DefaultFestivals.all.first);
     }
 
+    final festival = currentFestival;
     final token = ++_drinksLoadToken;
-    _isLoading = true;
-    _error = null;
-    notifyListeners();
 
-    try {
-      // Repository returns drinks with favorites and ratings already populated
-      final drinks = await _drinkRepository!.getDrinks(currentFestival);
+    // Phase 1: render cached data instantly when we have nothing in memory.
+    if (_allDrinks.isEmpty) {
+      final cached = await _drinkRepository!.getCachedDrinks(festival);
       if (token != _drinksLoadToken) return;
-      _allDrinks = drinks;
-      _applyFiltersAndSort();
-      _error = null;
-      _lastDrinksRefresh = DateTime.now();
-    } catch (e, stackTrace) {
-      if (token != _drinksLoadToken) return;
-      _error = _getUserFriendlyErrorMessage(e);
-      _allDrinks = [];
-      _filteredDrinks = [];
-      // Log error to Crashlytics
-      await _analyticsService.logError(
-        e,
-        stackTrace,
-        reason: 'Failed to load drinks for festival: ${currentFestival.id}',
-      );
-    } finally {
-      if (token == _drinksLoadToken) {
+      if (cached != null) {
+        _allDrinks = cached;
+        _applyFiltersAndSort();
+        _error = null;
         _isLoading = false;
-        notifyListeners();
+      } else {
+        _isLoading = true;
       }
     }
+    _refreshNotice = null;
+    _isRefreshing = true;
+    notifyListeners();
+
+    // Phase 2: refresh from the network.
+    await _refreshDrinksFromNetwork(token, festival);
   }
 
   /// Change the current festival (drinks loaded lazily on demand)
@@ -330,12 +367,24 @@ class BeerProvider extends ChangeNotifier {
     _selectedCategory = null;
     _selectedStyles = {};
     _searchQuery = '';
-    // Clear existing drinks and show loading state immediately
+    // Clear existing drinks; the new festival's cached drinks (if any) replace
+    // them immediately below, otherwise a loading spinner is shown.
     _allDrinks = [];
     _filteredDrinks = [];
-    _isLoading = true;
     _error = null;
+    _refreshNotice = null;
     final token = ++_drinksLoadToken;
+
+    final cached = await _drinkRepository?.getCachedDrinks(festival);
+    if (token != _drinksLoadToken) return;
+    if (cached != null) {
+      _allDrinks = cached;
+      _applyFiltersAndSort();
+      _isLoading = false;
+    } else {
+      _isLoading = true;
+    }
+    _isRefreshing = true;
     notifyListeners();
 
     await _analyticsService.logFestivalSelected(festival);
@@ -344,40 +393,76 @@ class BeerProvider extends ChangeNotifier {
       await _festivalRepository?.setSelectedFestivalId(festival.id);
     }
 
-    await _loadDrinksInternal(token, festival);
+    await _refreshDrinksFromNetwork(token, festival);
   }
 
-  /// Internal method to load drinks without setting initial loading state.
+  /// Fetch fresh drinks from the network and reconcile with what's on screen.
+  ///
   /// [token] must match [_drinksLoadToken] for results to be applied; a
   /// mismatch means a newer load has started and this response is stale.
   /// [festival] is captured at call time to avoid reading the live
   /// [currentFestival] getter after intervening awaits may have changed it.
-  Future<void> _loadDrinksInternal(int token, Festival festival) async {
+  ///
+  /// On failure, cached drinks already on screen are kept (with a quiet
+  /// [refreshNotice]); only a fully blocked load (no data) surfaces an [error].
+  Future<void> _refreshDrinksFromNetwork(int token, Festival festival) async {
     try {
-      // Repository returns drinks with favorites and ratings already populated
+      // Repository returns drinks with favorites and ratings already populated.
       final drinks = await _drinkRepository!.getDrinks(festival);
       if (token != _drinksLoadToken) return;
       _allDrinks = drinks;
       _applyFiltersAndSort();
       _error = null;
+      _refreshNotice = null;
       _lastDrinksRefresh = DateTime.now();
     } catch (e, stackTrace) {
       if (token != _drinksLoadToken) return;
-      _error = _getUserFriendlyErrorMessage(e);
-      _allDrinks = [];
-      _filteredDrinks = [];
-      // Log error to Crashlytics
-      await _analyticsService.logError(
-        e,
-        stackTrace,
-        reason: 'Failed to load drinks internally for festival: ${festival.id}',
-      );
+      final haveData = _allDrinks.isNotEmpty;
+      if (haveData) {
+        // Keep showing cached data; surface a quiet, dismissible notice.
+        _refreshNotice = "Showing saved data — couldn't refresh.";
+        _error = null;
+      } else {
+        _error = _getUserFriendlyErrorMessage(e);
+        _allDrinks = [];
+        _filteredDrinks = [];
+      }
+      // Log to Crashlytics unless this is an expected offline failure that we
+      // already covered with cached data. Always log when fully blocked, and
+      // always log non-connectivity failures so a silent never-load bug
+      // (e.g. a server or parsing error masked by the cache) still surfaces.
+      if (!haveData || !_isConnectivityError(e)) {
+        await _analyticsService.logError(
+          e,
+          stackTrace,
+          reason: 'Failed to load drinks for festival: ${festival.id}',
+        );
+      }
     } finally {
       if (token == _drinksLoadToken) {
         _isLoading = false;
+        _isRefreshing = false;
         notifyListeners();
       }
     }
+  }
+
+  /// Whether [error] represents a connectivity failure (offline / timeout)
+  /// rather than a server or data error.
+  bool _isConnectivityError(Object error) {
+    if (error is http.ClientException || error is TimeoutException) {
+      return true;
+    }
+    // Match SocketException by name to avoid importing dart:io (unavailable on
+    // web).
+    return error.runtimeType.toString() == 'SocketException';
+  }
+
+  /// Dismiss the "showing saved data" notice (e.g. when the user taps it away).
+  void dismissRefreshNotice() {
+    if (_refreshNotice == null) return;
+    _refreshNotice = null;
+    notifyListeners();
   }
 
   /// Refresh data if it's stale (called when app resumes from background)

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -206,6 +206,7 @@ class BeerProvider extends ChangeNotifier {
         ratingsService: ratingsService,
         tastingLogService: tastingLogService,
         cacheService: drinkCacheService,
+        analyticsService: _analyticsService,
       );
     }
 
@@ -217,6 +218,7 @@ class BeerProvider extends ChangeNotifier {
         festivalService: festivalService,
         festivalStorageService: festivalStorageService,
         cacheService: festivalCacheService,
+        analyticsService: _analyticsService,
       );
     }
 
@@ -448,14 +450,14 @@ class BeerProvider extends ChangeNotifier {
   }
 
   /// Whether [error] represents a connectivity failure (offline / timeout)
-  /// rather than a server or data error.
+  /// rather than a server or data error. Recognises [BeerApiException]
+  /// wrappers that carry an underlying connectivity error as [cause].
   bool _isConnectivityError(Object error) {
-    if (error is http.ClientException || error is TimeoutException) {
-      return true;
+    if (isConnectivityFailure(error)) return true;
+    if (error is BeerApiException && error.cause != null) {
+      return isConnectivityFailure(error.cause!);
     }
-    // Match SocketException by name to avoid importing dart:io (unavailable on
-    // web).
-    return error.runtimeType.toString() == 'SocketException';
+    return false;
   }
 
   /// Dismiss the "showing saved data" notice (e.g. when the user taps it away).

--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -53,6 +53,9 @@ class _DrinksScreenState extends State<DrinksScreen> {
                   SliverToBoxAdapter(
                     child: _buildFestivalBanner(context, provider),
                   ),
+                  SliverToBoxAdapter(
+                    child: _buildRefreshStatus(context, provider),
+                  ),
                   if (_showSearch)
                     SliverToBoxAdapter(
                       child: _buildSearchBar(context, provider),
@@ -400,8 +403,66 @@ class _DrinksScreenState extends State<DrinksScreen> {
     );
   }
 
+  /// Thin progress bar while a background refresh runs with data on screen, or
+  /// a dismissible notice when a refresh failed but cached data remains shown.
+  Widget _buildRefreshStatus(BuildContext context, BeerProvider provider) {
+    final theme = Theme.of(context);
+    final hasData = provider.drinks.isNotEmpty;
+
+    if (provider.refreshNotice != null && hasData) {
+      return Material(
+        color: theme.colorScheme.secondaryContainer,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              Icon(
+                Icons.cloud_off,
+                size: 18,
+                color: theme.colorScheme.onSecondaryContainer,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  provider.refreshNotice!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSecondaryContainer,
+                  ),
+                ),
+              ),
+              Semantics(
+                label: 'Dismiss saved data notice',
+                hint: 'Double tap to dismiss',
+                button: true,
+                child: IconButton(
+                  visualDensity: VisualDensity.compact,
+                  icon: Icon(
+                    Icons.close,
+                    size: 18,
+                    color: theme.colorScheme.onSecondaryContainer,
+                  ),
+                  onPressed: provider.dismissRefreshNotice,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (provider.isRefreshing && hasData) {
+      return Semantics(
+        label: 'Refreshing drinks',
+        liveRegion: true,
+        child: const LinearProgressIndicator(minHeight: 2),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
   Widget _buildDrinksListSliver(BuildContext context, BeerProvider provider) {
-    if (provider.isLoading) {
+    if (provider.isLoading && provider.drinks.isEmpty) {
       return SliverFillRemaining(
         hasScrollBody: false,
         child: Center(
@@ -417,7 +478,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
       );
     }
 
-    if (provider.error != null) {
+    if (provider.error != null && provider.drinks.isEmpty) {
       return SliverFillRemaining(
         child: Center(
           child: Column(

--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -407,7 +407,9 @@ class _DrinksScreenState extends State<DrinksScreen> {
   /// a dismissible notice when a refresh failed but cached data remains shown.
   Widget _buildRefreshStatus(BuildContext context, BeerProvider provider) {
     final theme = Theme.of(context);
-    final hasData = provider.drinks.isNotEmpty;
+    // Test against the unfiltered list so an active filter (favourites only,
+    // search query with no matches) doesn't hide the refresh indicator.
+    final hasData = provider.allDrinks.isNotEmpty;
 
     if (provider.refreshNotice != null && hasData) {
       return Material(

--- a/lib/services/beer_api_service.dart
+++ b/lib/services/beer_api_service.dart
@@ -36,42 +36,51 @@ class BeerApiService {
     }
   }
 
-  /// Fetches all available drinks from a festival (all beverage types)
+  /// Fetches all beverage types in parallel, reporting per-type outcomes.
+  ///
+  /// A type that loads (HTTP 200, or 404 → empty) appears in
+  /// [FestivalDrinksResult.drinksByType]; a type that errors (network, timeout,
+  /// 5xx, …) appears in [FestivalDrinksResult.failedTypes]. This lets callers
+  /// merge fresh data per type while preserving the last-good cache for types
+  /// that failed, instead of treating a partial fetch as a full snapshot.
+  Future<FestivalDrinksResult> fetchDrinksByType(Festival festival) async {
+    final entries = await Future.wait(
+      festival.availableBeverageTypes.map((beverageType) async {
+        try {
+          final drinks = await fetchDrinks(festival, beverageType);
+          return (type: beverageType, drinks: drinks, error: null);
+        } catch (e) {
+          return (type: beverageType, drinks: null, error: e.toString());
+        }
+      }),
+    );
+
+    final drinksByType = <String, List<Drink>>{};
+    final failedTypes = <String, String>{};
+    for (final entry in entries) {
+      if (entry.drinks != null) {
+        drinksByType[entry.type] = entry.drinks!;
+      } else {
+        failedTypes[entry.type] = entry.error!;
+      }
+    }
+
+    return FestivalDrinksResult(
+      drinksByType: drinksByType,
+      failedTypes: failedTypes,
+    );
+  }
+
+  /// Fetches all available drinks from a festival (all beverage types).
   ///
   /// Fetches all beverage types in parallel for faster loading.
   /// Throws [BeerApiException] if ALL beverage types fail to load or return
   /// no drinks. Individual failures are tracked and reported in the exception
   /// message to help diagnose issues like CORS or network problems.
   Future<List<Drink>> fetchAllDrinks(Festival festival) async {
-    final allDrinks = <Drink>[];
-    final errors = <String, String>{};
-
-    // Fetch all beverage types in parallel for faster loading
-    final results = await Future.wait(
-      festival.availableBeverageTypes.map((beverageType) async {
-        try {
-          return await fetchDrinks(festival, beverageType);
-        } catch (e) {
-          errors[beverageType] = e.toString();
-          return <Drink>[];
-        }
-      }),
-    );
-
-    for (final drinks in results) {
-      allDrinks.addAll(drinks);
-    }
-
-    // If we got no drinks at all and there were errors, throw with details
-    if (allDrinks.isEmpty && errors.isNotEmpty) {
-      final errorDetails =
-          errors.entries.map((e) => '${e.key}: ${e.value}').join('\n');
-      throw BeerApiException(
-        'Failed to load any drinks. This may be a network or CORS issue.\n\nDetails:\n$errorDetails',
-      );
-    }
-
-    return allDrinks;
+    final result = await fetchDrinksByType(festival);
+    result.throwIfCompleteFailure();
+    return result.allDrinks;
   }
 
   /// Parses an API response body (the `{ "producers": [...] }` shape) into a
@@ -100,6 +109,38 @@ class BeerApiService {
 
   void dispose() {
     _client.close();
+  }
+}
+
+/// Per-beverage-type outcome of fetching a festival's drinks.
+///
+/// [drinksByType] holds the types that loaded successfully (a 404 counts as a
+/// successful empty result); [failedTypes] maps each errored type to a
+/// diagnostic string.
+class FestivalDrinksResult {
+  final Map<String, List<Drink>> drinksByType;
+  final Map<String, String> failedTypes;
+
+  const FestivalDrinksResult({
+    required this.drinksByType,
+    required this.failedTypes,
+  });
+
+  /// All successfully fetched drinks, flattened across beverage types.
+  List<Drink> get allDrinks =>
+      [for (final drinks in drinksByType.values) ...drinks];
+
+  /// True when every beverage type errored and nothing was fetched.
+  bool get isCompleteFailure => drinksByType.isEmpty && failedTypes.isNotEmpty;
+
+  /// Throws a [BeerApiException] describing the failures when nothing loaded.
+  void throwIfCompleteFailure() {
+    if (!isCompleteFailure) return;
+    final details =
+        failedTypes.entries.map((e) => '${e.key}: ${e.value}').join('\n');
+    throw BeerApiException(
+      'Failed to load any drinks. This may be a network or CORS issue.\n\nDetails:\n$details',
+    );
   }
 }
 

--- a/lib/services/beer_api_service.dart
+++ b/lib/services/beer_api_service.dart
@@ -24,7 +24,7 @@ class BeerApiService {
       // which causes "Rosé" to display as "RosÃ©" (mojibake)
       final jsonString = utf8.decode(response.bodyBytes);
       final data = json.decode(jsonString) as Map<String, dynamic>;
-      return _parseDrinks(data, festival.id);
+      return parseProducers(data, festival.id);
     } else if (response.statusCode == 404) {
       // Beverage type not available for this festival
       return [];
@@ -74,8 +74,13 @@ class BeerApiService {
     return allDrinks;
   }
 
-  /// Parses the API response into a list of Drink objects
-  List<Drink> _parseDrinks(Map<String, dynamic> data, String festivalId) {
+  /// Parses an API response body (the `{ "producers": [...] }` shape) into a
+  /// flat list of [Drink] objects for the given festival.
+  ///
+  /// Public and static so the local data cache can deserialize stored payloads
+  /// through the exact same logic used for live API responses.
+  static List<Drink> parseProducers(
+      Map<String, dynamic> data, String festivalId) {
     final drinks = <Drink>[];
     final producers = data['producers'] as List<dynamic>? ?? [];
 

--- a/lib/services/beer_api_service.dart
+++ b/lib/services/beer_api_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/models.dart';
@@ -12,8 +13,20 @@ class BeerApiService {
     this.timeout = const Duration(seconds: 30),
   }) : _client = client ?? http.Client();
 
-  /// Fetches all drinks from a festival for a specific beverage type
+  /// Fetches all drinks from a festival for a specific beverage type.
+  ///
+  /// Returns an empty list when the beverage type is not available (HTTP 404).
+  /// Callers that need to distinguish "no data" from "type not offered" (the
+  /// per-type cache) should use [fetchDrinksByType] instead.
   Future<List<Drink>> fetchDrinks(
+      Festival festival, String beverageType) async {
+    return (await _fetchDrinksOrNull(festival, beverageType)) ?? <Drink>[];
+  }
+
+  /// Returns the parsed drinks for one beverage type, or null when the API
+  /// responded 404 (meaning "not offered, or transiently unavailable").
+  /// Throws [BeerApiException] for non-200/404 statuses or other I/O errors.
+  Future<List<Drink>?> _fetchDrinksOrNull(
       Festival festival, String beverageType) async {
     final url = festival.getBeverageUrl(beverageType);
     final response = await _client.get(Uri.parse(url)).timeout(timeout);
@@ -26,43 +39,44 @@ class BeerApiService {
       final data = json.decode(jsonString) as Map<String, dynamic>;
       return parseProducers(data, festival.id);
     } else if (response.statusCode == 404) {
-      // Beverage type not available for this festival
-      return [];
-    } else {
-      throw BeerApiException(
-        'Failed to fetch $beverageType: ${response.statusCode}',
-        response.statusCode,
-      );
+      return null;
     }
+    throw BeerApiException(
+      'Failed to fetch $beverageType: ${response.statusCode}',
+      response.statusCode,
+    );
   }
 
   /// Fetches all beverage types in parallel, reporting per-type outcomes.
   ///
-  /// A type that loads (HTTP 200, or 404 → empty) appears in
-  /// [FestivalDrinksResult.drinksByType]; a type that errors (network, timeout,
-  /// 5xx, …) appears in [FestivalDrinksResult.failedTypes]. This lets callers
-  /// merge fresh data per type while preserving the last-good cache for types
-  /// that failed, instead of treating a partial fetch as a full snapshot.
+  /// A type that responded with HTTP 200 appears in
+  /// [FestivalDrinksResult.drinksByType]; a type that errored (network,
+  /// timeout, 5xx, …) appears in [FestivalDrinksResult.failedTypes]. A 404
+  /// is treated as a soft omission — it appears in NEITHER bucket — so the
+  /// per-type cache will preserve any previously-cached entry for that type
+  /// rather than overwriting it with empty on a transient 404 (e.g. mid-deploy).
   Future<FestivalDrinksResult> fetchDrinksByType(Festival festival) async {
     final entries = await Future.wait(
       festival.availableBeverageTypes.map((beverageType) async {
         try {
-          final drinks = await fetchDrinks(festival, beverageType);
+          final drinks = await _fetchDrinksOrNull(festival, beverageType);
+          // drinks == null → 404, omitted from result.
           return (type: beverageType, drinks: drinks, error: null);
         } catch (e) {
-          return (type: beverageType, drinks: null, error: e.toString());
+          return (type: beverageType, drinks: null, error: e);
         }
       }),
     );
 
     final drinksByType = <String, List<Drink>>{};
-    final failedTypes = <String, String>{};
+    final failedTypes = <String, Object>{};
     for (final entry in entries) {
       if (entry.drinks != null) {
         drinksByType[entry.type] = entry.drinks!;
-      } else {
+      } else if (entry.error != null) {
         failedTypes[entry.type] = entry.error!;
       }
+      // else: 404 — neither success nor failure, preserves cache.
     }
 
     return FestivalDrinksResult(
@@ -73,10 +87,10 @@ class BeerApiService {
 
   /// Fetches all available drinks from a festival (all beverage types).
   ///
-  /// Fetches all beverage types in parallel for faster loading.
-  /// Throws [BeerApiException] if ALL beverage types fail to load or return
-  /// no drinks. Individual failures are tracked and reported in the exception
-  /// message to help diagnose issues like CORS or network problems.
+  /// Throws [BeerApiException] if every beverage type errored. Types that
+  /// responded 404 contribute nothing and never trigger this throw on their
+  /// own — preserving the historical behaviour that an all-404 festival
+  /// returns an empty list rather than an error.
   Future<List<Drink>> fetchAllDrinks(Festival festival) async {
     final result = await fetchDrinksByType(festival);
     result.throwIfCompleteFailure();
@@ -114,12 +128,13 @@ class BeerApiService {
 
 /// Per-beverage-type outcome of fetching a festival's drinks.
 ///
-/// [drinksByType] holds the types that loaded successfully (a 404 counts as a
-/// successful empty result); [failedTypes] maps each errored type to a
-/// diagnostic string.
+/// [drinksByType] holds the types that loaded successfully (HTTP 200);
+/// [failedTypes] maps each errored type to the original error object so
+/// callers (and [throwIfCompleteFailure]) can inspect it for classification.
+/// 404s are deliberately omitted from both maps — see [BeerApiService.fetchDrinksByType].
 class FestivalDrinksResult {
   final Map<String, List<Drink>> drinksByType;
-  final Map<String, String> failedTypes;
+  final Map<String, Object> failedTypes;
 
   const FestivalDrinksResult({
     required this.drinksByType,
@@ -134,23 +149,54 @@ class FestivalDrinksResult {
   bool get isCompleteFailure => drinksByType.isEmpty && failedTypes.isNotEmpty;
 
   /// Throws a [BeerApiException] describing the failures when nothing loaded.
+  ///
+  /// When every underlying failure is a connectivity error, the thrown
+  /// exception carries one of them as [BeerApiException.cause] so the provider
+  /// can recognise the wrapped offline case and skip noisy analytics logging.
   void throwIfCompleteFailure() {
     if (!isCompleteFailure) return;
     final details =
         failedTypes.entries.map((e) => '${e.key}: ${e.value}').join('\n');
+    final allConnectivity = failedTypes.values.every(isConnectivityFailure);
     throw BeerApiException(
       'Failed to load any drinks. This may be a network or CORS issue.\n\nDetails:\n$details',
+      null,
+      allConnectivity ? failedTypes.values.first : null,
     );
   }
 }
 
-/// Exception thrown when API calls fail
+/// Exception thrown when API calls fail.
+///
+/// [cause] is the underlying error when this exception wraps one (e.g. a
+/// `SocketException`/`TimeoutException` aggregated from per-type failures),
+/// letting callers classify it without parsing strings.
 class BeerApiException implements Exception {
   final String message;
   final int? statusCode;
+  final Object? cause;
 
-  BeerApiException(this.message, [this.statusCode]);
+  BeerApiException(this.message, [this.statusCode, this.cause]);
 
   @override
   String toString() => 'BeerApiException: $message';
+}
+
+/// Whether [error] represents a connectivity failure (offline, timeout, DNS,
+/// TLS handshake) rather than a server-side or programming error.
+///
+/// Lives next to [BeerApiException] so that error classification and the
+/// per-type fetch logic share a single source of truth.
+bool isConnectivityFailure(Object error) {
+  if (error is http.ClientException || error is TimeoutException) return true;
+  // dart:io types aren't available on web; match by runtime type name to
+  // cover SocketException, HandshakeException, and HttpException without an
+  // unconditional dart:io import.
+  const connectivityTypeNames = {
+    'SocketException',
+    'HandshakeException',
+    'HttpException',
+    'TlsException',
+  };
+  return connectivityTypeNames.contains(error.runtimeType.toString());
 }

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -7,8 +7,18 @@ import 'festival_service.dart';
 /// Persists the last successfully fetched drinks per festival so the app can
 /// render immediately on launch (stale-while-revalidate) instead of blocking on
 /// the network.
+///
+/// Drinks are stored per beverage type so a refresh can update only the types
+/// that succeeded while keeping the last-good data for types that failed (e.g.
+/// a flaky `cider.json`), rather than overwriting a complete cache with a
+/// partial fetch.
+///
+/// Backed by [SharedPreferences] to match the app's other local storage and to
+/// work on web; this trades off ideal large-blob handling for simplicity, so a
+/// small number of festival snapshots are retained ([_maxCachedFestivals]).
 class DrinkCacheService {
   static const _keyPrefix = 'drinks_cache';
+  static const _maxCachedFestivals = 12;
 
   final SharedPreferences _prefs;
 
@@ -16,18 +26,71 @@ class DrinkCacheService {
 
   String _key(String festivalId) => '${_keyPrefix}_$festivalId';
 
-  /// Store the given drinks for a festival, serialized in the same
-  /// `{ "producers": [...] }` shape the API returns so reads can reuse
-  /// [BeerApiService.parseProducers].
-  Future<void> save(String festivalId, List<Drink> drinks) async {
+  /// Read cached drinks for a festival, or null if nothing usable is stored.
+  ///
+  /// Returns null on absent, empty, or corrupt data so callers can fall back to
+  /// a network fetch.
+  List<Drink>? read(String festivalId) {
+    final types = _readRawTypes(festivalId);
+    if (types == null) return null;
+    final drinks = _flatten(types, festivalId);
+    return drinks.isEmpty ? null : drinks;
+  }
+
+  /// Merge freshly fetched beverage types over the cached snapshot, preserving
+  /// any cached types not present in [freshByType].
+  ///
+  /// Returns the merged drinks immediately (computed in memory); the updated
+  /// cache is written in the background. Callers that must observe the write
+  /// (e.g. tests) can await [DrinkCacheUpdate.written]; the app intentionally
+  /// does not, to keep persistence off the load critical path.
+  DrinkCacheUpdate merge(
+      String festivalId, Map<String, List<Drink>> freshByType) {
+    final types = Map<String, dynamic>.from(_readRawTypes(festivalId) ?? {});
+    freshByType.forEach((type, drinks) {
+      types[type] = _producersJson(drinks);
+    });
+    final written = _persistTypes(festivalId, types);
+    return DrinkCacheUpdate(_flatten(types, festivalId), written);
+  }
+
+  /// Remove cached drinks for a festival.
+  Future<void> clear(String festivalId) async {
+    await _prefs.remove(_key(festivalId));
+  }
+
+  Map<String, dynamic>? _readRawTypes(String festivalId) {
+    final raw = _prefs.getString(_key(festivalId));
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final data = json.decode(raw) as Map<String, dynamic>;
+      final types = data['beverageTypes'];
+      if (types is Map) return Map<String, dynamic>.from(types);
+      return null;
+    } catch (_) {
+      // Corrupt or unexpected payload — treat as a cache miss.
+      return null;
+    }
+  }
+
+  List<Drink> _flatten(Map<String, dynamic> types, String festivalId) {
+    final drinks = <Drink>[];
+    for (final producers in types.values) {
+      drinks.addAll(
+        BeerApiService.parseProducers({'producers': producers}, festivalId),
+      );
+    }
+    return drinks;
+  }
+
+  List<Map<String, dynamic>> _producersJson(List<Drink> drinks) {
     final byProducerId = <String, List<Drink>>{};
     for (final drink in drinks) {
       byProducerId.putIfAbsent(drink.producer.id, () => []).add(drink);
     }
-
-    final producers = byProducerId.values.map((group) {
+    return byProducerId.values.map((group) {
       final producer = group.first.producer;
-      return {
+      return <String, dynamic>{
         'id': producer.id,
         'name': producer.name,
         'location': producer.location,
@@ -36,37 +99,49 @@ class DrinkCacheService {
         'products': group.map((d) => d.product.toJson()).toList(),
       };
     }).toList();
+  }
 
+  Future<void> _persistTypes(
+      String festivalId, Map<String, dynamic> types) async {
     final payload = {
       'timestamp': DateTime.now().millisecondsSinceEpoch,
-      'producers': producers,
+      'beverageTypes': types,
     };
-
     await _prefs.setString(_key(festivalId), json.encode(payload));
+    await _evictOldCaches();
   }
 
-  /// Read cached drinks for a festival, or null if nothing usable is stored.
-  ///
-  /// Returns null on absent, empty, or corrupt data so callers can fall back to
-  /// a network fetch.
-  List<Drink>? read(String festivalId) {
-    final raw = _prefs.getString(_key(festivalId));
-    if (raw == null || raw.isEmpty) return null;
+  /// Drop the oldest festival snapshots once more than [_maxCachedFestivals]
+  /// are stored, so the cache cannot grow without bound across festivals.
+  Future<void> _evictOldCaches() async {
+    final keys =
+        _prefs.getKeys().where((k) => k.startsWith('${_keyPrefix}_')).toList();
+    if (keys.length <= _maxCachedFestivals) return;
 
-    try {
-      final data = json.decode(raw) as Map<String, dynamic>;
-      final drinks = BeerApiService.parseProducers(data, festivalId);
-      return drinks.isEmpty ? null : drinks;
-    } catch (_) {
-      // Corrupt or unexpected payload — treat as a cache miss.
-      return null;
+    int timestampOf(String key) {
+      try {
+        final data =
+            json.decode(_prefs.getString(key)!) as Map<String, dynamic>;
+        return data['timestamp'] as int? ?? 0;
+      } catch (_) {
+        return 0;
+      }
+    }
+
+    keys.sort((a, b) => timestampOf(a).compareTo(timestampOf(b)));
+    for (final key in keys.take(keys.length - _maxCachedFestivals)) {
+      await _prefs.remove(key);
     }
   }
+}
 
-  /// Remove cached drinks for a festival.
-  Future<void> clear(String festivalId) async {
-    await _prefs.remove(_key(festivalId));
-  }
+/// Result of [DrinkCacheService.merge]: the merged drinks plus a future that
+/// completes when the background cache write finishes.
+class DrinkCacheUpdate {
+  final List<Drink> drinks;
+  final Future<void> written;
+
+  const DrinkCacheUpdate(this.drinks, this.written);
 }
 
 /// Persists the last successfully fetched festival registry so the festival

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/models.dart';
+import 'beer_api_service.dart';
+import 'festival_service.dart';
+
+/// Persists the last successfully fetched drinks per festival so the app can
+/// render immediately on launch (stale-while-revalidate) instead of blocking on
+/// the network.
+class DrinkCacheService {
+  static const _keyPrefix = 'drinks_cache';
+
+  final SharedPreferences _prefs;
+
+  DrinkCacheService(this._prefs);
+
+  String _key(String festivalId) => '${_keyPrefix}_$festivalId';
+
+  /// Store the given drinks for a festival, serialized in the same
+  /// `{ "producers": [...] }` shape the API returns so reads can reuse
+  /// [BeerApiService.parseProducers].
+  Future<void> save(String festivalId, List<Drink> drinks) async {
+    final byProducerId = <String, List<Drink>>{};
+    for (final drink in drinks) {
+      byProducerId.putIfAbsent(drink.producer.id, () => []).add(drink);
+    }
+
+    final producers = byProducerId.values.map((group) {
+      final producer = group.first.producer;
+      return {
+        'id': producer.id,
+        'name': producer.name,
+        'location': producer.location,
+        if (producer.yearFounded != null) 'year_founded': producer.yearFounded,
+        if (producer.notes != null) 'notes': producer.notes,
+        'products': group.map((d) => d.product.toJson()).toList(),
+      };
+    }).toList();
+
+    final payload = {
+      'timestamp': DateTime.now().millisecondsSinceEpoch,
+      'producers': producers,
+    };
+
+    await _prefs.setString(_key(festivalId), json.encode(payload));
+  }
+
+  /// Read cached drinks for a festival, or null if nothing usable is stored.
+  ///
+  /// Returns null on absent, empty, or corrupt data so callers can fall back to
+  /// a network fetch.
+  List<Drink>? read(String festivalId) {
+    final raw = _prefs.getString(_key(festivalId));
+    if (raw == null || raw.isEmpty) return null;
+
+    try {
+      final data = json.decode(raw) as Map<String, dynamic>;
+      final drinks = BeerApiService.parseProducers(data, festivalId);
+      return drinks.isEmpty ? null : drinks;
+    } catch (_) {
+      // Corrupt or unexpected payload — treat as a cache miss.
+      return null;
+    }
+  }
+
+  /// Remove cached drinks for a festival.
+  Future<void> clear(String festivalId) async {
+    await _prefs.remove(_key(festivalId));
+  }
+}
+
+/// Persists the last successfully fetched festival registry so the festival
+/// switcher and a saved festival selection work offline at startup.
+class FestivalCacheService {
+  static const _key = 'festivals_cache';
+
+  final SharedPreferences _prefs;
+
+  FestivalCacheService(this._prefs);
+
+  /// Store the festivals response. Festival URLs are already absolute at this
+  /// point, so [FestivalsResponse.fromJson]'s relative-URL resolution is a
+  /// no-op when reading back.
+  Future<void> save(FestivalsResponse response) async {
+    final payload = {
+      'timestamp': DateTime.now().millisecondsSinceEpoch,
+      'base_url': response.baseUrl,
+      'version': response.version,
+      if (response.lastUpdated != null)
+        'last_updated': response.lastUpdated!.toIso8601String(),
+      'default_festival_id': response.defaultFestivalId,
+      'festivals': response.festivals.map((f) => f.toJson()).toList(),
+    };
+
+    await _prefs.setString(_key, json.encode(payload));
+  }
+
+  /// Read the cached festivals response, or null if nothing usable is stored.
+  FestivalsResponse? read() {
+    final raw = _prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return null;
+
+    try {
+      final data = json.decode(raw) as Map<String, dynamic>;
+      final baseUrl = (data['base_url'] as String?) ?? '';
+      final response = FestivalsResponse.fromJson(data, baseUrl);
+      return response.festivals.isEmpty ? null : response;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Remove the cached festivals response.
+  Future<void> clear() async {
+    await _prefs.remove(_key);
+  }
+}

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -65,8 +65,15 @@ class DrinkCacheService {
     try {
       final data = json.decode(raw) as Map<String, dynamic>;
       final types = data['beverageTypes'];
-      if (types is Map) return Map<String, dynamic>.from(types);
-      return null;
+      if (types is! Map) return null;
+      // Drop any entry whose value isn't a producers list — corrupt or
+      // partially-migrated payloads should degrade to a miss for that type
+      // rather than crash later in _flatten/parseProducers.
+      final clean = <String, dynamic>{};
+      for (final entry in types.entries) {
+        if (entry.value is List) clean[entry.key.toString()] = entry.value;
+      }
+      return clean;
     } catch (_) {
       // Corrupt or unexpected payload — treat as a cache miss.
       return null;
@@ -76,9 +83,14 @@ class DrinkCacheService {
   List<Drink> _flatten(Map<String, dynamic> types, String festivalId) {
     final drinks = <Drink>[];
     for (final producers in types.values) {
-      drinks.addAll(
-        BeerApiService.parseProducers({'producers': producers}, festivalId),
-      );
+      try {
+        drinks.addAll(
+          BeerApiService.parseProducers({'producers': producers}, festivalId),
+        );
+      } catch (_) {
+        // Skip a beverage type whose payload fails to parse rather than
+        // failing the whole read — the next successful refresh will fix it.
+      }
     }
     return drinks;
   }

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -131,9 +131,12 @@ class DrinkCacheService {
     if (keys.length <= _maxCachedFestivals) return;
 
     int timestampOf(String key) {
+      // Guard against a concurrent removal between getKeys() above and this
+      // read: the key may have vanished, so treat it as the oldest possible.
+      final raw = _prefs.getString(key);
+      if (raw == null) return 0;
       try {
-        final data =
-            json.decode(_prefs.getString(key)!) as Map<String, dynamic>;
+        final data = json.decode(raw) as Map<String, dynamic>;
         return data['timestamp'] as int? ?? 0;
       } catch (_) {
         return 0;

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -1,5 +1,6 @@
 export 'analytics_service.dart';
 export 'beer_api_service.dart';
+export 'cache_service.dart';
 export 'environment_service.dart';
 export 'festival_service.dart';
 export 'storage_service.dart';

--- a/mise-tasks/analyze.sh
+++ b/mise-tasks/analyze.sh
@@ -5,9 +5,9 @@
 set -uo pipefail
 ANALYZE_LOG="${ANALYZE_LOG:-$(mktemp /tmp/analyze-XXXXXX.log)}"
 echo "ANALYZE_LOG=$ANALYZE_LOG"
-flutter analyze --no-fatal-infos "$@" 2>&1 \
-	| grep -v -E "Woah! You appear|superuser privileges" \
-	| tee "$ANALYZE_LOG"
+flutter analyze --no-fatal-infos "$@" 2>&1 |
+	grep -v -E "Woah! You appear|superuser privileges" |
+	tee "$ANALYZE_LOG"
 EXIT_CODE=${PIPESTATUS[0]}
 echo "---"
 echo "Grep with: grep -n 'error\|warning' $ANALYZE_LOG"

--- a/mise-tasks/test.sh
+++ b/mise-tasks/test.sh
@@ -5,9 +5,9 @@
 set -uo pipefail
 TEST_LOG="${TEST_LOG:-$(mktemp /tmp/test-XXXXXX.log)}"
 echo "TEST_LOG=$TEST_LOG"
-flutter test "$@" 2>&1 \
-	| grep -v -E "Woah! You appear|superuser privileges" \
-	| tee "$TEST_LOG"
+flutter test "$@" 2>&1 |
+	grep -v -E "Woah! You appear|superuser privileges" |
+	tee "$TEST_LOG"
 EXIT_CODE=${PIPESTATUS[0]}
 echo "---"
 echo "Grep with: grep -n 'FAILED\|ERROR' $TEST_LOG"

--- a/mise.lock
+++ b/mise.lock
@@ -49,6 +49,7 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellchec
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.aarch64.tar.xz"
 
 [tools.shellcheck."platforms.linux-x64"]
+checksum = "blake3:2a6377cc08f05029b0e91d05a63a707ff5919e607bc362588538737e201d9ba4"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz"
 
 [tools.shellcheck."platforms.linux-x64-musl"]

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,7 @@ _.path = ["./bin"]
 
 [tools]
 flutter = "3.38.3"
-node = "22"        # For http_server and Playwright e2e tests
+node = "22"          # For http_server and Playwright e2e tests
 shellcheck = "0.9.0"
 shfmt = "3.8.0"
 

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -1996,6 +1996,36 @@ void main() {
             reason: anyNamed('reason')));
       });
 
+      test('does not log when BeerApiException wraps a connectivity cause',
+          () async {
+        // When every beverage type fails offline, the repository throws a
+        // BeerApiException whose `cause` carries one of the underlying network
+        // errors. _isConnectivityError must unwrap it so analytics stays quiet
+        // for the offline-with-cache case (not just the raw TimeoutException).
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        when(mockDrinkRepository.getDrinks(any)).thenThrow(
+          BeerApiException(
+            'Failed to load any drinks...',
+            null,
+            TimeoutException('offline'),
+          ),
+        );
+
+        await provider.loadDrinks();
+
+        expect(provider.refreshNotice, isNotNull);
+        verifyNever(mockAnalyticsService.logError(any, any,
+            reason: anyNamed('reason')));
+      });
+
       test('shows error when refresh fails and there is no cache', () async {
         provider = BeerProvider(
           drinkRepository: mockDrinkRepository,

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -1866,6 +1866,101 @@ void main() {
         expect(provider.allDrinks, isNotEmpty);
       });
 
+      test('refreshIfStale skips a duplicate fetch while SWR refresh in flight',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        // Cache renders instantly; the network refresh hangs so isRefreshing
+        // stays true while we attempt a resume-triggered refreshIfStale.
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        final pending = Completer<List<Drink>>();
+        when(mockDrinkRepository.getDrinks(any))
+            .thenAnswer((_) => pending.future);
+
+        final firstLoad = provider.loadDrinks();
+        await Future<void>.delayed(Duration.zero);
+        expect(provider.isRefreshing, isTrue);
+
+        // refreshIfStale while a refresh is mid-flight must not kick a second
+        // getDrinks call — _isRefreshing guards against the duplicate.
+        await provider.refreshIfStale();
+        verify(mockDrinkRepository.getDrinks(any)).called(1);
+
+        pending.complete(createSampleDrinks());
+        await firstLoad;
+      });
+
+      test('setFestival on the current festival retries when a notice is up',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        // Get into the "showing saved data" state.
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        when(mockDrinkRepository.getDrinks(any))
+            .thenThrow(TimeoutException('offline'));
+        await provider.loadDrinks();
+        expect(provider.refreshNotice, isNotNull);
+        clearInteractions(mockDrinkRepository);
+
+        // Re-tapping the current festival in the switcher must fire a retry.
+        when(mockDrinkRepository.getDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        await provider.setFestival(provider.currentFestival);
+
+        verify(mockDrinkRepository.getDrinks(any)).called(1);
+        expect(provider.refreshNotice, isNull);
+      });
+
+      test(
+          'initialize ignores a retired saved festival id rather than '
+          'resurrecting it from DefaultFestivals', () async {
+        // Saved id matches an active DefaultFestival but no longer exists in
+        // the live registry; the user should land on the registry default,
+        // not on a defunct hard-coded festival whose URL would 404.
+        final retired = DefaultFestivals.all.first;
+        SharedPreferences.setMockInitialValues({
+          'selected_festival_id': retired.id,
+        });
+        final liveFestival = Festival(
+          id: '${retired.id}-successor',
+          name: 'Successor Festival',
+          dataBaseUrl: 'https://example.com/successor',
+        );
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: [liveFestival],
+            defaultFestivalId: liveFestival.id,
+            baseUrl: 'https://example.com',
+            version: '1.0.0',
+          ),
+        );
+        when(mockFestivalRepository.getSelectedFestivalId())
+            .thenAnswer((_) async => retired.id);
+        when(mockFestivalRepository.getCachedFestivals())
+            .thenAnswer((_) async => null);
+
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        expect(provider.currentFestival.id, liveFestival.id);
+      });
+
       test('toggleFavorite re-applies filters when showing favourites only',
           () async {
         provider = BeerProvider(

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -2086,6 +2086,116 @@ void main() {
         provider.dismissRefreshNotice();
         expect(provider.refreshNotice, isNull);
       });
+
+      test('setFestival shows the target festival cached drinks immediately',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        final other = DefaultFestivals.all
+            .firstWhere((f) => f.id != provider.currentFestival.id);
+
+        // Cached drinks available for the new festival; the network refresh
+        // hangs so only the cache path has resolved when we assert.
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        final pending = Completer<List<Drink>>();
+        when(mockDrinkRepository.getDrinks(any))
+            .thenAnswer((_) => pending.future);
+
+        final future = provider.setFestival(other);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(provider.currentFestival.id, other.id);
+        expect(provider.drinks, isNotEmpty); // cached drinks shown
+        expect(provider.isLoading, isFalse); // no blank spinner
+        expect(provider.isRefreshing, isTrue); // background refresh running
+
+        pending.complete(createSampleDrinks());
+        await future;
+        expect(provider.isRefreshing, isFalse);
+      });
+
+      test('setFestival shows a spinner when the target has no cache',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        final other = DefaultFestivals.all
+            .firstWhere((f) => f.id != provider.currentFestival.id);
+
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => null);
+        final pending = Completer<List<Drink>>();
+        when(mockDrinkRepository.getDrinks(any))
+            .thenAnswer((_) => pending.future);
+
+        final future = provider.setFestival(other);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(provider.drinks, isEmpty);
+        expect(provider.isLoading, isTrue); // spinner until network resolves
+
+        pending.complete(createSampleDrinks());
+        await future;
+        expect(provider.isLoading, isFalse);
+        expect(provider.drinks, isNotEmpty);
+      });
+
+      test('loadFestivals falls back to cached festivals when network fails',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        when(mockFestivalRepository.getFestivals())
+            .thenThrow(FestivalServiceException('boom', 500));
+        when(mockFestivalRepository.getCachedFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: [DefaultFestivals.cambridge2025],
+            defaultFestivalId: DefaultFestivals.cambridge2025.id,
+            version: '1.0',
+            baseUrl: 'https://data.cambeerfestival.app',
+          ),
+        );
+
+        await provider.loadFestivals();
+
+        // Switcher keeps working from cache; no error surfaced.
+        expect(provider.festivals, isNotEmpty);
+        expect(provider.festivalsError, isNull);
+      });
+
+      test('loadFestivals surfaces an error when network fails and no cache',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        when(mockFestivalRepository.getFestivals())
+            .thenThrow(FestivalServiceException('boom', 500));
+        when(mockFestivalRepository.getCachedFestivals())
+            .thenAnswer((_) async => null);
+
+        await provider.loadFestivals();
+
+        expect(provider.festivals, isEmpty);
+        expect(provider.festivalsError, isNotNull);
+      });
     });
   });
 }

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cambridge_beer_festival/providers/beer_provider.dart';
 import 'package:cambridge_beer_festival/services/services.dart';
@@ -1924,6 +1926,165 @@ void main() {
         await provider.loadDrinks();
 
         expect(provider.lastDrinksRefresh, isNotNull);
+      });
+    });
+
+    group('stale-while-revalidate', () {
+      test('shows cached drinks and surfaces a notice when refresh fails',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        when(mockDrinkRepository.getDrinks(any))
+            .thenThrow(BeerApiException('boom', 500));
+
+        await provider.loadDrinks();
+
+        // Cached data stays on screen; no blocking error, just a quiet notice.
+        expect(provider.drinks, isNotEmpty);
+        expect(provider.error, isNull);
+        expect(provider.refreshNotice, isNotNull);
+        expect(provider.isRefreshing, isFalse);
+      });
+
+      test('logs non-connectivity refresh failures even with cached data',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        final error = BeerApiException('server', 500);
+        when(mockDrinkRepository.getDrinks(any)).thenThrow(error);
+
+        await provider.loadDrinks();
+
+        // A server/parse error is a real bug that the cache would otherwise
+        // mask, so it must still be logged (catches "silent never-load").
+        verify(mockAnalyticsService.logError(error, any,
+                reason: anyNamed('reason')))
+            .called(1);
+      });
+
+      test('does not log offline refresh failures covered by cache', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        when(mockDrinkRepository.getDrinks(any))
+            .thenThrow(TimeoutException('offline'));
+
+        await provider.loadDrinks();
+
+        expect(provider.refreshNotice, isNotNull);
+        verifyNever(mockAnalyticsService.logError(any, any,
+            reason: anyNamed('reason')));
+      });
+
+      test('shows error when refresh fails and there is no cache', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => null);
+        final error = TimeoutException('offline');
+        when(mockDrinkRepository.getDrinks(any)).thenThrow(error);
+
+        await provider.loadDrinks();
+
+        expect(provider.drinks, isEmpty);
+        expect(provider.error, isNotNull);
+        expect(provider.refreshNotice, isNull);
+        // Fully blocked loads are always logged, even when offline.
+        verify(mockAnalyticsService.logError(error, any,
+                reason: anyNamed('reason')))
+            .called(1);
+      });
+
+      test('successful refresh clears the notice and updates drinks', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        // First load shows cache then fails refresh -> notice set.
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        when(mockDrinkRepository.getDrinks(any))
+            .thenThrow(TimeoutException('offline'));
+        await provider.loadDrinks();
+        expect(provider.refreshNotice, isNotNull);
+
+        // Second load succeeds -> notice cleared, drinks refreshed.
+        when(mockDrinkRepository.getDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        await provider.loadDrinks();
+
+        expect(provider.refreshNotice, isNull);
+        expect(provider.error, isNull);
+        expect(provider.drinks, isNotEmpty);
+      });
+
+      test('initialize populates festivals from cache without a network call',
+          () async {
+        when(mockFestivalRepository.getCachedFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: [DefaultFestivals.cambridge2025],
+            defaultFestivalId: DefaultFestivals.cambridge2025.id,
+            version: '1.0',
+            baseUrl: 'https://data.cambeerfestival.app',
+          ),
+        );
+
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        expect(provider.festivals, isNotEmpty);
+        // Background refresh fires, but the cache populated the list first.
+      });
+
+      test('dismissRefreshNotice clears the notice', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        when(mockDrinkRepository.getDrinks(any))
+            .thenThrow(TimeoutException('offline'));
+        await provider.loadDrinks();
+        expect(provider.refreshNotice, isNotNull);
+
+        provider.dismissRefreshNotice();
+        expect(provider.refreshNotice, isNull);
       });
     });
   });

--- a/test/cache_service_test.dart
+++ b/test/cache_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:cambridge_beer_festival/models/models.dart';
 import 'package:cambridge_beer_festival/services/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -137,6 +139,41 @@ void main() {
       final corruptCache = DrinkCacheService(prefs);
 
       expect(corruptCache.read('cbf2025'), isNull);
+    });
+
+    test('drops a beverage type whose producers value is not a list', () async {
+      // Decodable JSON but the per-type payload is malformed (e.g. a partial
+      // migration left a string where a producers list belongs). Reading must
+      // degrade to the well-formed entries instead of throwing.
+      final goodProducer = {
+        'id': 'b1',
+        'name': 'Producer b1',
+        'location': 'Cambridge',
+        'products': [
+          {
+            'id': 'p1',
+            'name': 'Good',
+            'category': 'beer',
+            'dispense': 'cask',
+            'abv': '5.5',
+          },
+        ],
+      };
+      SharedPreferences.setMockInitialValues({
+        'drinks_cache_cbf2025': json.encode({
+          'timestamp': 1,
+          'beverageTypes': {
+            'beer': [goodProducer],
+            'cider': 'oops not a list',
+          },
+        }),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final corruptCache = DrinkCacheService(prefs);
+
+      final read = corruptCache.read('cbf2025');
+      expect(read, isNotNull);
+      expect(read!.single.id, 'p1');
     });
 
     test('clear removes cached drinks', () async {

--- a/test/cache_service_test.dart
+++ b/test/cache_service_test.dart
@@ -8,6 +8,7 @@ void main() {
     String producerId,
     String productId, {
     String name = 'Test Drink',
+    String category = 'beer',
     Map<String, int> allergens = const {},
     bool? isVegan,
   }) =>
@@ -15,7 +16,7 @@ void main() {
         product: Product(
           id: productId,
           name: name,
-          category: 'beer',
+          category: category,
           style: 'IPA',
           dispense: 'cask',
           abv: 5.5,
@@ -41,18 +42,29 @@ void main() {
       cache = DrinkCacheService(prefs);
     });
 
+    Future<void> store(String festivalId, Map<String, List<Drink>> byType) =>
+        cache.merge(festivalId, byType).written;
+
     test('returns null when nothing is cached', () {
       expect(cache.read('cbf2025'), isNull);
     });
 
-    test('round-trips drinks across multiple producers', () async {
-      final drinks = [
-        makeDrink('b1', 'p1', name: 'Alpha'),
-        makeDrink('b1', 'p2', name: 'Beta'),
-        makeDrink('b2', 'p3', name: 'Gamma'),
-      ];
+    test('merge returns the merged drinks synchronously', () {
+      final update = cache.merge('cbf2025', {
+        'beer': [makeDrink('b1', 'p1'), makeDrink('b2', 'p2')],
+      });
 
-      await cache.save('cbf2025', drinks);
+      expect(update.drinks.map((d) => d.id), containsAll(['p1', 'p2']));
+    });
+
+    test('round-trips drinks across multiple producers', () async {
+      await store('cbf2025', {
+        'beer': [
+          makeDrink('b1', 'p1', name: 'Alpha'),
+          makeDrink('b1', 'p2', name: 'Beta'),
+          makeDrink('b2', 'p3', name: 'Gamma'),
+        ],
+      });
       final read = cache.read('cbf2025');
 
       expect(read, isNotNull);
@@ -66,17 +78,18 @@ void main() {
     });
 
     test('preserves allergens, vegan flag and unicode names', () async {
-      final drinks = [
-        makeDrink(
-          'b1',
-          'p1',
-          name: 'Rosé Cider',
-          allergens: const {'gluten': 1, 'sulphites': 0},
-          isVegan: true,
-        ),
-      ];
-
-      await cache.save('cbf2025', drinks);
+      await store('cbf2025', {
+        'cider': [
+          makeDrink(
+            'b1',
+            'p1',
+            name: 'Rosé Cider',
+            category: 'cider',
+            allergens: const {'gluten': 1, 'sulphites': 0},
+            isVegan: true,
+          ),
+        ],
+      });
       final read = cache.read('cbf2025')!;
 
       expect(read.single.name, 'Rosé Cider');
@@ -85,15 +98,34 @@ void main() {
       expect(read.single.producer.yearFounded, 1990);
     });
 
+    test('merge preserves beverage types that are not refreshed', () async {
+      await store('cbf2025', {
+        'beer': [makeDrink('b1', 'beer-1', category: 'beer')],
+        'cider': [makeDrink('c1', 'cider-1', category: 'cider')],
+      });
+
+      // Refresh only beer; cider should be retained from the previous snapshot.
+      await store('cbf2025', {
+        'beer': [makeDrink('b1', 'beer-2', category: 'beer')],
+      });
+
+      final read = cache.read('cbf2025')!;
+      final ids = read.map((d) => d.id).toSet();
+      expect(ids, containsAll(['beer-2', 'cider-1']));
+      expect(ids.contains('beer-1'), isFalse);
+    });
+
     test('is scoped per festival', () async {
-      await cache.save('cbf2025', [makeDrink('b1', 'p1')]);
+      await store('cbf2025', {
+        'beer': [makeDrink('b1', 'p1')],
+      });
 
       expect(cache.read('cbf2025'), isNotNull);
       expect(cache.read('cbf2024'), isNull);
     });
 
     test('returns null for an empty drink list', () async {
-      await cache.save('cbf2025', []);
+      await store('cbf2025', {'beer': []});
       expect(cache.read('cbf2025'), isNull);
     });
 
@@ -108,10 +140,24 @@ void main() {
     });
 
     test('clear removes cached drinks', () async {
-      await cache.save('cbf2025', [makeDrink('b1', 'p1')]);
+      await store('cbf2025', {
+        'beer': [makeDrink('b1', 'p1')],
+      });
       await cache.clear('cbf2025');
 
       expect(cache.read('cbf2025'), isNull);
+    });
+
+    test('evicts the oldest festival snapshots beyond the cap', () async {
+      // Cap is 12; create 13 festival snapshots, the oldest should be dropped.
+      for (var i = 0; i < 13; i++) {
+        await store('cbf$i', {
+          'beer': [makeDrink('b$i', 'p$i')],
+        });
+      }
+
+      expect(cache.read('cbf0'), isNull); // oldest evicted
+      expect(cache.read('cbf12'), isNotNull); // newest retained
     });
   });
 

--- a/test/cache_service_test.dart
+++ b/test/cache_service_test.dart
@@ -187,10 +187,15 @@ void main() {
 
     test('evicts the oldest festival snapshots beyond the cap', () async {
       // Cap is 12; create 13 festival snapshots, the oldest should be dropped.
+      // Eviction sorts by stored timestamp (millis-since-epoch); on a fast
+      // machine multiple stores can land in the same millisecond, making the
+      // "oldest" order ambiguous and the assertion flaky. Yield 2ms between
+      // writes so each snapshot is guaranteed a distinct timestamp.
       for (var i = 0; i < 13; i++) {
         await store('cbf$i', {
           'beer': [makeDrink('b$i', 'p$i')],
         });
+        await Future<void>.delayed(const Duration(milliseconds: 2));
       }
 
       expect(cache.read('cbf0'), isNull); // oldest evicted

--- a/test/cache_service_test.dart
+++ b/test/cache_service_test.dart
@@ -1,0 +1,186 @@
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:cambridge_beer_festival/services/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  Drink makeDrink(
+    String producerId,
+    String productId, {
+    String name = 'Test Drink',
+    Map<String, int> allergens = const {},
+    bool? isVegan,
+  }) =>
+      Drink(
+        product: Product(
+          id: productId,
+          name: name,
+          category: 'beer',
+          style: 'IPA',
+          dispense: 'cask',
+          abv: 5.5,
+          allergens: allergens,
+          isVegan: isVegan,
+        ),
+        producer: Producer(
+          id: producerId,
+          name: 'Producer $producerId',
+          location: 'Cambridge',
+          yearFounded: 1990,
+          products: const [],
+        ),
+        festivalId: 'cbf2025',
+      );
+
+  group('DrinkCacheService', () {
+    late DrinkCacheService cache;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      cache = DrinkCacheService(prefs);
+    });
+
+    test('returns null when nothing is cached', () {
+      expect(cache.read('cbf2025'), isNull);
+    });
+
+    test('round-trips drinks across multiple producers', () async {
+      final drinks = [
+        makeDrink('b1', 'p1', name: 'Alpha'),
+        makeDrink('b1', 'p2', name: 'Beta'),
+        makeDrink('b2', 'p3', name: 'Gamma'),
+      ];
+
+      await cache.save('cbf2025', drinks);
+      final read = cache.read('cbf2025');
+
+      expect(read, isNotNull);
+      expect(read!.length, 3);
+      final byId = {for (final d in read) d.id: d};
+      expect(byId['p1']!.name, 'Alpha');
+      expect(byId['p1']!.producer.id, 'b1');
+      expect(byId['p3']!.producer.id, 'b2');
+      expect(byId['p1']!.abv, 5.5);
+      expect(byId['p1']!.style, 'IPA');
+    });
+
+    test('preserves allergens, vegan flag and unicode names', () async {
+      final drinks = [
+        makeDrink(
+          'b1',
+          'p1',
+          name: 'Rosé Cider',
+          allergens: const {'gluten': 1, 'sulphites': 0},
+          isVegan: true,
+        ),
+      ];
+
+      await cache.save('cbf2025', drinks);
+      final read = cache.read('cbf2025')!;
+
+      expect(read.single.name, 'Rosé Cider');
+      expect(read.single.allergens['gluten'], 1);
+      expect(read.single.isVegan, isTrue);
+      expect(read.single.producer.yearFounded, 1990);
+    });
+
+    test('is scoped per festival', () async {
+      await cache.save('cbf2025', [makeDrink('b1', 'p1')]);
+
+      expect(cache.read('cbf2025'), isNotNull);
+      expect(cache.read('cbf2024'), isNull);
+    });
+
+    test('returns null for an empty drink list', () async {
+      await cache.save('cbf2025', []);
+      expect(cache.read('cbf2025'), isNull);
+    });
+
+    test('returns null for corrupt cached data', () async {
+      SharedPreferences.setMockInitialValues({
+        'drinks_cache_cbf2025': 'not valid json {',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final corruptCache = DrinkCacheService(prefs);
+
+      expect(corruptCache.read('cbf2025'), isNull);
+    });
+
+    test('clear removes cached drinks', () async {
+      await cache.save('cbf2025', [makeDrink('b1', 'p1')]);
+      await cache.clear('cbf2025');
+
+      expect(cache.read('cbf2025'), isNull);
+    });
+  });
+
+  group('FestivalCacheService', () {
+    late FestivalCacheService cache;
+
+    FestivalsResponse makeResponse() => FestivalsResponse.fromJson(
+          {
+            'festivals': [
+              {
+                'id': 'cbf2025',
+                'name': 'Cambridge Beer Festival 2025',
+                'data_base_url': 'https://example.com/cbf2025',
+                'is_active': true,
+                'available_beverage_types': ['beer', 'cider'],
+              },
+              {
+                'id': 'cbf2024',
+                'name': 'Cambridge Beer Festival 2024',
+                'data_base_url': 'https://example.com/cbf2024',
+              },
+            ],
+            'default_festival_id': 'cbf2025',
+            'version': '2.0.0',
+          },
+          'https://example.com',
+        );
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      cache = FestivalCacheService(prefs);
+    });
+
+    test('returns null when nothing is cached', () {
+      expect(cache.read(), isNull);
+    });
+
+    test('round-trips the festivals response', () async {
+      await cache.save(makeResponse());
+      final read = cache.read();
+
+      expect(read, isNotNull);
+      expect(read!.festivals.length, 2);
+      expect(read.defaultFestivalId, 'cbf2025');
+      expect(read.version, '2.0.0');
+
+      final cbf2025 = read.festivals.firstWhere((f) => f.id == 'cbf2025');
+      expect(cbf2025.dataBaseUrl, 'https://example.com/cbf2025');
+      expect(cbf2025.isActive, isTrue);
+      expect(cbf2025.availableBeverageTypes, ['beer', 'cider']);
+      expect(read.defaultFestival?.id, 'cbf2025');
+    });
+
+    test('returns null for corrupt cached data', () async {
+      SharedPreferences.setMockInitialValues({
+        'festivals_cache': '}{ broken',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final corruptCache = FestivalCacheService(prefs);
+
+      expect(corruptCache.read(), isNull);
+    });
+
+    test('clear removes the cached response', () async {
+      await cache.save(makeResponse());
+      await cache.clear();
+
+      expect(cache.read(), isNull);
+    });
+  });
+}

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -8,7 +8,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'api_drink_repository_test.mocks.dart';
 
-@GenerateNiceMocks([MockSpec<BeerApiService>()])
+@GenerateNiceMocks([
+  MockSpec<BeerApiService>(),
+  MockSpec<AnalyticsService>(),
+])
 void main() {
   const festival = Festival(
     id: 'cbf2025',
@@ -39,6 +42,7 @@ void main() {
     late RatingsService ratingsService;
     late TastingLogService tastingLogService;
     late DrinkCacheService cacheService;
+    late MockAnalyticsService analyticsService;
     late ApiDrinkRepository repository;
 
     setUp(() async {
@@ -49,12 +53,14 @@ void main() {
       ratingsService = RatingsService(prefs);
       tastingLogService = TastingLogService(prefs);
       cacheService = DrinkCacheService(prefs);
+      analyticsService = MockAnalyticsService();
       repository = ApiDrinkRepository(
         apiService: apiService,
         favoritesService: favoritesService,
         ratingsService: ratingsService,
         tastingLogService: tastingLogService,
         cacheService: cacheService,
+        analyticsService: analyticsService,
       );
     });
 
@@ -160,6 +166,67 @@ void main() {
         expect(ids, containsAll(['beer-2', 'cider-1']));
         expect(ids.contains('beer-1'), isFalse);
       });
+
+      test('keeps cached data for a beverage type that 404s on refresh',
+          () async {
+        // First load: both beer and cider 200 and are cached.
+        when(apiService.fetchDrinksByType(festival)).thenAnswer(
+          (_) async => FestivalDrinksResult(
+            drinksByType: {
+              'beer': [makeDrink('beer-1')],
+              'cider': [makeDrink('cider-1')],
+            },
+            failedTypes: const {},
+          ),
+        );
+        await repository.getDrinks(festival);
+        await pumpEventQueue();
+
+        // Second load: cider responds 404 → omitted from BOTH drinksByType
+        // AND failedTypes (per fetchDrinksByType's contract), so the cache
+        // must preserve cider rather than overwriting it with empty.
+        when(apiService.fetchDrinksByType(festival)).thenAnswer(
+          (_) async => FestivalDrinksResult(
+            drinksByType: {
+              'beer': [makeDrink('beer-2')],
+            },
+            failedTypes: const {},
+          ),
+        );
+        final drinks = await repository.getDrinks(festival);
+
+        final ids = drinks.map((d) => d.id).toSet();
+        expect(ids, containsAll(['beer-2', 'cider-1']));
+        expect(ids.contains('beer-1'), isFalse);
+      });
+
+      test('logs cache write failures to analytics instead of swallowing them',
+          () async {
+        // SharedPreferences mock can't fail directly, but we can drive the
+        // analytics path by handing back an already-failed `written` future
+        // via a fake cache that always fails on persist.
+        final prefs = await SharedPreferences.getInstance();
+        final failingCache = _FailingDrinkCacheService(prefs);
+        final repo = ApiDrinkRepository(
+          apiService: apiService,
+          favoritesService: favoritesService,
+          ratingsService: ratingsService,
+          tastingLogService: tastingLogService,
+          cacheService: failingCache,
+          analyticsService: analyticsService,
+        );
+
+        when(apiService.fetchDrinksByType(festival))
+            .thenAnswer((_) async => ok([makeDrink('d1')]));
+
+        await repo.getDrinks(festival);
+        await pumpEventQueue();
+
+        verify(analyticsService.logError(any, any,
+                reason:
+                    argThat(contains('cache write failed'), named: 'reason')))
+            .called(1);
+      });
     });
 
     group('getCachedDrinks', () {
@@ -243,4 +310,21 @@ void main() {
       });
     });
   });
+}
+
+/// Drink cache subclass whose merge() always returns a failed `written` future,
+/// so we can verify the repository surfaces persistence errors via analytics
+/// rather than letting them become unhandled async errors.
+class _FailingDrinkCacheService extends DrinkCacheService {
+  _FailingDrinkCacheService(super.prefs);
+
+  @override
+  DrinkCacheUpdate merge(
+      String festivalId, Map<String, List<Drink>> freshByType) {
+    final drinks = [for (final list in freshByType.values) ...list];
+    return DrinkCacheUpdate(
+      drinks,
+      Future<void>.error(StateError('persist failed')),
+    );
+  }
 }

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -38,6 +38,7 @@ void main() {
     late FavoritesService favoritesService;
     late RatingsService ratingsService;
     late TastingLogService tastingLogService;
+    late DrinkCacheService cacheService;
     late ApiDrinkRepository repository;
 
     setUp(() async {
@@ -47,11 +48,13 @@ void main() {
       favoritesService = FavoritesService(prefs);
       ratingsService = RatingsService(prefs);
       tastingLogService = TastingLogService(prefs);
+      cacheService = DrinkCacheService(prefs);
       repository = ApiDrinkRepository(
         apiService: apiService,
         favoritesService: favoritesService,
         ratingsService: ratingsService,
         tastingLogService: tastingLogService,
+        cacheService: cacheService,
       );
     });
 
@@ -92,6 +95,41 @@ void main() {
             .thenAnswer((_) async => <Drink>[]);
 
         expect(await repository.getDrinks(festival), isEmpty);
+      });
+
+      test('writes fetched drinks to the cache', () async {
+        when(apiService.fetchAllDrinks(festival))
+            .thenAnswer((_) async => [makeDrink('d1'), makeDrink('d2')]);
+
+        await repository.getDrinks(festival);
+
+        final cached = cacheService.read(festival.id);
+        expect(cached, isNotNull);
+        expect(cached!.map((d) => d.id), containsAll(['d1', 'd2']));
+      });
+    });
+
+    group('getCachedDrinks', () {
+      test('returns null when nothing is cached', () async {
+        expect(await repository.getCachedDrinks(festival), isNull);
+      });
+
+      test('returns cached drinks with user state applied', () async {
+        when(apiService.fetchAllDrinks(festival))
+            .thenAnswer((_) async => [makeDrink('d1'), makeDrink('d2')]);
+        // Populate the cache via a live fetch.
+        await repository.getDrinks(festival);
+
+        // Set user state after caching; getCachedDrinks must re-apply it.
+        await favoritesService.addFavorite(festival.id, 'd1');
+        await ratingsService.setRating(festival.id, 'd2', 5);
+
+        final cached = await repository.getCachedDrinks(festival);
+
+        expect(cached, isNotNull);
+        final byId = {for (final d in cached!) d.id: d};
+        expect(byId['d1']!.isFavorite, isTrue);
+        expect(byId['d2']!.rating, 5);
       });
     });
 

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -58,11 +58,17 @@ void main() {
       );
     });
 
+    FestivalDrinksResult ok(List<Drink> drinks, {String type = 'beer'}) =>
+        FestivalDrinksResult(
+          drinksByType: {type: drinks},
+          failedTypes: const {},
+        );
+
     group('getDrinks', () {
       test('populates favourite, rating and tasted state in one pass',
           () async {
-        when(apiService.fetchAllDrinks(festival)).thenAnswer(
-          (_) async => [makeDrink('d1'), makeDrink('d2'), makeDrink('d3')],
+        when(apiService.fetchDrinksByType(festival)).thenAnswer(
+          (_) async => ok([makeDrink('d1'), makeDrink('d2'), makeDrink('d3')]),
         );
         await favoritesService.addFavorite(festival.id, 'd1');
         await ratingsService.setRating(festival.id, 'd2', 4);
@@ -80,8 +86,8 @@ void main() {
       });
 
       test('leaves all state unset when nothing is stored', () async {
-        when(apiService.fetchAllDrinks(festival))
-            .thenAnswer((_) async => [makeDrink('d1')]);
+        when(apiService.fetchDrinksByType(festival))
+            .thenAnswer((_) async => ok([makeDrink('d1')]));
 
         final drinks = await repository.getDrinks(festival);
 
@@ -91,21 +97,68 @@ void main() {
       });
 
       test('returns an empty list when the API returns no drinks', () async {
-        when(apiService.fetchAllDrinks(festival))
-            .thenAnswer((_) async => <Drink>[]);
+        when(apiService.fetchDrinksByType(festival))
+            .thenAnswer((_) async => ok(<Drink>[]));
 
         expect(await repository.getDrinks(festival), isEmpty);
       });
 
+      test('throws when every beverage type fails', () async {
+        when(apiService.fetchDrinksByType(festival)).thenAnswer(
+          (_) async => const FestivalDrinksResult(
+            drinksByType: {},
+            failedTypes: {'beer': 'network error'},
+          ),
+        );
+
+        expect(
+          () => repository.getDrinks(festival),
+          throwsA(isA<BeerApiException>()),
+        );
+      });
+
       test('writes fetched drinks to the cache', () async {
-        when(apiService.fetchAllDrinks(festival))
-            .thenAnswer((_) async => [makeDrink('d1'), makeDrink('d2')]);
+        when(apiService.fetchDrinksByType(festival))
+            .thenAnswer((_) async => ok([makeDrink('d1'), makeDrink('d2')]));
 
         await repository.getDrinks(festival);
+        await pumpEventQueue(); // cache write is intentionally backgrounded
 
         final cached = cacheService.read(festival.id);
         expect(cached, isNotNull);
         expect(cached!.map((d) => d.id), containsAll(['d1', 'd2']));
+      });
+
+      test('keeps cached data for a beverage type that fails to refresh',
+          () async {
+        // First load: both beer and cider succeed and are cached.
+        when(apiService.fetchDrinksByType(festival)).thenAnswer(
+          (_) async => FestivalDrinksResult(
+            drinksByType: {
+              'beer': [makeDrink('beer-1')],
+              'cider': [makeDrink('cider-1')],
+            },
+            failedTypes: const {},
+          ),
+        );
+        await repository.getDrinks(festival);
+        await pumpEventQueue();
+
+        // Second load: cider fails (network), only beer refreshes.
+        when(apiService.fetchDrinksByType(festival)).thenAnswer(
+          (_) async => FestivalDrinksResult(
+            drinksByType: {
+              'beer': [makeDrink('beer-2')],
+            },
+            failedTypes: const {'cider': 'network error'},
+          ),
+        );
+        final drinks = await repository.getDrinks(festival);
+
+        final ids = drinks.map((d) => d.id).toSet();
+        // Stale cider retained; beer refreshed; old beer dropped.
+        expect(ids, containsAll(['beer-2', 'cider-1']));
+        expect(ids.contains('beer-1'), isFalse);
       });
     });
 
@@ -115,10 +168,11 @@ void main() {
       });
 
       test('returns cached drinks with user state applied', () async {
-        when(apiService.fetchAllDrinks(festival))
-            .thenAnswer((_) async => [makeDrink('d1'), makeDrink('d2')]);
+        when(apiService.fetchDrinksByType(festival))
+            .thenAnswer((_) async => ok([makeDrink('d1'), makeDrink('d2')]));
         // Populate the cache via a live fetch.
         await repository.getDrinks(festival);
+        await pumpEventQueue();
 
         // Set user state after caching; getCachedDrinks must re-apply it.
         await favoritesService.addFavorite(festival.id, 'd1');

--- a/test/domain/repositories/api_drink_repository_test.mocks.dart
+++ b/test/domain/repositories/api_drink_repository_test.mocks.dart
@@ -3,10 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
+import 'dart:async' as _i5;
 
-import 'package:cambridge_beer_festival/models/models.dart' as _i4;
+import 'package:cambridge_beer_festival/models/models.dart' as _i6;
+import 'package:cambridge_beer_festival/services/analytics_service.dart' as _i7;
 import 'package:cambridge_beer_festival/services/beer_api_service.dart' as _i2;
+import 'package:firebase_analytics/firebase_analytics.dart' as _i3;
+import 'package:firebase_crashlytics/firebase_crashlytics.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: type=lint
@@ -45,6 +48,28 @@ class _FakeFestivalDrinksResult_1 extends _i1.SmartFake
         );
 }
 
+class _FakeFirebaseAnalytics_2 extends _i1.SmartFake
+    implements _i3.FirebaseAnalytics {
+  _FakeFirebaseAnalytics_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeFirebaseCrashlytics_3 extends _i1.SmartFake
+    implements _i4.FirebaseCrashlytics {
+  _FakeFirebaseCrashlytics_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [BeerApiService].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -63,8 +88,8 @@ class MockBeerApiService extends _i1.Mock implements _i2.BeerApiService {
       ) as Duration);
 
   @override
-  _i3.Future<List<_i4.Drink>> fetchDrinks(
-    _i4.Festival? festival,
+  _i5.Future<List<_i6.Drink>> fetchDrinks(
+    _i6.Festival? festival,
     String? beverageType,
   ) =>
       (super.noSuchMethod(
@@ -75,20 +100,20 @@ class MockBeerApiService extends _i1.Mock implements _i2.BeerApiService {
             beverageType,
           ],
         ),
-        returnValue: _i3.Future<List<_i4.Drink>>.value(<_i4.Drink>[]),
+        returnValue: _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
         returnValueForMissingStub:
-            _i3.Future<List<_i4.Drink>>.value(<_i4.Drink>[]),
-      ) as _i3.Future<List<_i4.Drink>>);
+            _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
+      ) as _i5.Future<List<_i6.Drink>>);
 
   @override
-  _i3.Future<_i2.FestivalDrinksResult> fetchDrinksByType(
-          _i4.Festival? festival) =>
+  _i5.Future<_i2.FestivalDrinksResult> fetchDrinksByType(
+          _i6.Festival? festival) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchDrinksByType,
           [festival],
         ),
-        returnValue: _i3.Future<_i2.FestivalDrinksResult>.value(
+        returnValue: _i5.Future<_i2.FestivalDrinksResult>.value(
             _FakeFestivalDrinksResult_1(
           this,
           Invocation.method(
@@ -96,7 +121,7 @@ class MockBeerApiService extends _i1.Mock implements _i2.BeerApiService {
             [festival],
           ),
         )),
-        returnValueForMissingStub: _i3.Future<_i2.FestivalDrinksResult>.value(
+        returnValueForMissingStub: _i5.Future<_i2.FestivalDrinksResult>.value(
             _FakeFestivalDrinksResult_1(
           this,
           Invocation.method(
@@ -104,19 +129,19 @@ class MockBeerApiService extends _i1.Mock implements _i2.BeerApiService {
             [festival],
           ),
         )),
-      ) as _i3.Future<_i2.FestivalDrinksResult>);
+      ) as _i5.Future<_i2.FestivalDrinksResult>);
 
   @override
-  _i3.Future<List<_i4.Drink>> fetchAllDrinks(_i4.Festival? festival) =>
+  _i5.Future<List<_i6.Drink>> fetchAllDrinks(_i6.Festival? festival) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchAllDrinks,
           [festival],
         ),
-        returnValue: _i3.Future<List<_i4.Drink>>.value(<_i4.Drink>[]),
+        returnValue: _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
         returnValueForMissingStub:
-            _i3.Future<List<_i4.Drink>>.value(<_i4.Drink>[]),
-      ) as _i3.Future<List<_i4.Drink>>);
+            _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
+      ) as _i5.Future<List<_i6.Drink>>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -126,4 +151,239 @@ class MockBeerApiService extends _i1.Mock implements _i2.BeerApiService {
         ),
         returnValueForMissingStub: null,
       );
+}
+
+/// A class which mocks [AnalyticsService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockAnalyticsService extends _i1.Mock implements _i7.AnalyticsService {
+  @override
+  _i3.FirebaseAnalytics get analytics => (super.noSuchMethod(
+        Invocation.getter(#analytics),
+        returnValue: _FakeFirebaseAnalytics_2(
+          this,
+          Invocation.getter(#analytics),
+        ),
+        returnValueForMissingStub: _FakeFirebaseAnalytics_2(
+          this,
+          Invocation.getter(#analytics),
+        ),
+      ) as _i3.FirebaseAnalytics);
+
+  @override
+  _i4.FirebaseCrashlytics get crashlytics => (super.noSuchMethod(
+        Invocation.getter(#crashlytics),
+        returnValue: _FakeFirebaseCrashlytics_3(
+          this,
+          Invocation.getter(#crashlytics),
+        ),
+        returnValueForMissingStub: _FakeFirebaseCrashlytics_3(
+          this,
+          Invocation.getter(#crashlytics),
+        ),
+      ) as _i4.FirebaseCrashlytics);
+
+  @override
+  _i5.Future<void> logAppLaunch() => (super.noSuchMethod(
+        Invocation.method(
+          #logAppLaunch,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalSelected(_i6.Festival? festival) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #logFestivalSelected,
+          [festival],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logSearch(String? query) => (super.noSuchMethod(
+        Invocation.method(
+          #logSearch,
+          [query],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logCategoryFilter(String? category) => (super.noSuchMethod(
+        Invocation.method(
+          #logCategoryFilter,
+          [category],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logStyleFilter(Set<String>? styles) => (super.noSuchMethod(
+        Invocation.method(
+          #logStyleFilter,
+          [styles],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logSortChange(String? sortType) => (super.noSuchMethod(
+        Invocation.method(
+          #logSortChange,
+          [sortType],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFavoriteAdded(_i6.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logFavoriteAdded,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFavoriteRemoved(_i6.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logFavoriteRemoved,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logTastedAdded(_i6.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logTastedAdded,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logTastedRemoved(_i6.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logTastedRemoved,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logDrinkViewed(_i6.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logDrinkViewed,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logBreweryViewed(String? breweryName) => (super.noSuchMethod(
+        Invocation.method(
+          #logBreweryViewed,
+          [breweryName],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logStyleViewed(String? style) => (super.noSuchMethod(
+        Invocation.method(
+          #logStyleViewed,
+          [style],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logRatingGiven(
+    _i6.Drink? drink,
+    int? rating,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #logRatingGiven,
+          [
+            drink,
+            rating,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logDrinkShared(_i6.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logDrinkShared,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logError(
+    Object? error,
+    StackTrace? stackTrace, {
+    String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #logError,
+          [
+            error,
+            stackTrace,
+          ],
+          {#reason: reason},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setUserProperty(
+    String? name,
+    String? value,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setUserProperty,
+          [
+            name,
+            value,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setUserId(String? userId) => (super.noSuchMethod(
+        Invocation.method(
+          #setUserId,
+          [userId],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }

--- a/test/domain/repositories/api_drink_repository_test.mocks.dart
+++ b/test/domain/repositories/api_drink_repository_test.mocks.dart
@@ -34,6 +34,17 @@ class _FakeDuration_0 extends _i1.SmartFake implements Duration {
         );
 }
 
+class _FakeFestivalDrinksResult_1 extends _i1.SmartFake
+    implements _i2.FestivalDrinksResult {
+  _FakeFestivalDrinksResult_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [BeerApiService].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -68,6 +79,32 @@ class MockBeerApiService extends _i1.Mock implements _i2.BeerApiService {
         returnValueForMissingStub:
             _i3.Future<List<_i4.Drink>>.value(<_i4.Drink>[]),
       ) as _i3.Future<List<_i4.Drink>>);
+
+  @override
+  _i3.Future<_i2.FestivalDrinksResult> fetchDrinksByType(
+          _i4.Festival? festival) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchDrinksByType,
+          [festival],
+        ),
+        returnValue: _i3.Future<_i2.FestivalDrinksResult>.value(
+            _FakeFestivalDrinksResult_1(
+          this,
+          Invocation.method(
+            #fetchDrinksByType,
+            [festival],
+          ),
+        )),
+        returnValueForMissingStub: _i3.Future<_i2.FestivalDrinksResult>.value(
+            _FakeFestivalDrinksResult_1(
+          this,
+          Invocation.method(
+            #fetchDrinksByType,
+            [festival],
+          ),
+        )),
+      ) as _i3.Future<_i2.FestivalDrinksResult>);
 
   @override
   _i3.Future<List<_i4.Drink>> fetchAllDrinks(_i4.Festival? festival) =>

--- a/test/domain/repositories/api_festival_repository_test.dart
+++ b/test/domain/repositories/api_festival_repository_test.dart
@@ -77,6 +77,7 @@ void main() {
       when(festivalService.fetchFestivals()).thenAnswer((_) async => response);
 
       await repository.getFestivals();
+      await pumpEventQueue(); // cache write is intentionally backgrounded
 
       final cached = await repository.getCachedFestivals();
       expect(cached, isNotNull);

--- a/test/domain/repositories/api_festival_repository_test.dart
+++ b/test/domain/repositories/api_festival_repository_test.dart
@@ -12,6 +12,7 @@ void main() {
   group('ApiFestivalRepository', () {
     late MockFestivalService festivalService;
     late FestivalStorageService storageService;
+    late FestivalCacheService cacheService;
     late ApiFestivalRepository repository;
 
     setUp(() async {
@@ -19,9 +20,11 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       festivalService = MockFestivalService();
       storageService = FestivalStorageService(prefs);
+      cacheService = FestivalCacheService(prefs);
       repository = ApiFestivalRepository(
         festivalService: festivalService,
         festivalStorageService: storageService,
+        cacheService: cacheService,
       );
     });
 
@@ -55,6 +58,34 @@ void main() {
         () => repository.getFestivals(),
         throwsA(isA<FestivalServiceException>()),
       );
+    });
+
+    test('getFestivals caches the fetched response', () async {
+      final response = FestivalsResponse.fromJson(
+        {
+          'festivals': [
+            {
+              'id': 'cbf2025',
+              'name': 'Cambridge Beer Festival 2025',
+              'data_base_url': 'https://example.com/cbf2025',
+            },
+          ],
+          'default_festival_id': 'cbf2025',
+        },
+        'https://example.com',
+      );
+      when(festivalService.fetchFestivals()).thenAnswer((_) async => response);
+
+      await repository.getFestivals();
+
+      final cached = await repository.getCachedFestivals();
+      expect(cached, isNotNull);
+      expect(cached!.festivals.single.id, 'cbf2025');
+      expect(cached.defaultFestivalId, 'cbf2025');
+    });
+
+    test('getCachedFestivals returns null when nothing is cached', () async {
+      expect(await repository.getCachedFestivals(), isNull);
     });
 
     test('getSelectedFestivalId returns null before any selection', () async {

--- a/test/domain/repositories/api_festival_repository_test.dart
+++ b/test/domain/repositories/api_festival_repository_test.dart
@@ -7,12 +7,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'api_festival_repository_test.mocks.dart';
 
-@GenerateNiceMocks([MockSpec<FestivalService>()])
+@GenerateNiceMocks([
+  MockSpec<FestivalService>(),
+  MockSpec<AnalyticsService>(),
+])
 void main() {
   group('ApiFestivalRepository', () {
     late MockFestivalService festivalService;
     late FestivalStorageService storageService;
     late FestivalCacheService cacheService;
+    late MockAnalyticsService analyticsService;
     late ApiFestivalRepository repository;
 
     setUp(() async {
@@ -21,10 +25,12 @@ void main() {
       festivalService = MockFestivalService();
       storageService = FestivalStorageService(prefs);
       cacheService = FestivalCacheService(prefs);
+      analyticsService = MockAnalyticsService();
       repository = ApiFestivalRepository(
         festivalService: festivalService,
         festivalStorageService: storageService,
         cacheService: cacheService,
+        analyticsService: analyticsService,
       );
     });
 

--- a/test/domain/repositories/api_festival_repository_test.mocks.dart
+++ b/test/domain/repositories/api_festival_repository_test.mocks.dart
@@ -3,9 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
+import 'dart:async' as _i5;
 
+import 'package:cambridge_beer_festival/models/models.dart' as _i7;
+import 'package:cambridge_beer_festival/services/analytics_service.dart' as _i6;
 import 'package:cambridge_beer_festival/services/festival_service.dart' as _i2;
+import 'package:firebase_analytics/firebase_analytics.dart' as _i3;
+import 'package:firebase_crashlytics/firebase_crashlytics.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: type=lint
@@ -44,6 +48,28 @@ class _FakeFestivalsResponse_1 extends _i1.SmartFake
         );
 }
 
+class _FakeFirebaseAnalytics_2 extends _i1.SmartFake
+    implements _i3.FirebaseAnalytics {
+  _FakeFirebaseAnalytics_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeFirebaseCrashlytics_3 extends _i1.SmartFake
+    implements _i4.FirebaseCrashlytics {
+  _FakeFirebaseCrashlytics_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [FestivalService].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -62,13 +88,13 @@ class MockFestivalService extends _i1.Mock implements _i2.FestivalService {
       ) as Duration);
 
   @override
-  _i3.Future<_i2.FestivalsResponse> fetchFestivals() => (super.noSuchMethod(
+  _i5.Future<_i2.FestivalsResponse> fetchFestivals() => (super.noSuchMethod(
         Invocation.method(
           #fetchFestivals,
           [],
         ),
         returnValue:
-            _i3.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_1(
+            _i5.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_1(
           this,
           Invocation.method(
             #fetchFestivals,
@@ -76,14 +102,14 @@ class MockFestivalService extends _i1.Mock implements _i2.FestivalService {
           ),
         )),
         returnValueForMissingStub:
-            _i3.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_1(
+            _i5.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_1(
           this,
           Invocation.method(
             #fetchFestivals,
             [],
           ),
         )),
-      ) as _i3.Future<_i2.FestivalsResponse>);
+      ) as _i5.Future<_i2.FestivalsResponse>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -93,4 +119,239 @@ class MockFestivalService extends _i1.Mock implements _i2.FestivalService {
         ),
         returnValueForMissingStub: null,
       );
+}
+
+/// A class which mocks [AnalyticsService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockAnalyticsService extends _i1.Mock implements _i6.AnalyticsService {
+  @override
+  _i3.FirebaseAnalytics get analytics => (super.noSuchMethod(
+        Invocation.getter(#analytics),
+        returnValue: _FakeFirebaseAnalytics_2(
+          this,
+          Invocation.getter(#analytics),
+        ),
+        returnValueForMissingStub: _FakeFirebaseAnalytics_2(
+          this,
+          Invocation.getter(#analytics),
+        ),
+      ) as _i3.FirebaseAnalytics);
+
+  @override
+  _i4.FirebaseCrashlytics get crashlytics => (super.noSuchMethod(
+        Invocation.getter(#crashlytics),
+        returnValue: _FakeFirebaseCrashlytics_3(
+          this,
+          Invocation.getter(#crashlytics),
+        ),
+        returnValueForMissingStub: _FakeFirebaseCrashlytics_3(
+          this,
+          Invocation.getter(#crashlytics),
+        ),
+      ) as _i4.FirebaseCrashlytics);
+
+  @override
+  _i5.Future<void> logAppLaunch() => (super.noSuchMethod(
+        Invocation.method(
+          #logAppLaunch,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalSelected(_i7.Festival? festival) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #logFestivalSelected,
+          [festival],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logSearch(String? query) => (super.noSuchMethod(
+        Invocation.method(
+          #logSearch,
+          [query],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logCategoryFilter(String? category) => (super.noSuchMethod(
+        Invocation.method(
+          #logCategoryFilter,
+          [category],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logStyleFilter(Set<String>? styles) => (super.noSuchMethod(
+        Invocation.method(
+          #logStyleFilter,
+          [styles],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logSortChange(String? sortType) => (super.noSuchMethod(
+        Invocation.method(
+          #logSortChange,
+          [sortType],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFavoriteAdded(_i7.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logFavoriteAdded,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFavoriteRemoved(_i7.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logFavoriteRemoved,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logTastedAdded(_i7.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logTastedAdded,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logTastedRemoved(_i7.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logTastedRemoved,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logDrinkViewed(_i7.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logDrinkViewed,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logBreweryViewed(String? breweryName) => (super.noSuchMethod(
+        Invocation.method(
+          #logBreweryViewed,
+          [breweryName],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logStyleViewed(String? style) => (super.noSuchMethod(
+        Invocation.method(
+          #logStyleViewed,
+          [style],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logRatingGiven(
+    _i7.Drink? drink,
+    int? rating,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #logRatingGiven,
+          [
+            drink,
+            rating,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logDrinkShared(_i7.Drink? drink) => (super.noSuchMethod(
+        Invocation.method(
+          #logDrinkShared,
+          [drink],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logError(
+    Object? error,
+    StackTrace? stackTrace, {
+    String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #logError,
+          [
+            error,
+            stackTrace,
+          ],
+          {#reason: reason},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setUserProperty(
+    String? name,
+    String? value,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setUserProperty,
+          [
+            name,
+            value,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setUserId(String? userId) => (super.noSuchMethod(
+        Invocation.method(
+          #setUserId,
+          [userId],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }

--- a/test/drinks_screen_refresh_status_test.dart
+++ b/test/drinks_screen_refresh_status_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cambridge_beer_festival/screens/screens.dart';
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:cambridge_beer_festival/providers/providers.dart';
+import 'package:cambridge_beer_festival/services/services.dart';
+import 'package:provider/provider.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'provider_test.mocks.dart';
+
+void main() {
+  group('DrinksScreen refresh status', () {
+    late MockDrinkRepository mockDrinkRepository;
+    late MockFestivalRepository mockFestivalRepository;
+    late MockAnalyticsService mockAnalyticsService;
+    late BeerProvider provider;
+
+    final testDrinks = [
+      Drink(
+        product: const Product(
+          id: 'drink1',
+          name: 'Alpha IPA',
+          abv: 5.5,
+          category: 'beer',
+          dispense: 'cask',
+          style: 'IPA',
+        ),
+        producer: const Producer(
+          id: 'brewery1',
+          name: 'Test Brewery',
+          location: 'Cambridge',
+          products: [],
+        ),
+        festivalId: 'cbf2025',
+      ),
+    ];
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      mockDrinkRepository = MockDrinkRepository();
+      mockFestivalRepository = MockFestivalRepository();
+      mockAnalyticsService = MockAnalyticsService();
+
+      const testFestival = Festival(
+        id: 'cbf2025',
+        name: 'Cambridge Beer Festival 2025',
+        dataBaseUrl: 'https://test.example.com/cbf2025',
+      );
+      when(mockFestivalRepository.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: [testFestival],
+          defaultFestivalId: 'cbf2025',
+          baseUrl: 'https://example.com',
+          version: '1.0.0',
+        ),
+      );
+      when(mockFestivalRepository.getSelectedFestivalId())
+          .thenAnswer((_) async => null);
+      when(mockDrinkRepository.getDrinks(any))
+          .thenAnswer((_) async => testDrinks);
+
+      provider = BeerProvider(
+        drinkRepository: mockDrinkRepository,
+        festivalRepository: mockFestivalRepository,
+        analyticsService: mockAnalyticsService,
+      );
+      await provider.initialize();
+      await provider.loadDrinks();
+    });
+
+    tearDown(() => provider.dispose());
+
+    Widget createTestWidget() {
+      return ChangeNotifierProvider<BeerProvider>.value(
+        value: provider,
+        child: const MaterialApp(
+          home: DrinksScreen(festivalId: 'cbf2025'),
+        ),
+      );
+    }
+
+    testWidgets('shows a dismissible notice when a refresh fails with cache',
+        (tester) async {
+      // A refresh fails while cached drinks remain on screen.
+      when(mockDrinkRepository.getDrinks(any))
+          .thenThrow(TimeoutException('offline'));
+      await provider.loadDrinks();
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(provider.refreshNotice, isNotNull);
+      expect(find.textContaining('saved data'), findsOneWidget);
+
+      // The drinks list is still shown, not a full-screen error.
+      expect(find.text('Alpha IPA'), findsOneWidget);
+      expect(find.text('Error loading drinks'), findsNothing);
+
+      // Tapping dismiss removes the notice.
+      await tester.tap(find.bySemanticsLabel('Dismiss saved data notice'));
+      await tester.pumpAndSettle();
+
+      expect(provider.refreshNotice, isNull);
+      expect(find.textContaining('saved data'), findsNothing);
+    });
+
+    testWidgets('shows a progress bar while refreshing with data on screen',
+        (tester) async {
+      // Hold the network refresh open so isRefreshing stays true.
+      final pending = Completer<List<Drink>>();
+      when(mockDrinkRepository.getDrinks(any))
+          .thenAnswer((_) => pending.future);
+
+      final future = provider.loadDrinks();
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump();
+
+      expect(provider.isRefreshing, isTrue);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+
+      pending.complete(testDrinks);
+      await future;
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+    });
+  });
+}

--- a/test/drinks_screen_refresh_status_test.dart
+++ b/test/drinks_screen_refresh_status_test.dart
@@ -84,27 +84,34 @@ void main() {
 
     testWidgets('shows a dismissible notice when a refresh fails with cache',
         (tester) async {
-      // A refresh fails while cached drinks remain on screen.
-      when(mockDrinkRepository.getDrinks(any))
-          .thenThrow(TimeoutException('offline'));
-      await provider.loadDrinks();
+      // bySemanticsLabel requires an active semantics tree; dispose explicitly
+      // before the test ends so Flutter's end-of-test verifier is happy.
+      final semantics = tester.ensureSemantics();
+      try {
+        // A refresh fails while cached drinks remain on screen.
+        when(mockDrinkRepository.getDrinks(any))
+            .thenThrow(TimeoutException('offline'));
+        await provider.loadDrinks();
 
-      await tester.pumpWidget(createTestWidget());
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
 
-      expect(provider.refreshNotice, isNotNull);
-      expect(find.textContaining('saved data'), findsOneWidget);
+        expect(provider.refreshNotice, isNotNull);
+        expect(find.textContaining('saved data'), findsOneWidget);
 
-      // The drinks list is still shown, not a full-screen error.
-      expect(find.text('Alpha IPA'), findsOneWidget);
-      expect(find.text('Error loading drinks'), findsNothing);
+        // The drinks list is still shown, not a full-screen error.
+        expect(find.text('Alpha IPA'), findsOneWidget);
+        expect(find.text('Error loading drinks'), findsNothing);
 
-      // Tapping dismiss removes the notice.
-      await tester.tap(find.bySemanticsLabel('Dismiss saved data notice'));
-      await tester.pumpAndSettle();
+        // Tapping dismiss removes the notice.
+        await tester.tap(find.bySemanticsLabel('Dismiss saved data notice'));
+        await tester.pumpAndSettle();
 
-      expect(provider.refreshNotice, isNull);
-      expect(find.textContaining('saved data'), findsNothing);
+        expect(provider.refreshNotice, isNull);
+        expect(find.textContaining('saved data'), findsNothing);
+      } finally {
+        semantics.dispose();
+      }
     });
 
     testWidgets('shows a progress bar while refreshing with data on screen',

--- a/test/provider_test.mocks.dart
+++ b/test/provider_test.mocks.dart
@@ -81,6 +81,17 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
       ) as _i6.Future<List<_i7.Drink>>);
 
   @override
+  _i6.Future<List<_i7.Drink>?> getCachedDrinks(_i7.Festival? festival) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getCachedDrinks,
+          [festival],
+        ),
+        returnValue: _i6.Future<List<_i7.Drink>?>.value(),
+        returnValueForMissingStub: _i6.Future<List<_i7.Drink>?>.value(),
+      ) as _i6.Future<List<_i7.Drink>?>);
+
+  @override
   _i6.Future<List<String>> getFavorites(String? festivalId) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -235,6 +246,17 @@ class MockFestivalRepository extends _i1.Mock
           ),
         )),
       ) as _i6.Future<_i2.FestivalsResponse>);
+
+  @override
+  _i6.Future<_i2.FestivalsResponse?> getCachedFestivals() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getCachedFestivals,
+          [],
+        ),
+        returnValue: _i6.Future<_i2.FestivalsResponse?>.value(),
+        returnValueForMissingStub: _i6.Future<_i2.FestivalsResponse?>.value(),
+      ) as _i6.Future<_i2.FestivalsResponse?>);
 
   @override
   _i6.Future<String?> getSelectedFestivalId() => (super.noSuchMethod(

--- a/test/widgets/festival_menu_sheets_test.mocks.dart
+++ b/test/widgets/festival_menu_sheets_test.mocks.dart
@@ -81,6 +81,17 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
       ) as _i6.Future<List<_i7.Drink>>);
 
   @override
+  _i6.Future<List<_i7.Drink>?> getCachedDrinks(_i7.Festival? festival) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getCachedDrinks,
+          [festival],
+        ),
+        returnValue: _i6.Future<List<_i7.Drink>?>.value(),
+        returnValueForMissingStub: _i6.Future<List<_i7.Drink>?>.value(),
+      ) as _i6.Future<List<_i7.Drink>?>);
+
+  @override
   _i6.Future<List<String>> getFavorites(String? festivalId) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -235,6 +246,17 @@ class MockFestivalRepository extends _i1.Mock
           ),
         )),
       ) as _i6.Future<_i2.FestivalsResponse>);
+
+  @override
+  _i6.Future<_i2.FestivalsResponse?> getCachedFestivals() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getCachedFestivals,
+          [],
+        ),
+        returnValue: _i6.Future<_i2.FestivalsResponse?>.value(),
+        returnValueForMissingStub: _i6.Future<_i2.FestivalsResponse?>.value(),
+      ) as _i6.Future<_i2.FestivalsResponse?>);
 
   @override
   _i6.Future<String?> getSelectedFestivalId() => (super.noSuchMethod(


### PR DESCRIPTION
On a slow network the app was unusable at launch: startup ran two
sequential network calls (festivals then drinks) before rendering, and
neither feed was ever persisted — only favourites/ratings were. Users who
had loaded data on a previous run still saw a spinner or a full-screen
error.

Persist the last-good drinks (per festival) and festivals registry to
SharedPreferences and adopt stale-while-revalidate:

- New DrinkCacheService / FestivalCacheService reuse the existing
  Producer/Festival JSON shapes; drink reads go through a promoted
  BeerApiService.parseProducers so cache and live data parse identically.
- Repositories write through on successful fetch and expose cached reads
  (getCachedDrinks / getCachedFestivals) with user state applied.
- BeerProvider renders cached drinks immediately, then refreshes in the
  background; initialize() no longer blocks drinks on the festivals network
  when a cache exists. A failed refresh keeps cached data on screen with a
  quiet, dismissible notice instead of an error.
- Refresh failures are logged to analytics unless they are an expected
  offline failure already covered by cache — non-connectivity failures and
  fully blocked loads are always logged so a silent never-load still surfaces.
- Drinks screen shows a thin refresh indicator and the saved-data notice;
  the full-screen spinner/error only appear when there is no data.

https://claude.ai/code/session_01FuznZnpQvk9mqYsLcKwmhK