### PR TITLE
fix(ci): replace report-lcov action with codecov for coverage gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,20 +77,6 @@ jobs:
       - name: Run tests with coverage
         run: flutter test --coverage
 
-      - name: Install lcov
-        run: |
-          curl -sL https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz | tar xz -C /tmp/
-          sudo make -C /tmp/lcov-1.16 install
-
-      - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@v4
-        with:
-          coverage-files: coverage/lcov.info
-          minimum-coverage: 70
-          artifact-name: code-coverage-report
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          update-comment: true
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,14 @@ jobs:
         run: flutter test --coverage
 
       - name: Install lcov
-        run: sudo apt-get update && sudo apt-get install -y lcov
+        run: |
+          curl -sL https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz | tar xz -C /tmp/
+          sudo make -C /tmp/lcov-1.16 install
 
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v4
         with:
           coverage-files: coverage/lcov.info
-          # Updated: Coverage threshold increased from 25% to 70%
-          # Current coverage: 72%+ with comprehensive test improvements
           minimum-coverage: 70
           artifact-name: code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+        threshold: 1%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default

--- a/mise.lock
+++ b/mise.lock
@@ -49,6 +49,7 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellchec
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.aarch64.tar.xz"
 
 [tools.shellcheck."platforms.linux-x64"]
+checksum = "blake3:2a6377cc08f05029b0e91d05a63a707ff5919e607bc362588538737e201d9ba4"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz"
 
 [tools.shellcheck."platforms.linux-x64-musl"]


### PR DESCRIPTION
The `zgosalvez/github-actions-report-lcov` action was reporting 0.0%
coverage on all changed files in PR #302 despite tests passing and
Codecov correctly showing 84% patch coverage.

## Root cause

`ubuntu-latest` runners now install lcov v2.0 via apt. lcov v2.0 has a
regression in its `--list` subcommand: it silently outputs `0.0%` for
every file's rate when the tracefile has no function-coverage data.
Flutter/Dart never emits function coverage, so every file showed 0%.
(`lcov --summary` uses a different code path and was unaffected, which
is why the overall 80.8% total was correct while per-file rates were
broken.)

## Fix

The report-lcov action was duplicating what Codecov already does, with
worse reliability (fragile lcov version dependency, no historical
tracking). Removed it entirely and replaced it with a `codecov.yml`
that enforces the same 70% minimum on both overall project coverage and
per-PR patch coverage — so `codecov/patch` now gates merges instead.

## Changes

- Remove `Install lcov` and `Report code coverage` steps from `ci.yml`
- Add `codecov.yml` enforcing 70% threshold on project and patch coverage

https://claude.ai/code/session_019PE7Kk1zftT1iQ29Cmd8mn