### PR TITLE
ci: extract fmt check into parallel job, add fmt:check mise task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,18 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Install shfmt
+        run: |
+          curl -sSL "https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64" -o /usr/local/bin/shfmt
+          chmod +x /usr/local/bin/shfmt
+
       - name: Check formatting
         run: |
           dart format --output=none --set-exit-if-changed .
           npm ci
           npx prettier --check "**/*.{js,ts,mjs}"
+          mapfile -t SH_FILES < <(find . -name '*.sh' -not -path './.git/*' -not -path './.mise/*' -not -path '*/node_modules/*' | sort)
+          [[ ${#SH_FILES[@]} -gt 0 ]] && shfmt -d -i 0 -ci "${SH_FILES[@]}"
 
   # Run tests once before building
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,37 @@ jobs:
             functions:
               - 'functions/**'
 
+  # Check formatting before expensive jobs
+  fmt:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.app == 'true' ||
+      needs.changes.outputs.functions == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.38.3'
+          channel: 'stable'
+          cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Check formatting
+        run: |
+          dart format --output=none --set-exit-if-changed .
+          npm ci
+          npx prettier --check "**/*.{js,ts,mjs}"
+
   # Run tests once before building
   test:
     needs: changes
@@ -64,12 +95,6 @@ jobs:
         with:
           google-services-json: ${{ secrets.GOOGLE_SERVICES_JSON }}
           generate-mocks: 'true'
-
-      - name: Check formatting
-        run: |
-          dart format --output=none --set-exit-if-changed .
-          npm ci
-          npx prettier --check "**/*.{js,ts,mjs}"
 
       - name: Analyze code
         run: flutter analyze --no-fatal-infos
@@ -92,7 +117,7 @@ jobs:
 
   # Build web after tests pass
   build-web:
-    needs: [changes, test]
+    needs: [changes, test, fmt]
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -185,7 +210,7 @@ jobs:
 
   # Build Android after tests pass
   build-android:
-    needs: [changes, test]
+    needs: [changes, test, fmt]
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Get dependencies
+        run: flutter pub get
+
       - name: Install shfmt
         run: |
           curl -sSL "https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64" -o /usr/local/bin/shfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
           channel: 'stable'
           cache: true
 
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/mise-tasks/analyze.sh
+++ b/mise-tasks/analyze.sh
@@ -5,9 +5,9 @@
 set -uo pipefail
 ANALYZE_LOG="${ANALYZE_LOG:-$(mktemp /tmp/analyze-XXXXXX.log)}"
 echo "ANALYZE_LOG=$ANALYZE_LOG"
-flutter analyze --no-fatal-infos "$@" 2>&1 \
-	| grep -v -E "Woah! You appear|superuser privileges" \
-	| tee "$ANALYZE_LOG"
+flutter analyze --no-fatal-infos "$@" 2>&1 |
+	grep -v -E "Woah! You appear|superuser privileges" |
+	tee "$ANALYZE_LOG"
 EXIT_CODE=${PIPESTATUS[0]}
 echo "---"
 echo "Grep with: grep -n 'error\|warning' $ANALYZE_LOG"

--- a/mise-tasks/shell/format-check.sh
+++ b/mise-tasks/shell/format-check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#MISE description="Check shell formatting without modifying files"
+
+set -euo pipefail
+
+mapfile -t ALL_FILES < <(find . -name "*.sh" -not -path "./.git/*" -not -path "./.mise/*" -not -path "*/node_modules/*" | sort)
+
+if [ "${#ALL_FILES[@]}" -eq 0 ]; then
+	echo "No shell scripts found"
+	exit 0
+fi
+
+echo "Checking ${#ALL_FILES[@]} files with shfmt..."
+shfmt -d -i 0 -ci "${ALL_FILES[@]}"
+echo "shfmt check passed"

--- a/mise-tasks/test.sh
+++ b/mise-tasks/test.sh
@@ -5,9 +5,9 @@
 set -uo pipefail
 TEST_LOG="${TEST_LOG:-$(mktemp /tmp/test-XXXXXX.log)}"
 echo "TEST_LOG=$TEST_LOG"
-flutter test "$@" 2>&1 \
-	| grep -v -E "Woah! You appear|superuser privileges" \
-	| tee "$TEST_LOG"
+flutter test "$@" 2>&1 |
+	grep -v -E "Woah! You appear|superuser privileges" |
+	tee "$TEST_LOG"
 EXIT_CODE=${PIPESTATUS[0]}
 echo "---"
 echo "Grep with: grep -n 'FAILED\|ERROR' $TEST_LOG"

--- a/mise.toml
+++ b/mise.toml
@@ -50,8 +50,8 @@ description = "Check JS/TS/MJS formatting without modifying files"
 run = 'npm ci && npx prettier --check "**/*.{js,ts,mjs}"'
 
 [tasks."fmt:check"]
-description = "Check all code formatting (Dart, JS/TS) — fails if any file needs reformatting"
-depends = ['dart:format:check', 'prettier:check']
+description = "Check all code formatting (Dart, JS/TS, shell) — fails if any file needs reformatting"
+depends = ['dart:format:check', 'prettier:check', 'shell:format:check']
 run = 'echo "Format check passed"'
 
 [tasks."mise:format"]

--- a/mise.toml
+++ b/mise.toml
@@ -37,9 +37,22 @@ description = "Format all Dart code in place (depends on generate so mock files 
 depends = ['generate']
 run = 'dart format .'
 
+[tasks."dart:format:check"]
+description = "Check Dart formatting without modifying files"
+run = 'dart format --output=none --set-exit-if-changed .'
+
 [tasks."prettier:format"]
 description = "Format JS/TS/MJS files with Prettier"
 run = 'npm ci && npx prettier --write "**/*.{js,ts,mjs}"'
+
+[tasks."prettier:check"]
+description = "Check JS/TS/MJS formatting without modifying files"
+run = 'npm ci && npx prettier --check "**/*.{js,ts,mjs}"'
+
+[tasks."fmt:check"]
+description = "Check all code formatting (Dart, JS/TS) — fails if any file needs reformatting"
+depends = ['dart:format:check', 'prettier:check']
+run = 'echo "Format check passed"'
 
 [tasks."mise:format"]
 description = "Format mise.toml"

--- a/mise.toml
+++ b/mise.toml
@@ -51,7 +51,7 @@ run = 'npm ci && npx prettier --check "**/*.{js,ts,mjs}"'
 
 [tasks."fmt:check"]
 description = "Check all code formatting (Dart, JS/TS, shell) — fails if any file needs reformatting"
-depends = ['dart:format:check', 'prettier:check', 'shell:format:check']
+depends = ['dart:format:check', 'prettier:check', 'shell:format-check']
 run = 'echo "Format check passed"'
 
 [tasks."mise:format"]


### PR DESCRIPTION
Moves dart format and prettier checks out of the test job into a
dedicated fmt job that runs in parallel with test. build-web and
build-android now require both test and fmt to pass.

Adds dart:format:check, prettier:check, and fmt:check tasks to
mise.toml so developers can run the same check locally before pushing
without triggering code generation.