### PR TITLE
fix(detail): show festival name instead of ID in app bar subtitle

### DIFF
--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -115,7 +115,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          '${provider.currentFestival.id} > ${drink.breweryName}',
+          '${provider.currentFestival.name} > ${drink.breweryName}',
           style: Theme.of(context).textTheme.labelSmall,
           overflow: TextOverflow.ellipsis,
         ),


### PR DESCRIPTION
## Summary

- Fix drink detail app bar subtitle showing raw festival ID (`cbf2025`) instead of human-readable name (`Cambridge Beer Festival 2025`)
- One-line change: `.id` → `.name` in `lib/screens/drink_detail_screen.dart` line 118

## Test plan

- [x] `./bin/mise run check` passes (analyze + test)
- [ ] Manual: open a drink detail view and confirm breadcrumb shows festival name

Fixes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)