### PR TITLE
docs(agents): add implicit patterns subsection to Code Style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,31 @@ Container(
 
 **Linter rules enforced** (among others): `prefer_const_constructors`, `prefer_const_declarations`, `prefer_final_locals`, `prefer_final_fields`, `avoid_print`, `prefer_single_quotes`, `sort_child_properties_last`, `use_key_in_widget_constructors`.
 
+### Patterns
+
+**Provider reads** — `context.watch<BeerProvider>()` in `build()` only (subscribes to rebuilds). `context.read<BeerProvider>()` in callbacks, `initState`, and post-frame callbacks (one-shot, no rebuild subscription). Analytics calls in `initState` must be deferred via `WidgetsBinding.instance.addPostFrameCallback()`.
+
+**Navigation** — always call `navigateToRoute()` from `lib/utils/navigation_helpers.dart`; it selects `context.go()` (web) or `context.push()` (mobile) automatically. Build URL paths with the typed helpers (`buildFestivalPath()`, `buildDrinkDetailPath()`, etc.) — never interpolate raw strings.
+
+**Loading/error states** — four mutually exclusive signals on `BeerProvider`:
+
+| Field | Widget | Condition |
+|---|---|---|
+| `_isLoading` | `CircularProgressIndicator` (full-screen) | cold load, no cached data |
+| `_isRefreshing` | `LinearProgressIndicator(minHeight: 2)` at top | background network refresh |
+| `_refreshNotice` (non-null) | dismissible banner | network failed, cached data shown |
+| `_error` (non-null) | full error view with Retry | blocking failure, no data |
+
+`_error` and `_refreshNotice` are never both non-null simultaneously.
+
+**Analytics** — always `unawaited(_analyticsService.logX(...))`. Don't log trivial/empty values (e.g. skip `logSearch` when the query is blank).
+
+**Null vs empty-set semantics** — `null` means "not set by user" or "unknown from API". Empty `Set {}` means the filter is active. Never use `0` or `''` as a sentinel for "not set".
+
+**Multiple toggles** — prefer `enum` + `Set<EnumValue>` over separate boolean fields. Persist as `prefs.setStringList('key', filters.map((f) => f.name).toList())`. See `DrinkVisibilityFilter` for the established pattern.
+
+**Tests** — mock generation uses mockito with `@GenerateNiceMocks([MockSpec<Foo>()])` (run `./bin/mise run generate` after adding annotations). Name test-data factory helpers `createSample{Model}()`. In widget tests, use `find.byKey(const ValueKey('id'))` for tappable elements and `find.widgetWithText(WidgetType, 'label')` to find options within lists.
+
 ---
 
 ## Accessibility Requirements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ Container(
 
 **Provider reads** — `context.watch<BeerProvider>()` in `build()` only (subscribes to rebuilds). `context.read<BeerProvider>()` in callbacks, `initState`, and post-frame callbacks (one-shot, no rebuild subscription). Analytics calls in `initState` must be deferred via `WidgetsBinding.instance.addPostFrameCallback()`.
 
-**Navigation** — always call `navigateToRoute()` from `lib/utils/navigation_helpers.dart`; it selects `context.go()` (web) or `context.push()` (mobile) automatically. Build URL paths with the typed helpers (`buildFestivalPath()`, `buildDrinkDetailPath()`, etc.) — never interpolate raw strings.
+**Navigation** — for drill-down navigation to content (drink detail, brewery), use `navigateToRoute()` from `lib/utils/navigation_helpers.dart`; it selects `context.go()` (web) or `context.push()` (mobile) automatically. For root/tab navigation that replaces the route stack (bottom nav, home button), use `context.go()` directly. Build URL paths with the typed helpers (`buildFestivalPath()`, `buildDrinkDetailPath()`, etc.) — never interpolate raw strings.
 
 **Loading/error states** — four mutually exclusive signals on `BeerProvider`:
 
@@ -176,9 +176,9 @@ Container(
 
 `_error` and `_refreshNotice` are never both non-null simultaneously.
 
-**Analytics** — always `unawaited(_analyticsService.logX(...))`. Don't log trivial/empty values (e.g. skip `logSearch` when the query is blank).
+**Analytics** — use `unawaited(_analyticsService.logX(...))` for UI interaction events (filters, sort, search, favourites, ratings). Await for festival selection (`logFestivalSelected`) and error reporting (`logError`), where the call must complete before proceeding. Don't log trivial/empty values (e.g. skip `logSearch` when the query is blank).
 
-**Null vs empty-set semantics** — `null` means "not set by user" or "unknown from API". Empty `Set {}` means the filter is active. Never use `0` or `''` as a sentinel for "not set".
+**Null vs empty-set semantics** — `null` means "not set by user" or "unknown from API". For filter fields, empty `Set {}` means no filter is applied (show all); a non-empty `Set` means the filter is active. Filter fields are always initialized to `{}`, never `null`. Never use `0` or `''` as a sentinel for "not set".
 
 **Multiple toggles** — prefer `enum` + `Set<EnumValue>` over separate boolean fields. Persist as `prefs.setStringList('key', filters.map((f) => f.name).toList())`. See `DrinkVisibilityFilter` for the established pattern.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ Container(
 
 `_error` and `_refreshNotice` are never both non-null simultaneously.
 
-**Analytics** — use `unawaited(_analyticsService.logX(...))` for UI interaction events (filters, sort, search, favourites, ratings). Await for festival selection (`logFestivalSelected`) and error reporting (`logError`), where the call must complete before proceeding. Don't log trivial/empty values (e.g. skip `logSearch` when the query is blank).
+**Analytics** — always `unawaited(_analyticsService.logX(...))`. Don't log trivial/empty values (e.g. skip `logSearch` when the query is blank).
 
 **Null vs empty-set semantics** — `null` means "not set by user" or "unknown from API". For filter fields, empty `Set {}` means no filter is applied (show all); a non-empty `Set` means the filter is active. Filter fields are always initialized to `{}`, never `null`. Never use `0` or `''` as a sentinel for "not set".
 


### PR DESCRIPTION
Documents seven conventions that are used consistently throughout
the codebase but weren't written down: provider watch/read rule,
web-vs-mobile navigation helpers, the four-state loading model,
analytics fire-and-forget pattern, null-vs-empty-set semantics,
enum+Set for multiple toggles, and mockito/test-fixture conventions.

Three anti-patterns found during the same review were NOT added as
conventions and are tracked as issues instead:
- #322 in-place Drink field mutation
- #323 missing == / hashCode on model classes
- #324 fragile string-based isConnectivityFailure() detection