### PR TITLE
fix(analytics): prevent Cloudflare Pages preview hosts from logging to production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,6 +419,30 @@ To update golden files:
 
 Use `testWidgets()` (not plain `test()`) when loading assets — it ensures the asset bundle is available. Don't use `TestWidgetsFlutterBinding.ensureInitialized()` in plain tests.
 
+### TDD Workflow (preferred for bug fixes)
+
+For bug fixes — especially on pure Dart services and domain logic — use red/green/refactor:
+
+1. **Red** — write the failing test first. If the code isn't testable (e.g. a `kIsWeb` guard blocks the VM), extract the logic into a `@visibleForTesting` pure static helper _before_ writing the tests. Tests call the helper directly; public methods delegate to it.
+2. **Green** — write the minimal code change to make the failing tests pass.
+3. **Refactor** — clean up with tests still green (improve defaults, remove redundancy, etc).
+
+**Testability pattern for static utility classes** — prefer extracting a named pure helper over adding an optional parameter to the public method:
+
+```dart
+// Public API — unchanged signature, delegates to helper
+static bool isProduction() {
+  if (!kIsWeb) return true;
+  return isProductionHost(Uri.base.host);
+}
+
+// Pure helper — all real logic, testable without a browser
+@visibleForTesting
+static bool isProductionHost(String hostname) { ... }
+```
+
+Tests call `isProductionHost(...)` directly, bypassing any platform guards. Note: lines that delegate to `Uri.base.host` will show as uncovered in Codecov — this is expected and acceptable, since the logic itself is fully covered via the helper.
+
 ---
 
 ## API Integration

--- a/lib/services/environment_service.dart
+++ b/lib/services/environment_service.dart
@@ -10,7 +10,7 @@ class EnvironmentService {
   /// Non-production environments:
   /// - staging.cambeerfestival.app (staging custom domain)
   /// - *.staging-cambeerfestival.pages.dev (staging Cloudflare Pages)
-  /// - *.cambeerfestival.pages.dev (PR preview Cloudflare Pages)
+  /// - *.cambeerfestival.pages.dev (Cloudflare Pages: PR previews and main staging branch)
   /// - localhost / 127.0.0.1 (local development)
   static bool isProduction() {
     if (!kIsWeb) return true;

--- a/lib/services/environment_service.dart
+++ b/lib/services/environment_service.dart
@@ -9,53 +9,49 @@ class EnvironmentService {
   ///
   /// Non-production environments:
   /// - staging.cambeerfestival.app (staging custom domain)
-  /// - *.staging-cambeerfestival.pages.dev (PR previews)
+  /// - *.staging-cambeerfestival.pages.dev (staging Cloudflare Pages)
+  /// - *.cambeerfestival.pages.dev (PR preview Cloudflare Pages)
   /// - localhost / 127.0.0.1 (local development)
   static bool isProduction() {
-    if (kIsWeb) {
-      // On web, check the window location hostname using Uri.base
-      final hostname = Uri.base.host;
-
-      // Production domain
-      if (hostname == 'cambeerfestival.app') {
-        return true;
-      }
-
-      // Non-production: staging, preview, and local development
-      if (hostname == 'staging.cambeerfestival.app' ||
-          hostname.endsWith('.staging-cambeerfestival.pages.dev') ||
-          hostname == 'localhost' ||
-          hostname == '127.0.0.1') {
-        return false;
-      }
-
-      // Default to production for unknown domains (safety fallback)
-      return true;
-    }
-
-    // On mobile platforms, always treat as production
-    // (mobile apps don't have staging environments)
-    return true;
+    if (!kIsWeb) return true;
+    return isProductionHost(Uri.base.host);
   }
 
   /// Get a human-readable environment name for debugging
   static String getEnvironmentName() {
-    if (!kIsWeb) {
-      return 'mobile';
+    if (!kIsWeb) return 'mobile';
+    return classifyHostname(Uri.base.host);
+  }
+
+  /// Pure hostname-to-production classification. Exposed for testing.
+  @visibleForTesting
+  static bool isProductionHost(String hostname) {
+    if (hostname == 'cambeerfestival.app') return true;
+
+    if (hostname == 'staging.cambeerfestival.app' ||
+        hostname.endsWith('.staging-cambeerfestival.pages.dev') ||
+        hostname.endsWith('.cambeerfestival.pages.dev') ||
+        hostname == 'localhost' ||
+        hostname == '127.0.0.1') {
+      return false;
     }
 
-    final hostname = Uri.base.host;
+    // Unknown hosts are not production — safer to under-count than pollute analytics.
+    return false;
+  }
 
-    if (hostname == 'cambeerfestival.app') {
-      return 'production';
-    } else if (hostname == 'staging.cambeerfestival.app') {
-      return 'staging';
-    } else if (hostname.endsWith('.staging-cambeerfestival.pages.dev')) {
+  /// Pure hostname-to-environment-name classification. Exposed for testing.
+  @visibleForTesting
+  static String classifyHostname(String hostname) {
+    if (hostname == 'cambeerfestival.app') return 'production';
+    if (hostname == 'staging.cambeerfestival.app') return 'staging';
+    if (hostname.endsWith('.staging-cambeerfestival.pages.dev') ||
+        hostname.endsWith('.cambeerfestival.pages.dev')) {
       return 'preview';
-    } else if (hostname == 'localhost' || hostname == '127.0.0.1') {
+    }
+    if (hostname == 'localhost' || hostname == '127.0.0.1') {
       return 'development';
     }
-
     return 'unknown';
   }
 }

--- a/test/environment_service_test.dart
+++ b/test/environment_service_test.dart
@@ -35,8 +35,6 @@ void main() {
     });
 
     test('Cloudflare Pages PR preview host → false', () {
-      // This is the bug: PR preview deployments like pr-42.cambeerfestival.pages.dev
-      // currently fall through to the production fallback and return true.
       expect(
         EnvironmentService.isProductionHost('pr-42.cambeerfestival.pages.dev'),
         isFalse,

--- a/test/environment_service_test.dart
+++ b/test/environment_service_test.dart
@@ -14,4 +14,99 @@ void main() {
       expect(EnvironmentService.getEnvironmentName(), equals('mobile'));
     });
   });
+
+  group('isProductionHost()', () {
+    test('production custom domain → true', () {
+      expect(
+          EnvironmentService.isProductionHost('cambeerfestival.app'), isTrue);
+    });
+
+    test('staging custom domain → false', () {
+      expect(EnvironmentService.isProductionHost('staging.cambeerfestival.app'),
+          isFalse);
+    });
+
+    test('staging Cloudflare Pages subdomain → false', () {
+      expect(
+        EnvironmentService.isProductionHost(
+            'abc123.staging-cambeerfestival.pages.dev'),
+        isFalse,
+      );
+    });
+
+    test('Cloudflare Pages PR preview host → false', () {
+      // This is the bug: PR preview deployments like pr-42.cambeerfestival.pages.dev
+      // currently fall through to the production fallback and return true.
+      expect(
+        EnvironmentService.isProductionHost('pr-42.cambeerfestival.pages.dev'),
+        isFalse,
+      );
+    });
+
+    test('main Cloudflare Pages deployment → false', () {
+      expect(
+        EnvironmentService.isProductionHost('main.cambeerfestival.pages.dev'),
+        isFalse,
+      );
+    });
+
+    test('localhost → false', () {
+      expect(EnvironmentService.isProductionHost('localhost'), isFalse);
+    });
+
+    test('loopback IP → false', () {
+      expect(EnvironmentService.isProductionHost('127.0.0.1'), isFalse);
+    });
+
+    test('unknown host → false', () {
+      // Safe default: unknown hosts should not be treated as production
+      // to avoid accidentally logging staging/test traffic.
+      expect(
+          EnvironmentService.isProductionHost('mystery.example.com'), isFalse);
+    });
+  });
+
+  group('classifyHostname()', () {
+    test('production custom domain → "production"', () {
+      expect(EnvironmentService.classifyHostname('cambeerfestival.app'),
+          equals('production'));
+    });
+
+    test('staging custom domain → "staging"', () {
+      expect(
+        EnvironmentService.classifyHostname('staging.cambeerfestival.app'),
+        equals('staging'),
+      );
+    });
+
+    test('staging Cloudflare Pages subdomain → "preview"', () {
+      expect(
+        EnvironmentService.classifyHostname(
+            'abc123.staging-cambeerfestival.pages.dev'),
+        equals('preview'),
+      );
+    });
+
+    test('Cloudflare Pages PR preview host → "preview"', () {
+      expect(
+        EnvironmentService.classifyHostname('pr-42.cambeerfestival.pages.dev'),
+        equals('preview'),
+      );
+    });
+
+    test('localhost → "development"', () {
+      expect(EnvironmentService.classifyHostname('localhost'),
+          equals('development'));
+    });
+
+    test('loopback IP → "development"', () {
+      expect(EnvironmentService.classifyHostname('127.0.0.1'),
+          equals('development'));
+    });
+
+    test('unknown host → "unknown"', () {
+      expect(EnvironmentService.classifyHostname('mystery.example.com'),
+          equals('unknown'));
+    });
+  });
 }


### PR DESCRIPTION
EnvironmentService misclassified any *.cambeerfestival.pages.dev host
(PR previews, main staging) as production because the pattern was missing
from the hostname check list. The result was staging/preview traffic mixing
into production Firebase Analytics metrics.

Also extracts the hostname classification logic into @visibleForTesting
pure static helpers (isProductionHost, classifyHostname) so the web
branching logic can be unit-tested without a browser. Flips the
unknown-host fallback from true to false — safer to under-count prod
events than to pollute analytics from unknown environments.

Expands test/environment_service_test.dart from 2 mobile-only tests
to 17 tests covering all hostname patterns.

Fixes #269

https://claude.ai/code/session_01FkwdCMxUeA5uyy1d8wBQNL