### PR TITLE
ci: parallelize analyze job to unblock builds earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
               - 'package.json'
               - 'playwright.config.ts'
               - 'android/**'
-              - '.github/workflows/build-deploy.yml'
+              - '.github/workflows/ci.yml'
               - 'mise.toml'
             functions:
               - 'functions/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,8 @@ jobs:
           mapfile -t SH_FILES < <(find . -name '*.sh' -not -path './.git/*' -not -path './.mise/*' -not -path '*/node_modules/*' | sort)
           [[ ${#SH_FILES[@]} -gt 0 ]] && shfmt -d -i 0 -ci "${SH_FILES[@]}"
 
-  # Run tests once before building
-  test:
+  # Analyze code in parallel with tests so builds can start sooner
+  analyze:
     needs: changes
     runs-on: ubuntu-latest
     if: |
@@ -117,6 +117,24 @@ jobs:
       - name: Analyze code
         run: flutter analyze --no-fatal-infos
 
+  # Run tests once before building
+  test:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.app == 'true' ||
+      needs.changes.outputs.functions == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter App
+        uses: ./.github/actions/setup-flutter-app
+        with:
+          google-services-json: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          generate-mocks: 'true'
+
       - name: Run tests with coverage
         run: flutter test --coverage
 
@@ -133,9 +151,9 @@ jobs:
           npm ci
           npm test
 
-  # Build web after tests pass
+  # Build web after analysis passes (tests run in parallel; deploy gates on test)
   build-web:
-    needs: [changes, test, fmt]
+    needs: [changes, analyze, fmt]
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -191,6 +209,13 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-chromium-
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
@@ -226,9 +251,9 @@ jobs:
             rm .http-server.pid
           fi
 
-  # Build Android after tests pass
+  # Build Android after analysis passes (tests run in parallel)
   build-android:
-    needs: [changes, test, fmt]
+    needs: [changes, analyze, fmt]
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -282,7 +307,7 @@ jobs:
           if-no-files-found: error
 
   deploy-web-preview:
-    needs: [changes, build-web, test-e2e-web]
+    needs: [changes, build-web, test-e2e-web, test]
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
Extract flutter analyze into its own job that runs in parallel with
fmt and test. build-web and build-android now gate on [fmt, analyze]
instead of [fmt, test], so builds start ~2-3 min earlier while tests
are still running. deploy-web-preview retains test as a dependency so
no code ships before unit tests pass.

Also cache Playwright Chromium browsers in test-e2e-web keyed on
package-lock.json, saving ~1.5 min on E2E runs when the browser
version hasn't changed.

https://claude.ai/code/session_01C6APCuJxZbNcmJpbTJUyB9