### PR TITLE
fix(provider): rate-limit refreshIfStale retries after failed network calls

### DIFF
--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -42,9 +42,19 @@ class BeerProvider extends ChangeNotifier {
   DateTime? _lastDrinksRefresh;
   DateTime? _lastFestivalsRefresh;
 
+  // Per-attempt timestamps — set on every call regardless of success/failure.
+  // Used by refreshIfStale to rate-limit retries without suppressing the
+  // staleness window for a successfully recovered network.
+  DateTime? _lastDrinksRefreshAttempt;
+  DateTime? _lastFestivalsRefreshAttempt;
+
   // Staleness thresholds
   static const Duration _drinksStalenessThreshold = Duration(hours: 1);
   static const Duration _festivalsStalenessThreshold = Duration(hours: 24);
+
+  // Minimum interval between refresh attempts (covers failed refreshes so the
+  // app doesn't hammer the network on every resume when offline).
+  static const Duration _refreshRetryThreshold = Duration(minutes: 1);
 
   // Token incremented on every new drinks load; stale responses check against it
   int _drinksLoadToken = 0;
@@ -104,6 +114,16 @@ class BeerProvider extends ChangeNotifier {
   bool get hasFestivals => _festivals.isNotEmpty;
   ThemeMode get themeMode => _themeMode;
   DateTime? get lastDrinksRefresh => _lastDrinksRefresh;
+  @visibleForTesting
+  DateTime? get lastDrinksRefreshAttempt => _lastDrinksRefreshAttempt;
+  @visibleForTesting
+  set lastDrinksRefreshAttempt(DateTime? value) =>
+      _lastDrinksRefreshAttempt = value;
+  @visibleForTesting
+  DateTime? get lastFestivalsRefreshAttempt => _lastFestivalsRefreshAttempt;
+  @visibleForTesting
+  set lastFestivalsRefreshAttempt(DateTime? value) =>
+      _lastFestivalsRefreshAttempt = value;
   AnalyticsService get analyticsService => _analyticsService;
 
   /// Get unique categories from loaded drinks
@@ -329,6 +349,7 @@ class BeerProvider extends ChangeNotifier {
         _festivals = [];
       }
     } finally {
+      _lastFestivalsRefreshAttempt = DateTime.now();
       _isFestivalsLoading = false;
       notifyListeners();
     }
@@ -466,6 +487,7 @@ class BeerProvider extends ChangeNotifier {
       }
     } finally {
       if (token == _drinksLoadToken) {
+        _lastDrinksRefreshAttempt = DateTime.now();
         _isLoading = false;
         _isRefreshing = false;
         notifyListeners();
@@ -498,13 +520,20 @@ class BeerProvider extends ChangeNotifier {
     // and the older response gets discarded via the token.
     if (_isLoading || _isRefreshing || _isFestivalsLoading) return;
 
-    // Refresh festivals if stale
-    if (isFestivalsDataStale) {
+    final now = DateTime.now();
+
+    // Rate-limit retries: skip if an attempt was made recently (e.g. last call
+    // failed with the network offline but cached data kept the app usable).
+    // This prevents hammering the network on every app-resume while offline.
+    final festivalsRetryReady = _lastFestivalsRefreshAttempt == null ||
+        now.difference(_lastFestivalsRefreshAttempt!) > _refreshRetryThreshold;
+    if (isFestivalsDataStale && festivalsRetryReady) {
       await loadFestivals();
     }
 
-    // Refresh drinks if stale
-    if (isDrinksDataStale) {
+    final drinksRetryReady = _lastDrinksRefreshAttempt == null ||
+        now.difference(_lastDrinksRefreshAttempt!) > _refreshRetryThreshold;
+    if (isDrinksDataStale && drinksRetryReady) {
       await loadDrinks();
     }
   }

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -520,19 +520,21 @@ class BeerProvider extends ChangeNotifier {
     // and the older response gets discarded via the token.
     if (_isLoading || _isRefreshing || _isFestivalsLoading) return;
 
-    final now = DateTime.now();
-
     // Rate-limit retries: skip if an attempt was made recently (e.g. last call
     // failed with the network offline but cached data kept the app usable).
     // This prevents hammering the network on every app-resume while offline.
+    // DateTime.now() is evaluated separately for each check so that a slow
+    // loadFestivals() await doesn't cause the drinks check to use a stale time.
     final festivalsRetryReady = _lastFestivalsRefreshAttempt == null ||
-        now.difference(_lastFestivalsRefreshAttempt!) > _refreshRetryThreshold;
+        DateTime.now().difference(_lastFestivalsRefreshAttempt!) >
+            _refreshRetryThreshold;
     if (isFestivalsDataStale && festivalsRetryReady) {
       await loadFestivals();
     }
 
     final drinksRetryReady = _lastDrinksRefreshAttempt == null ||
-        now.difference(_lastDrinksRefreshAttempt!) > _refreshRetryThreshold;
+        DateTime.now().difference(_lastDrinksRefreshAttempt!) >
+            _refreshRetryThreshold;
     if (isDrinksDataStale && drinksRetryReady) {
       await loadDrinks();
     }

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -1840,6 +1840,143 @@ void main() {
         // Data should still be fresh after festival change
         expect(provider.isDrinksDataStale, isFalse);
       });
+
+      test('loadFestivals stamps attempt timestamp even when network fails',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        when(mockFestivalRepository.getFestivals())
+            .thenThrow(Exception('offline'));
+        when(mockFestivalRepository.getCachedFestivals())
+            .thenAnswer((_) async => null);
+
+        expect(provider.lastFestivalsRefreshAttempt, isNull);
+        await provider.loadFestivals();
+        expect(provider.lastFestivalsRefreshAttempt, isNotNull);
+      });
+
+      test('refreshIfStale skips festivals retry when last attempt was recent',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        when(mockFestivalRepository.getFestivals())
+            .thenThrow(Exception('offline'));
+        when(mockFestivalRepository.getCachedFestivals())
+            .thenAnswer((_) async => null);
+
+        // First attempt fails and stamps the attempt timestamp.
+        await provider.loadFestivals();
+        expect(provider.isFestivalsDataStale, isTrue);
+
+        reset(mockFestivalRepository);
+
+        // Suppress drinks retry too: loadDrinks() would internally call
+        // loadFestivals() when _currentFestival is null and _festivals is empty.
+        provider.lastDrinksRefreshAttempt = DateTime.now();
+
+        // Immediate retry via refreshIfStale must be suppressed.
+        await provider.refreshIfStale();
+        verifyNever(mockFestivalRepository.getFestivals());
+      });
+
+      test(
+          'refreshIfStale retries festivals when last attempt is past threshold',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        when(mockFestivalRepository.getFestivals())
+            .thenThrow(Exception('offline'));
+        when(mockFestivalRepository.getCachedFestivals())
+            .thenAnswer((_) async => null);
+
+        // Simulate a stale attempt by backdating the timestamp.
+        provider.lastFestivalsRefreshAttempt =
+            DateTime.now().subtract(const Duration(minutes: 2));
+        // Suppress drinks retry so loadDrinks() doesn't re-trigger loadFestivals().
+        provider.lastDrinksRefreshAttempt = DateTime.now();
+
+        expect(provider.isFestivalsDataStale, isTrue);
+
+        await provider.refreshIfStale();
+        verify(mockFestivalRepository.getFestivals()).called(1);
+      });
+
+      test(
+          '_refreshDrinksFromNetwork stamps attempt timestamp even when network fails',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        when(mockDrinkRepository.getDrinks(any))
+            .thenThrow(Exception('offline'));
+
+        expect(provider.lastDrinksRefreshAttempt, isNull);
+        await provider.loadDrinks();
+        expect(provider.lastDrinksRefreshAttempt, isNotNull);
+      });
+
+      test('refreshIfStale skips drinks retry when last attempt was recent',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        when(mockDrinkRepository.getDrinks(any))
+            .thenThrow(Exception('offline'));
+
+        // First attempt fails and stamps the attempt timestamp.
+        await provider.loadDrinks();
+        expect(provider.isDrinksDataStale, isTrue);
+
+        reset(mockDrinkRepository);
+
+        // Immediate retry via refreshIfStale must be suppressed.
+        await provider.refreshIfStale();
+        verifyNever(mockDrinkRepository.getDrinks(any));
+      });
+
+      test('refreshIfStale retries drinks when last attempt is past threshold',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+        when(mockDrinkRepository.getCachedDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        when(mockDrinkRepository.getDrinks(any))
+            .thenThrow(Exception('offline'));
+
+        // Simulate a stale attempt by backdating the attempt timestamp.
+        provider.lastDrinksRefreshAttempt =
+            DateTime.now().subtract(const Duration(minutes: 2));
+
+        expect(provider.isDrinksDataStale, isTrue);
+
+        when(mockDrinkRepository.getDrinks(any))
+            .thenAnswer((_) async => createSampleDrinks());
+        await provider.refreshIfStale();
+        verify(mockDrinkRepository.getDrinks(any)).called(1);
+      });
     });
 
     group('tasted, refresh and favourite filtering', () {


### PR DESCRIPTION
Previously _lastFestivalsRefresh and _lastDrinksRefresh were only set on
successful network responses. On a persistently offline device, both
timestamps stayed null after every failed loadFestivals / loadDrinks call,
so isFestivalsDataStale / isDrinksDataStale always returned true and
refreshIfStale fired a new network request on every app-resume event.

Adds _lastFestivalsRefreshAttempt and _lastDrinksRefreshAttempt, stamped
in the finally block of every attempt (success or failure). refreshIfStale
skips a re-fetch when the last attempt was less than one minute ago,
preventing the network-hammer pattern while still allowing natural retries
once the window passes or the 24 h / 1 h staleness thresholds expire.

Fixes #307

https://claude.ai/code/session_01KwcNezhdSo2VRH549UgQgb