### PR TITLE
ci: skip build-android and deploy-web-preview for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,8 +256,10 @@ jobs:
     needs: [changes, analyze, fmt]
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      needs.changes.outputs.app == 'true'
+      github.actor != 'dependabot[bot]' && (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.app == 'true'
+      )
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -310,9 +312,11 @@ jobs:
     needs: [changes, build-web, test-e2e-web, test]
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      needs.changes.outputs.app == 'true' ||
-      needs.changes.outputs.functions == 'true'
+      github.actor != 'dependabot[bot]' && (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.app == 'true' ||
+        needs.changes.outputs.functions == 'true'
+      )
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Both jobs require secrets (signing keys, CLOUDFLARE_API_TOKEN) that
GitHub withholds from dependabot by default, so they always fail on
dependabot PRs. Skip them rather than burning CI time on guaranteed
failures.

https://claude.ai/code/session_018shLcTuhXM7BkeGvjwnrea