### PR TITLE
refactor(storage): centralize SharedPreferences keys in PreferenceKeys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,9 +384,11 @@ void setMyField(String? value) {
 
 ### Adding User Preferences
 
-1. Create key constant for SharedPreferences
+1. Add the key to `PreferenceKeys` (`lib/constants/preference_keys.dart`) and pin its value in `test/constants/preference_keys_test.dart`. **Never use an inline SharedPreferences key string** — a mistyped key reads back `null` and silently loses the user's data. All `prefs.getX`/`setX` calls reference `PreferenceKeys.*`.
 2. Add to appropriate service (`FavoritesService`, `RatingsService`, or new)
 3. Load in `BeerProvider.initialize()`
+
+> **Changing an existing key's value** breaks data already stored under the old key — treat it as a data migration, not a rename. The pinned test will fail to force a deliberate decision.
 
 > **Drink categories are dynamic** — they come from API data, no code changes needed to support new ones.
 

--- a/lib/constants/preference_keys.dart
+++ b/lib/constants/preference_keys.dart
@@ -20,6 +20,10 @@ class PreferenceKeys {
   /// Active drink visibility filters. Stored as a string list of enum names.
   static const visibilityFilters = 'visibilityFilters';
 
+  /// Legacy boolean preference superseded by [visibilityFilters]. Read-only:
+  /// migrated on load (see `BeerProvider.initialize`) and never written again.
+  static const hideUnavailableLegacy = 'hideUnavailable';
+
   /// Allergens the user has excluded. Stored as a string list.
   static const excludedAllergens = 'excludedAllergens';
 

--- a/lib/constants/preference_keys.dart
+++ b/lib/constants/preference_keys.dart
@@ -1,0 +1,55 @@
+/// Centralized SharedPreferences key definitions.
+///
+/// Every persisted value in the app must reference a key from this class rather
+/// than an inline string literal. A mistyped key reads back `null` and silently
+/// loses the user's data, so keeping the producer and consumer of each key in
+/// one place removes that class of bug.
+///
+/// **These string values are part of the on-disk format.** Changing one orphans
+/// every value already stored under the old key. Don't edit a value here unless
+/// you also migrate existing data. [PreferenceKeys] is guarded by a test that
+/// pins the literals.
+class PreferenceKeys {
+  PreferenceKeys._();
+
+  // --- BeerProvider ---
+
+  /// Persisted [ThemeMode] index. Stored with `setInt`.
+  static const themeMode = 'themeMode';
+
+  /// Active drink visibility filters. Stored as a string list of enum names.
+  static const visibilityFilters = 'visibilityFilters';
+
+  /// Allergens the user has excluded. Stored as a string list.
+  static const excludedAllergens = 'excludedAllergens';
+
+  // --- FavoritesService ---
+
+  /// Base key for favourite drink IDs. Festival-scoped as `${favorites}_$festivalId`.
+  static const favorites = 'favorites';
+
+  // --- RatingsService ---
+
+  /// Base key for personal ratings. Scoped as `${ratings}_${festivalId}_$drinkId`.
+  static const ratings = 'ratings';
+
+  // --- FestivalStorageService ---
+
+  /// The last selected festival ID. Stored with `setString`.
+  static const selectedFestivalId = 'selected_festival_id';
+
+  // --- TastingLogService ---
+
+  /// Prefix for tasting-log entries. Scoped as `$tastingLogPrefix${festivalId}|$drinkId`.
+  static const tastingLogPrefix = 'tasting_log_';
+
+  // --- DrinkCacheService ---
+
+  /// Prefix for the per-festival drinks cache. Scoped as `${drinksCachePrefix}_$festivalId`.
+  static const drinksCachePrefix = 'drinks_cache';
+
+  // --- FestivalCacheService ---
+
+  /// The cached festival registry. Stored with `setString`.
+  static const festivalsCache = 'festivals_cache';
+}

--- a/lib/constants/preference_keys.dart
+++ b/lib/constants/preference_keys.dart
@@ -10,7 +10,7 @@
 /// you also migrate existing data. [PreferenceKeys] is guarded by a test that
 /// pins the literals.
 class PreferenceKeys {
-  PreferenceKeys._();
+  PreferenceKeys._(); // coverage:ignore-line
 
   // --- BeerProvider ---
 

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -274,7 +274,7 @@ class BeerProvider extends ChangeNotifier {
       }
     } else {
       // Migrate from legacy 'hideUnavailable' boolean preference
-      if (prefs.getBool('hideUnavailable') ?? false) {
+      if (prefs.getBool(PreferenceKeys.hideUnavailableLegacy) ?? false) {
         _visibilityFilters.add(DrinkVisibilityFilter.availableOnly);
       }
     }

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
+import '../constants/preference_keys.dart';
 import '../models/models.dart';
 import '../services/services.dart';
 import '../domain/services/services.dart';
@@ -257,12 +258,13 @@ class BeerProvider extends ChangeNotifier {
     }
 
     // Load theme mode preference
-    final themeIndex = prefs.getInt('themeMode') ?? ThemeMode.system.index;
+    final themeIndex =
+        prefs.getInt(PreferenceKeys.themeMode) ?? ThemeMode.system.index;
     _themeMode = ThemeMode.values[themeIndex];
 
     // Load visibility filter preferences (with migration from legacy hideUnavailable key)
     _visibilityFilters = {};
-    final savedFilters = prefs.getStringList('visibilityFilters');
+    final savedFilters = prefs.getStringList(PreferenceKeys.visibilityFilters);
     if (savedFilters != null) {
       for (final name in savedFilters) {
         final filter = DrinkVisibilityFilter.values
@@ -279,7 +281,7 @@ class BeerProvider extends ChangeNotifier {
 
     // Load excluded allergens preference
     _excludedAllergens =
-        Set.from(prefs.getStringList('excludedAllergens') ?? []);
+        Set.from(prefs.getStringList(PreferenceKeys.excludedAllergens) ?? []);
 
     // Populate festivals from cache so the switcher works offline and we can
     // resolve the saved selection without waiting on the network.
@@ -651,7 +653,7 @@ class BeerProvider extends ChangeNotifier {
     // Persist the full set of active filters
     final prefs = await SharedPreferences.getInstance();
     await prefs.setStringList(
-      'visibilityFilters',
+      PreferenceKeys.visibilityFilters,
       _visibilityFilters.map((f) => f.name).toList(),
     );
   }
@@ -663,7 +665,7 @@ class BeerProvider extends ChangeNotifier {
     notifyListeners();
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList('visibilityFilters', []);
+    await prefs.setStringList(PreferenceKeys.visibilityFilters, []);
   }
 
   /// Toggle a per-allergen exclusion filter and persist
@@ -677,7 +679,8 @@ class BeerProvider extends ChangeNotifier {
     notifyListeners();
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList('excludedAllergens', _excludedAllergens.toList());
+    await prefs.setStringList(
+        PreferenceKeys.excludedAllergens, _excludedAllergens.toList());
   }
 
   /// Clear all allergen exclusion filters and persist
@@ -687,7 +690,7 @@ class BeerProvider extends ChangeNotifier {
     notifyListeners();
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList('excludedAllergens', []);
+    await prefs.setStringList(PreferenceKeys.excludedAllergens, []);
   }
 
   /// Set theme mode and persist preference
@@ -697,7 +700,7 @@ class BeerProvider extends ChangeNotifier {
 
     // Persist the preference
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt('themeMode', mode.index);
+    await prefs.setInt(PreferenceKeys.themeMode, mode.index);
   }
 
   /// Toggle favorite status for a drink

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../constants/preference_keys.dart';
 import '../models/models.dart';
 import 'beer_api_service.dart';
 import 'festival_service.dart';
@@ -17,7 +18,7 @@ import 'festival_service.dart';
 /// work on web; this trades off ideal large-blob handling for simplicity, so a
 /// small number of festival snapshots are retained ([_maxCachedFestivals]).
 class DrinkCacheService {
-  static const _keyPrefix = 'drinks_cache';
+  static const _keyPrefix = PreferenceKeys.drinksCachePrefix;
   static const _maxCachedFestivals = 12;
 
   final SharedPreferences _prefs;
@@ -162,7 +163,7 @@ class DrinkCacheUpdate {
 /// Persists the last successfully fetched festival registry so the festival
 /// switcher and a saved festival selection work offline at startup.
 class FestivalCacheService {
-  static const _key = 'festivals_cache';
+  static const _key = PreferenceKeys.festivalsCache;
 
   final SharedPreferences _prefs;
 

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -1,8 +1,10 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../constants/preference_keys.dart';
+
 /// Service for managing favorites locally
 class FavoritesService {
-  static const _favoritesKey = 'favorites';
+  static const _favoritesKey = PreferenceKeys.favorites;
 
   final SharedPreferences _prefs;
 
@@ -57,7 +59,7 @@ class FavoritesService {
 
 /// Service for managing personal ratings locally
 class RatingsService {
-  static const _ratingsKey = 'ratings';
+  static const _ratingsKey = PreferenceKeys.ratings;
 
   final SharedPreferences _prefs;
 
@@ -91,7 +93,7 @@ class RatingsService {
 
 /// Service for managing festival selection persistence
 class FestivalStorageService {
-  static const _selectedFestivalKey = 'selected_festival_id';
+  static const _selectedFestivalKey = PreferenceKeys.selectedFestivalId;
 
   final SharedPreferences _prefs;
 

--- a/lib/services/tasting_log_service.dart
+++ b/lib/services/tasting_log_service.dart
@@ -1,11 +1,13 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../constants/preference_keys.dart';
+
 /// Service for tracking which drinks a user has tasted at festivals
 ///
 /// Stores tasting logs with timestamps, allowing users to mark drinks
 /// they've tried during a festival session.
 class TastingLogService {
-  static const String _tastingLogPrefix = 'tasting_log_';
+  static const String _tastingLogPrefix = PreferenceKeys.tastingLogPrefix;
 
   final SharedPreferences _prefs;
 

--- a/test/constants/preference_keys_test.dart
+++ b/test/constants/preference_keys_test.dart
@@ -1,0 +1,36 @@
+import 'package:cambridge_beer_festival/constants/preference_keys.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // These literals are part of the on-disk SharedPreferences format. Changing a
+  // value orphans data already stored under the old key, so this test pins each
+  // one: a failure here means a migration is required, not a casual edit.
+  group('PreferenceKeys', () {
+    test('key values match the shipped on-disk format', () {
+      expect(PreferenceKeys.themeMode, 'themeMode');
+      expect(PreferenceKeys.visibilityFilters, 'visibilityFilters');
+      expect(PreferenceKeys.excludedAllergens, 'excludedAllergens');
+      expect(PreferenceKeys.favorites, 'favorites');
+      expect(PreferenceKeys.ratings, 'ratings');
+      expect(PreferenceKeys.selectedFestivalId, 'selected_festival_id');
+      expect(PreferenceKeys.tastingLogPrefix, 'tasting_log_');
+      expect(PreferenceKeys.drinksCachePrefix, 'drinks_cache');
+      expect(PreferenceKeys.festivalsCache, 'festivals_cache');
+    });
+
+    test('keys are unique', () {
+      final keys = <String>[
+        PreferenceKeys.themeMode,
+        PreferenceKeys.visibilityFilters,
+        PreferenceKeys.excludedAllergens,
+        PreferenceKeys.favorites,
+        PreferenceKeys.ratings,
+        PreferenceKeys.selectedFestivalId,
+        PreferenceKeys.tastingLogPrefix,
+        PreferenceKeys.drinksCachePrefix,
+        PreferenceKeys.festivalsCache,
+      ];
+      expect(keys.toSet().length, keys.length);
+    });
+  });
+}

--- a/test/constants/preference_keys_test.dart
+++ b/test/constants/preference_keys_test.dart
@@ -9,6 +9,7 @@ void main() {
     test('key values match the shipped on-disk format', () {
       expect(PreferenceKeys.themeMode, 'themeMode');
       expect(PreferenceKeys.visibilityFilters, 'visibilityFilters');
+      expect(PreferenceKeys.hideUnavailableLegacy, 'hideUnavailable');
       expect(PreferenceKeys.excludedAllergens, 'excludedAllergens');
       expect(PreferenceKeys.favorites, 'favorites');
       expect(PreferenceKeys.ratings, 'ratings');
@@ -22,6 +23,7 @@ void main() {
       final keys = <String>[
         PreferenceKeys.themeMode,
         PreferenceKeys.visibilityFilters,
+        PreferenceKeys.hideUnavailableLegacy,
         PreferenceKeys.excludedAllergens,
         PreferenceKeys.favorites,
         PreferenceKeys.ratings,


### PR DESCRIPTION
## Summary

SharedPreferences key strings were hardcoded across `BeerProvider` and four storage services, with the same conceptual key referenced in several places. A mistyped key reads back `null` and silently loses the user's data — a shotgun-surgery smell with a real correctness risk.

This introduces a single `PreferenceKeys` constants class and references it from every call site. **String values are unchanged**, so no data already on disk is orphaned.

Closes #352

## Changes

- **New `lib/constants/preference_keys.dart`** — one class holding all 9 keys, documented with the festival/drink-scoping format for each (`favorites`, `ratings`, `selected_festival_id`, `tasting_log_`, `drinks_cache`, `festivals_cache`, `themeMode`, `visibilityFilters`, `excludedAllergens`).
- **Wired every call site** to the constants:
  - `lib/providers/beer_provider.dart` — `themeMode`, `visibilityFilters`, `excludedAllergens` (8 inline literals removed)
  - `lib/services/storage_service.dart` — `favorites`, `ratings`, `selected_festival_id`
  - `lib/services/tasting_log_service.dart` — `tasting_log_` prefix
  - `lib/services/cache_service.dart` — `drinks_cache`, `festivals_cache`
- **New `test/constants/preference_keys_test.dart`** — pins each literal to its shipped value and asserts uniqueness, so any future value change fails loudly (signalling a required data migration rather than silent data loss).
- **`AGENTS.md`** — "Adding User Preferences" now mandates `PreferenceKeys` (no inline literals) and flags that changing an existing key's value is a data migration.

## Verification

- `./bin/mise run check` passes — analyzer clean, all tests green (including the new guard test).
- `dart format` reports 0 changes.
- Confirmed no raw prefs-key literals remain in `lib/` outside `PreferenceKeys`.

## Risk

Low. No behaviour change; key values are byte-for-byte identical to what shipped, so stored favourites/ratings/caches/preferences are preserved.

https://claude.ai/code/session_01LMCCAWaNbGxzWrdzzT6UpH

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMCCAWaNbGxzWrdzzT6UpH)_