### PR TITLE
refactor(provider): extract DrinkFilterController from BeerProvider

### DIFF
--- a/lib/domain/controllers/controllers.dart
+++ b/lib/domain/controllers/controllers.dart
@@ -1,0 +1,2 @@
+// Domain controllers - stateful application logic independent of UI and data layers
+export 'drink_filter_controller.dart';

--- a/lib/domain/controllers/drink_filter_controller.dart
+++ b/lib/domain/controllers/drink_filter_controller.dart
@@ -1,0 +1,237 @@
+import '../../models/models.dart';
+import '../models/models.dart';
+import '../services/services.dart';
+
+/// Owns drink filtering, sorting, and search state, and derives the views the
+/// UI needs (the filtered list plus category/style/allergen facets).
+///
+/// Pure application logic: no Flutter, persistence, async, or analytics
+/// dependencies, so it can be unit-tested in isolation. [BeerProvider] composes
+/// this controller, feeds it the loaded drinks via [setSource], and handles the
+/// cross-cutting concerns (persistence, analytics, change notification) around
+/// it.
+///
+/// All mutators are synchronous and side-effect free; callers are responsible
+/// for persisting and broadcasting changes.
+class DrinkFilterController {
+  final DrinkFilterService _filterService;
+  final DrinkSortService _sortService;
+
+  DrinkFilterController({
+    DrinkFilterService? filterService,
+    DrinkSortService? sortService,
+  })  : _filterService = filterService ?? DrinkFilterService(),
+        _sortService = sortService ?? DrinkSortService();
+
+  List<Drink> _source = [];
+  List<Drink> _filtered = [];
+
+  String? _selectedCategory;
+  Set<String> _selectedStyles = {};
+  DrinkSort _currentSort = DrinkSort.nameAsc;
+  String _searchQuery = '';
+  bool _showFavoritesOnly = false;
+  Set<DrinkVisibilityFilter> _visibilityFilters = {};
+  Set<String> _excludedAllergens = {};
+
+  // --- Criteria getters ---
+
+  String? get selectedCategory => _selectedCategory;
+  Set<String> get selectedStyles => _selectedStyles;
+  DrinkSort get currentSort => _currentSort;
+  String get searchQuery => _searchQuery;
+  bool get showFavoritesOnly => _showFavoritesOnly;
+  Set<DrinkVisibilityFilter> get visibilityFilters =>
+      Set.unmodifiable(_visibilityFilters);
+  Set<String> get excludedAllergens => Set.unmodifiable(_excludedAllergens);
+
+  /// Convenience flag mirroring the `availableOnly` visibility filter.
+  bool get hideUnavailable =>
+      _visibilityFilters.contains(DrinkVisibilityFilter.availableOnly);
+
+  // --- Derived views ---
+
+  /// Drinks after the active filters and sort have been applied.
+  List<Drink> get filteredDrinks => _filtered;
+
+  /// Unique categories present in the source drinks, sorted.
+  List<String> get availableCategories {
+    final categories = _source.map((d) => d.category).toSet().toList();
+    categories.sort();
+    return categories;
+  }
+
+  /// Unique styles in the source drinks, narrowed to the selected category when
+  /// one is active, sorted.
+  List<String> get availableStyles {
+    final styles = _categoryScopedSource()
+        .where((d) => d.style != null && d.style!.isNotEmpty)
+        .map((d) => d.style!)
+        .toSet()
+        .toList();
+    styles.sort();
+    return styles;
+  }
+
+  /// Drink count per category across the full source.
+  Map<String, int> get categoryCountsMap {
+    final counts = <String, int>{};
+    for (final drink in _source) {
+      counts[drink.category] = (counts[drink.category] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  /// Drink count per style, narrowed to the selected category when one is
+  /// active.
+  Map<String, int> get styleCountsMap {
+    final counts = <String, int>{};
+    for (final drink in _categoryScopedSource()) {
+      if (drink.style != null && drink.style!.isNotEmpty) {
+        counts[drink.style!] = (counts[drink.style!] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }
+
+  /// Every allergen key present across the source drinks.
+  Set<String> get availableAllergens {
+    final allergens = <String>{};
+    for (final drink in _source) {
+      allergens.addAll(drink.allergens.keys);
+    }
+    return allergens;
+  }
+
+  // --- Source management ---
+
+  /// Replace the drinks being filtered and recompute the filtered list.
+  void setSource(List<Drink> drinks) {
+    _source = drinks;
+    recompute();
+  }
+
+  /// Re-run the filter/sort pipeline against the current source. Use after the
+  /// source drinks mutate in place (e.g. favourite/tasted toggles).
+  void recompute() {
+    final filtered = _filterService.filterDrinks(
+      _source,
+      category: _selectedCategory,
+      styles: _selectedStyles,
+      favoritesOnly: _showFavoritesOnly,
+      visibilityFilters: _visibilityFilters,
+      excludedAllergens: _excludedAllergens,
+      searchQuery: _searchQuery,
+    );
+    _filtered = _sortService.sortDrinks(filtered, _currentSort);
+  }
+
+  // --- Mutators (synchronous, no side effects) ---
+
+  /// Set the category filter. Clears any active style filter, since styles are
+  /// category-dependent.
+  void setCategory(String? category) {
+    _selectedCategory = category;
+    if (_selectedStyles.isNotEmpty) {
+      _selectedStyles = {};
+    }
+    recompute();
+  }
+
+  /// Toggle a single style in the multi-select style filter.
+  void toggleStyle(String style) {
+    if (_selectedStyles.contains(style)) {
+      _selectedStyles = Set.from(_selectedStyles)..remove(style);
+    } else {
+      _selectedStyles = Set.from(_selectedStyles)..add(style);
+    }
+    recompute();
+  }
+
+  /// Clear all selected styles.
+  void clearStyles() {
+    _selectedStyles = {};
+    recompute();
+  }
+
+  /// Set the sort order.
+  void setSort(DrinkSort sort) {
+    _currentSort = sort;
+    recompute();
+  }
+
+  /// Set the search query (stored lower-cased to match existing behaviour).
+  void setSearchQuery(String query) {
+    _searchQuery = query.toLowerCase();
+    recompute();
+  }
+
+  /// Toggle the favourites-only filter.
+  void setShowFavoritesOnly(bool value) {
+    _showFavoritesOnly = value;
+    recompute();
+  }
+
+  /// Turn a visibility filter on or off.
+  void setVisibilityFilter(DrinkVisibilityFilter filter, bool active) {
+    if (active) {
+      _visibilityFilters = Set.from(_visibilityFilters)..add(filter);
+    } else {
+      _visibilityFilters = Set.from(_visibilityFilters)..remove(filter);
+    }
+    recompute();
+  }
+
+  /// Clear all visibility filters.
+  void clearVisibilityFilters() {
+    _visibilityFilters = {};
+    recompute();
+  }
+
+  /// Turn a per-allergen exclusion on or off.
+  void setAllergenFilter(String allergen, bool active) {
+    if (active) {
+      _excludedAllergens = Set.from(_excludedAllergens)..add(allergen);
+    } else {
+      _excludedAllergens = Set.from(_excludedAllergens)..remove(allergen);
+    }
+    recompute();
+  }
+
+  /// Clear all allergen exclusions.
+  void clearAllergenFilters() {
+    _excludedAllergens = {};
+    recompute();
+  }
+
+  /// Reset the category, style, and search filters (used when switching
+  /// festivals). Sort, visibility, and allergen preferences are intentionally
+  /// preserved.
+  void clearCategoryStyleSearch() {
+    _selectedCategory = null;
+    _selectedStyles = {};
+    _searchQuery = '';
+    recompute();
+  }
+
+  /// Seed the persisted filter preferences at startup without recomputing
+  /// (the source has not been loaded yet at hydration time).
+  void hydrate({
+    Set<DrinkVisibilityFilter>? visibilityFilters,
+    Set<String>? excludedAllergens,
+  }) {
+    if (visibilityFilters != null) {
+      _visibilityFilters = Set.from(visibilityFilters);
+    }
+    if (excludedAllergens != null) {
+      _excludedAllergens = Set.from(excludedAllergens);
+    }
+  }
+
+  /// Source narrowed to the selected category, or the full source when no
+  /// category is selected.
+  Iterable<Drink> _categoryScopedSource() {
+    if (_selectedCategory == null) return _source;
+    return _source.where((d) => d.category == _selectedCategory);
+  }
+}

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../constants/preference_keys.dart';
 import '../models/models.dart';
 import '../services/services.dart';
+import '../domain/controllers/controllers.dart';
 import '../domain/services/services.dart';
 import '../domain/repositories/repositories.dart';
 import '../domain/models/models.dart';
@@ -12,15 +13,17 @@ import '../domain/models/models.dart';
 /// Provider for managing beer festival data and state
 class BeerProvider extends ChangeNotifier {
   final AnalyticsService _analyticsService;
-  final DrinkFilterService _filterService;
-  final DrinkSortService _sortService;
+
+  /// Owns all filtering/sorting/search state and the derived views. This
+  /// provider feeds it the loaded drinks and handles persistence, analytics,
+  /// and change notification around it.
+  final DrinkFilterController _filter;
   DrinkRepository? _drinkRepository;
   FestivalRepository? _festivalRepository;
   ApiDrinkRepository? _ownedDrinkRepository;
   ApiFestivalRepository? _ownedFestivalRepository;
 
   List<Drink> _allDrinks = [];
-  List<Drink> _filteredDrinks = [];
   List<Festival> _festivals = [];
   Festival? _currentFestival;
   bool _isLoading = false;
@@ -30,13 +33,6 @@ class BeerProvider extends ChangeNotifier {
   String? _error;
   String? _refreshNotice;
   String? _festivalsError;
-  String? _selectedCategory;
-  Set<String> _selectedStyles = {};
-  DrinkSort _currentSort = DrinkSort.nameAsc;
-  String _searchQuery = '';
-  bool _showFavoritesOnly = false;
-  Set<DrinkVisibilityFilter> _visibilityFilters = {};
-  Set<String> _excludedAllergens = {};
   ThemeMode _themeMode = ThemeMode.system;
 
   // Timestamp tracking for automatic refresh
@@ -67,13 +63,15 @@ class BeerProvider extends ChangeNotifier {
     DrinkRepository? drinkRepository,
     FestivalRepository? festivalRepository,
   })  : _analyticsService = analyticsService ?? AnalyticsService(),
-        _filterService = filterService ?? DrinkFilterService(),
-        _sortService = sortService ?? DrinkSortService(),
+        _filter = DrinkFilterController(
+          filterService: filterService,
+          sortService: sortService,
+        ),
         _drinkRepository = drinkRepository,
         _festivalRepository = festivalRepository;
 
   // Getters
-  List<Drink> get drinks => _filteredDrinks;
+  List<Drink> get drinks => _filter.filteredDrinks;
   List<Drink> get allDrinks => _allDrinks;
   List<Festival> get festivals => _festivals;
 
@@ -94,23 +92,15 @@ class BeerProvider extends ChangeNotifier {
   /// Non-null when a background refresh failed but cached drinks remain shown.
   String? get refreshNotice => _refreshNotice;
   String? get festivalsError => _festivalsError;
-  String? get selectedCategory => _selectedCategory;
-  Set<String> get selectedStyles => _selectedStyles;
-  DrinkSort get currentSort => _currentSort;
-  String get searchQuery => _searchQuery;
-  bool get showFavoritesOnly => _showFavoritesOnly;
-  bool get hideUnavailable =>
-      _visibilityFilters.contains(DrinkVisibilityFilter.availableOnly);
-  Set<DrinkVisibilityFilter> get visibilityFilters =>
-      Set.unmodifiable(_visibilityFilters);
-  Set<String> get excludedAllergens => Set.unmodifiable(_excludedAllergens);
-  Set<String> get availableAllergens {
-    final allergens = <String>{};
-    for (final drink in _allDrinks) {
-      allergens.addAll(drink.allergens.keys);
-    }
-    return allergens;
-  }
+  String? get selectedCategory => _filter.selectedCategory;
+  Set<String> get selectedStyles => _filter.selectedStyles;
+  DrinkSort get currentSort => _filter.currentSort;
+  String get searchQuery => _filter.searchQuery;
+  bool get showFavoritesOnly => _filter.showFavoritesOnly;
+  bool get hideUnavailable => _filter.hideUnavailable;
+  Set<DrinkVisibilityFilter> get visibilityFilters => _filter.visibilityFilters;
+  Set<String> get excludedAllergens => _filter.excludedAllergens;
+  Set<String> get availableAllergens => _filter.availableAllergens;
 
   bool get hasFestivals => _festivals.isNotEmpty;
   ThemeMode get themeMode => _themeMode;
@@ -130,56 +120,16 @@ class BeerProvider extends ChangeNotifier {
   AnalyticsService get analyticsService => _analyticsService;
 
   /// Get unique categories from loaded drinks
-  List<String> get availableCategories {
-    final categories = _allDrinks.map((d) => d.category).toSet().toList();
-    categories.sort();
-    return categories;
-  }
+  List<String> get availableCategories => _filter.availableCategories;
 
   /// Get unique styles from loaded drinks (filtered by category if selected)
-  List<String> get availableStyles {
-    var drinks = _allDrinks;
-
-    // If a category is selected, only show styles from that category
-    if (_selectedCategory != null) {
-      drinks = drinks.where((d) => d.category == _selectedCategory).toList();
-    }
-
-    final styles = drinks
-        .where((d) => d.style != null && d.style!.isNotEmpty)
-        .map((d) => d.style!)
-        .toSet()
-        .toList();
-    styles.sort();
-    return styles;
-  }
+  List<String> get availableStyles => _filter.availableStyles;
 
   /// Get drink count by category
-  Map<String, int> get categoryCountsMap {
-    final counts = <String, int>{};
-    for (final drink in _allDrinks) {
-      counts[drink.category] = (counts[drink.category] ?? 0) + 1;
-    }
-    return counts;
-  }
+  Map<String, int> get categoryCountsMap => _filter.categoryCountsMap;
 
   /// Get drink count by style
-  Map<String, int> get styleCountsMap {
-    var drinks = _allDrinks;
-
-    // If a category is selected, only count styles from that category
-    if (_selectedCategory != null) {
-      drinks = drinks.where((d) => d.category == _selectedCategory).toList();
-    }
-
-    final counts = <String, int>{};
-    for (final drink in drinks) {
-      if (drink.style != null && drink.style!.isNotEmpty) {
-        counts[drink.style!] = (counts[drink.style!] ?? 0) + 1;
-      }
-    }
-    return counts;
-  }
+  Map<String, int> get styleCountsMap => _filter.styleCountsMap;
 
   /// Get favorite drinks
   List<Drink> get favoriteDrinks =>
@@ -263,25 +213,30 @@ class BeerProvider extends ChangeNotifier {
     _themeMode = ThemeMode.values[themeIndex];
 
     // Load visibility filter preferences (with migration from legacy hideUnavailable key)
-    _visibilityFilters = {};
+    final visibilityFilters = <DrinkVisibilityFilter>{};
     final savedFilters = prefs.getStringList(PreferenceKeys.visibilityFilters);
     if (savedFilters != null) {
       for (final name in savedFilters) {
         final filter = DrinkVisibilityFilter.values
             .where((f) => f.name == name)
             .firstOrNull;
-        if (filter != null) _visibilityFilters.add(filter);
+        if (filter != null) visibilityFilters.add(filter);
       }
     } else {
       // Migrate from legacy 'hideUnavailable' boolean preference
       if (prefs.getBool(PreferenceKeys.hideUnavailableLegacy) ?? false) {
-        _visibilityFilters.add(DrinkVisibilityFilter.availableOnly);
+        visibilityFilters.add(DrinkVisibilityFilter.availableOnly);
       }
     }
 
     // Load excluded allergens preference
-    _excludedAllergens =
-        Set.from(prefs.getStringList(PreferenceKeys.excludedAllergens) ?? []);
+    final excludedAllergens = Set<String>.from(
+        prefs.getStringList(PreferenceKeys.excludedAllergens) ?? []);
+
+    _filter.hydrate(
+      visibilityFilters: visibilityFilters,
+      excludedAllergens: excludedAllergens,
+    );
 
     // Populate festivals from cache so the switcher works offline and we can
     // resolve the saved selection without waiting on the network.
@@ -384,7 +339,7 @@ class BeerProvider extends ChangeNotifier {
       if (token != _drinksLoadToken) return;
       if (cached != null) {
         _allDrinks = cached;
-        _applyFiltersAndSort();
+        _filter.setSource(_allDrinks);
         _error = null;
         _isLoading = false;
       } else {
@@ -414,14 +369,12 @@ class BeerProvider extends ChangeNotifier {
       return;
     }
     _currentFestival = festival;
-    _selectedCategory = null;
-    _selectedStyles = {};
-    _searchQuery = '';
+    _filter.clearCategoryStyleSearch();
     // Clear existing drinks and signal the switch immediately so the UI rebuilds
     // against the new festival id; the new festival's cached drinks (if any)
     // replace them below, otherwise the spinner stays up.
     _allDrinks = [];
-    _filteredDrinks = [];
+    _filter.setSource(_allDrinks);
     _error = null;
     _refreshNotice = null;
     _isLoading = true;
@@ -433,7 +386,7 @@ class BeerProvider extends ChangeNotifier {
     if (token != _drinksLoadToken) return;
     if (cached != null) {
       _allDrinks = cached;
-      _applyFiltersAndSort();
+      _filter.setSource(_allDrinks);
       _isLoading = false;
       notifyListeners();
     }
@@ -462,7 +415,7 @@ class BeerProvider extends ChangeNotifier {
       final drinks = await _drinkRepository!.getDrinks(festival);
       if (token != _drinksLoadToken) return;
       _allDrinks = drinks;
-      _applyFiltersAndSort();
+      _filter.setSource(_allDrinks);
       _error = null;
       _refreshNotice = null;
       _lastDrinksRefresh = DateTime.now();
@@ -476,7 +429,7 @@ class BeerProvider extends ChangeNotifier {
       } else {
         _error = _getUserFriendlyErrorMessage(e);
         _allDrinks = [];
-        _filteredDrinks = [];
+        _filter.setSource(_allDrinks);
       }
       // Log to Crashlytics unless this is an expected offline failure that we
       // already covered with cached data. Always log when fully blocked, and
@@ -575,12 +528,9 @@ class BeerProvider extends ChangeNotifier {
 
   /// Set category filter
   void setCategory(String? category) {
-    _selectedCategory = category;
-    // Clear style filter when changing category since styles are category-dependent
-    if (_selectedStyles.isNotEmpty) {
-      _selectedStyles = {};
-    }
-    _applyFiltersAndSort();
+    // The controller clears the style filter when the category changes, since
+    // styles are category-dependent.
+    _filter.setCategory(category);
     notifyListeners();
     // Log analytics event (fire and forget)
     unawaited(_analyticsService.logCategoryFilter(category));
@@ -588,28 +538,21 @@ class BeerProvider extends ChangeNotifier {
 
   /// Toggle a style filter (supports multiple style selection)
   void toggleStyle(String style) {
-    if (_selectedStyles.contains(style)) {
-      _selectedStyles = Set.from(_selectedStyles)..remove(style);
-    } else {
-      _selectedStyles = Set.from(_selectedStyles)..add(style);
-    }
-    _applyFiltersAndSort();
+    _filter.toggleStyle(style);
     notifyListeners();
     // Log analytics event (fire and forget)
-    unawaited(_analyticsService.logStyleFilter(_selectedStyles));
+    unawaited(_analyticsService.logStyleFilter(_filter.selectedStyles));
   }
 
   /// Clear all style filters
   void clearStyles() {
-    _selectedStyles = {};
-    _applyFiltersAndSort();
+    _filter.clearStyles();
     notifyListeners();
   }
 
   /// Set sort option
   void setSort(DrinkSort sort) {
-    _currentSort = sort;
-    _applyFiltersAndSort();
+    _filter.setSort(sort);
     notifyListeners();
     // Log analytics event (fire and forget)
     unawaited(_analyticsService.logSortChange(sort.name));
@@ -617,8 +560,7 @@ class BeerProvider extends ChangeNotifier {
 
   /// Set search query
   void setSearchQuery(String query) {
-    _searchQuery = query.toLowerCase();
-    _applyFiltersAndSort();
+    _filter.setSearchQuery(query);
     notifyListeners();
     // Log analytics event if query is not empty (fire and forget)
     if (query.trim().isNotEmpty) {
@@ -628,8 +570,7 @@ class BeerProvider extends ChangeNotifier {
 
   /// Toggle showing favorites only
   void setShowFavoritesOnly(bool value) {
-    _showFavoritesOnly = value;
-    _applyFiltersAndSort();
+    _filter.setShowFavoritesOnly(value);
     notifyListeners();
   }
 
@@ -642,55 +583,46 @@ class BeerProvider extends ChangeNotifier {
   /// Set a visibility filter on or off and persist the preference
   Future<void> setVisibilityFilter(
       DrinkVisibilityFilter filter, bool active) async {
-    if (active) {
-      _visibilityFilters = Set.from(_visibilityFilters)..add(filter);
-    } else {
-      _visibilityFilters = Set.from(_visibilityFilters)..remove(filter);
-    }
-    _applyFiltersAndSort();
+    _filter.setVisibilityFilter(filter, active);
     notifyListeners();
-
-    // Persist the full set of active filters
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(
-      PreferenceKeys.visibilityFilters,
-      _visibilityFilters.map((f) => f.name).toList(),
-    );
+    await _persistVisibilityFilters();
   }
 
   /// Clear all visibility filters and persist
   Future<void> clearVisibilityFilters() async {
-    _visibilityFilters = {};
-    _applyFiltersAndSort();
+    _filter.clearVisibilityFilters();
     notifyListeners();
-
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(PreferenceKeys.visibilityFilters, []);
+    await _persistVisibilityFilters();
   }
 
   /// Toggle a per-allergen exclusion filter and persist
   Future<void> setAllergenFilter(String allergen, bool active) async {
-    if (active) {
-      _excludedAllergens = Set.from(_excludedAllergens)..add(allergen);
-    } else {
-      _excludedAllergens = Set.from(_excludedAllergens)..remove(allergen);
-    }
-    _applyFiltersAndSort();
+    _filter.setAllergenFilter(allergen, active);
     notifyListeners();
-
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(
-        PreferenceKeys.excludedAllergens, _excludedAllergens.toList());
+    await _persistExcludedAllergens();
   }
 
   /// Clear all allergen exclusion filters and persist
   Future<void> clearAllergenFilters() async {
-    _excludedAllergens = {};
-    _applyFiltersAndSort();
+    _filter.clearAllergenFilters();
     notifyListeners();
+    await _persistExcludedAllergens();
+  }
 
+  /// Persist the full set of active visibility filters.
+  Future<void> _persistVisibilityFilters() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(PreferenceKeys.excludedAllergens, []);
+    await prefs.setStringList(
+      PreferenceKeys.visibilityFilters,
+      _filter.visibilityFilters.map((f) => f.name).toList(),
+    );
+  }
+
+  /// Persist the full set of excluded allergens.
+  Future<void> _persistExcludedAllergens() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+        PreferenceKeys.excludedAllergens, _filter.excludedAllergens.toList());
   }
 
   /// Set theme mode and persist preference
@@ -713,8 +645,8 @@ class BeerProvider extends ChangeNotifier {
     );
     drink.isFavorite = newStatus;
 
-    if (_showFavoritesOnly) {
-      _applyFiltersAndSort();
+    if (_filter.showFavoritesOnly) {
+      _filter.recompute();
     }
 
     notifyListeners();
@@ -762,8 +694,8 @@ class BeerProvider extends ChangeNotifier {
 
     // Re-filter so the drink appears/disappears immediately when the
     // not-tasted visibility filter is active.
-    if (_visibilityFilters.contains(DrinkVisibilityFilter.notTasted)) {
-      _applyFiltersAndSort();
+    if (_filter.visibilityFilters.contains(DrinkVisibilityFilter.notTasted)) {
+      _filter.recompute();
     }
 
     notifyListeners();
@@ -783,22 +715,6 @@ class BeerProvider extends ChangeNotifier {
     } catch (e) {
       return null;
     }
-  }
-
-  void _applyFiltersAndSort() {
-    // Apply all filters using domain service (returns new list)
-    final filtered = _filterService.filterDrinks(
-      _allDrinks,
-      category: _selectedCategory,
-      styles: _selectedStyles,
-      favoritesOnly: _showFavoritesOnly,
-      visibilityFilters: _visibilityFilters,
-      excludedAllergens: _excludedAllergens,
-      searchQuery: _searchQuery,
-    );
-
-    // Apply sort using domain service (returns new sorted list)
-    _filteredDrinks = _sortService.sortDrinks(filtered, _currentSort);
   }
 
   @override

--- a/test/domain/controllers/drink_filter_controller_test.dart
+++ b/test/domain/controllers/drink_filter_controller_test.dart
@@ -1,0 +1,372 @@
+import 'package:cambridge_beer_festival/domain/controllers/controllers.dart';
+import 'package:cambridge_beer_festival/domain/models/models.dart';
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Unit tests for DrinkFilterController in isolation.
+//
+// The deep filter/sort *semantics* (availability, vegan, allergens, search
+// matching, sort orders) are covered by:
+// - test/domain/services/drink_filter_service_test.dart
+// - test/domain/services/drink_sort_service_test.dart
+//
+// These tests focus on what the controller adds on top of those services:
+// criteria state management, the derived facet views (with category scoping),
+// source management / recompute, and the lifecycle helpers.
+
+Drink _drink({
+  required String id,
+  required String name,
+  required String category,
+  String? style,
+  String abv = '5.0',
+  String? notes,
+  Map<String, dynamic> allergens = const {},
+  bool isFavorite = false,
+  bool isTasted = false,
+  String breweryName = 'Test Brewery',
+}) {
+  final producer = Producer.fromJson({
+    'id': 'brewery-$breweryName',
+    'name': breweryName,
+    'location': 'Cambridge',
+    'products': const [],
+  });
+  final product = Product.fromJson({
+    'id': id,
+    'name': name,
+    'category': category,
+    if (style != null) 'style': style,
+    'dispense': 'cask',
+    'abv': abv,
+    if (notes != null) 'notes': notes,
+    if (allergens.isNotEmpty) 'allergens': allergens,
+  });
+  return Drink(
+    product: product,
+    producer: producer,
+    festivalId: 'cbf2025',
+    isFavorite: isFavorite,
+    isTasted: isTasted,
+  );
+}
+
+List<Drink> _sampleDrinks() => [
+      _drink(id: 'd1', name: 'Alpha Ale', category: 'beer', style: 'IPA'),
+      _drink(id: 'd2', name: 'Beta Bitter', category: 'beer', style: 'Bitter'),
+      _drink(id: 'd3', name: 'Crisp Cider', category: 'cider', style: 'Dry'),
+      _drink(id: 'd4', name: 'Zesty Zider', category: 'cider', style: 'Sweet'),
+    ];
+
+void main() {
+  group('DrinkFilterController', () {
+    late DrinkFilterController controller;
+
+    setUp(() {
+      controller = DrinkFilterController();
+    });
+
+    group('initial state', () {
+      test('starts empty with default sort and no criteria', () {
+        expect(controller.filteredDrinks, isEmpty);
+        expect(controller.selectedCategory, isNull);
+        expect(controller.selectedStyles, isEmpty);
+        expect(controller.currentSort, DrinkSort.nameAsc);
+        expect(controller.searchQuery, isEmpty);
+        expect(controller.showFavoritesOnly, isFalse);
+        expect(controller.visibilityFilters, isEmpty);
+        expect(controller.excludedAllergens, isEmpty);
+        expect(controller.hideUnavailable, isFalse);
+      });
+    });
+
+    group('setSource', () {
+      test('exposes all drinks sorted by name when no filters active', () {
+        controller.setSource(_sampleDrinks());
+        expect(
+          controller.filteredDrinks.map((d) => d.name).toList(),
+          ['Alpha Ale', 'Beta Bitter', 'Crisp Cider', 'Zesty Zider'],
+        );
+      });
+
+      test('replacing the source recomputes the filtered list', () {
+        controller.setSource(_sampleDrinks());
+        expect(controller.filteredDrinks, hasLength(4));
+
+        controller
+            .setSource([_drink(id: 'x', name: 'Only One', category: 'beer')]);
+        expect(controller.filteredDrinks, hasLength(1));
+        expect(controller.filteredDrinks.single.name, 'Only One');
+      });
+
+      test('empty source yields empty filtered list', () {
+        controller.setSource(_sampleDrinks());
+        controller.setSource([]);
+        expect(controller.filteredDrinks, isEmpty);
+      });
+    });
+
+    group('category filter', () {
+      test('narrows filtered drinks to the selected category', () {
+        controller.setSource(_sampleDrinks());
+        controller.setCategory('cider');
+        expect(controller.filteredDrinks.map((d) => d.name),
+            ['Crisp Cider', 'Zesty Zider']);
+      });
+
+      test('setting category clears any active style filter', () {
+        controller.setSource(_sampleDrinks());
+        controller.setCategory('beer');
+        controller.toggleStyle('IPA');
+        expect(controller.selectedStyles, {'IPA'});
+
+        controller.setCategory('cider');
+        expect(controller.selectedStyles, isEmpty);
+      });
+
+      test('null category shows all categories again', () {
+        controller.setSource(_sampleDrinks());
+        controller.setCategory('beer');
+        controller.setCategory(null);
+        expect(controller.filteredDrinks, hasLength(4));
+      });
+    });
+
+    group('style filter', () {
+      test('toggleStyle adds then removes a style', () {
+        controller.setSource(_sampleDrinks());
+        controller.toggleStyle('IPA');
+        expect(controller.selectedStyles, {'IPA'});
+        expect(controller.filteredDrinks.map((d) => d.name), ['Alpha Ale']);
+
+        controller.toggleStyle('IPA');
+        expect(controller.selectedStyles, isEmpty);
+        expect(controller.filteredDrinks, hasLength(4));
+      });
+
+      test('multiple styles use OR logic', () {
+        controller.setSource(_sampleDrinks());
+        controller.toggleStyle('IPA');
+        controller.toggleStyle('Dry');
+        expect(controller.selectedStyles, {'IPA', 'Dry'});
+        expect(controller.filteredDrinks.map((d) => d.name),
+            ['Alpha Ale', 'Crisp Cider']);
+      });
+
+      test('clearStyles removes all style filters', () {
+        controller.setSource(_sampleDrinks());
+        controller.toggleStyle('IPA');
+        controller.clearStyles();
+        expect(controller.selectedStyles, isEmpty);
+        expect(controller.filteredDrinks, hasLength(4));
+      });
+    });
+
+    group('search filter', () {
+      test('matches name and is stored lower-cased', () {
+        controller.setSource(_sampleDrinks());
+        controller.setSearchQuery('CIDER');
+        expect(controller.searchQuery, 'cider');
+        expect(controller.filteredDrinks.map((d) => d.name), ['Crisp Cider']);
+      });
+    });
+
+    group('favorites filter', () {
+      test('shows only favourites when enabled', () {
+        final drinks = _sampleDrinks();
+        drinks[0].isFavorite = true;
+        controller.setSource(drinks);
+
+        controller.setShowFavoritesOnly(true);
+        expect(controller.filteredDrinks.map((d) => d.name), ['Alpha Ale']);
+
+        controller.setShowFavoritesOnly(false);
+        expect(controller.filteredDrinks, hasLength(4));
+      });
+    });
+
+    group('visibility filters', () {
+      test('setVisibilityFilter toggles membership and hideUnavailable', () {
+        controller.setVisibilityFilter(
+            DrinkVisibilityFilter.availableOnly, true);
+        expect(controller.visibilityFilters,
+            contains(DrinkVisibilityFilter.availableOnly));
+        expect(controller.hideUnavailable, isTrue);
+
+        controller.setVisibilityFilter(
+            DrinkVisibilityFilter.availableOnly, false);
+        expect(controller.visibilityFilters, isEmpty);
+        expect(controller.hideUnavailable, isFalse);
+      });
+
+      test('clearVisibilityFilters removes all', () {
+        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
+        controller.setVisibilityFilter(DrinkVisibilityFilter.veganOnly, true);
+        controller.clearVisibilityFilters();
+        expect(controller.visibilityFilters, isEmpty);
+      });
+
+      test('notTasted filter hides tasted drinks', () {
+        final drinks = _sampleDrinks();
+        drinks[0].isTasted = true;
+        controller.setSource(drinks);
+        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
+        expect(controller.filteredDrinks.map((d) => d.name),
+            isNot(contains('Alpha Ale')));
+        expect(controller.filteredDrinks, hasLength(3));
+      });
+
+      test('visibilityFilters getter is unmodifiable', () {
+        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
+        expect(
+          () =>
+              controller.visibilityFilters.add(DrinkVisibilityFilter.veganOnly),
+          throwsUnsupportedError,
+        );
+      });
+    });
+
+    group('allergen filters', () {
+      test('excludes drinks containing an excluded allergen', () {
+        controller.setSource([
+          _drink(id: 'a', name: 'Gluten Beer', category: 'beer', allergens: {
+            'gluten': 1,
+          }),
+          _drink(id: 'b', name: 'Clean Beer', category: 'beer'),
+        ]);
+        controller.setAllergenFilter('gluten', true);
+        expect(controller.filteredDrinks.map((d) => d.name), ['Clean Beer']);
+
+        controller.setAllergenFilter('gluten', false);
+        expect(controller.filteredDrinks, hasLength(2));
+      });
+
+      test('clearAllergenFilters removes all exclusions', () {
+        controller.setAllergenFilter('gluten', true);
+        controller.setAllergenFilter('nuts', true);
+        controller.clearAllergenFilters();
+        expect(controller.excludedAllergens, isEmpty);
+      });
+
+      test('excludedAllergens getter is unmodifiable', () {
+        controller.setAllergenFilter('gluten', true);
+        expect(() => controller.excludedAllergens.add('nuts'),
+            throwsUnsupportedError);
+      });
+    });
+
+    group('sort', () {
+      test('setSort reorders the filtered list', () {
+        controller.setSource(_sampleDrinks());
+        controller.setSort(DrinkSort.nameDesc);
+        expect(controller.currentSort, DrinkSort.nameDesc);
+        expect(controller.filteredDrinks.first.name, 'Zesty Zider');
+      });
+    });
+
+    group('facet getters', () {
+      test('availableCategories is unique and sorted', () {
+        controller.setSource(_sampleDrinks());
+        expect(controller.availableCategories, ['beer', 'cider']);
+      });
+
+      test('categoryCountsMap counts across the full source', () {
+        controller.setSource(_sampleDrinks());
+        expect(controller.categoryCountsMap, {'beer': 2, 'cider': 2});
+      });
+
+      test('availableStyles spans all categories when none selected', () {
+        controller.setSource(_sampleDrinks());
+        expect(controller.availableStyles, ['Bitter', 'Dry', 'IPA', 'Sweet']);
+      });
+
+      test('availableStyles narrows to the selected category', () {
+        controller.setSource(_sampleDrinks());
+        controller.setCategory('cider');
+        expect(controller.availableStyles, ['Dry', 'Sweet']);
+      });
+
+      test('styleCountsMap narrows to the selected category', () {
+        controller.setSource(_sampleDrinks());
+        controller.setCategory('beer');
+        expect(controller.styleCountsMap, {'IPA': 1, 'Bitter': 1});
+      });
+
+      test('availableAllergens aggregates keys across the source', () {
+        controller.setSource([
+          _drink(
+              id: 'a', name: 'A', category: 'beer', allergens: {'gluten': 1}),
+          _drink(id: 'b', name: 'B', category: 'beer', allergens: {'nuts': 0}),
+        ]);
+        expect(controller.availableAllergens, {'gluten', 'nuts'});
+      });
+    });
+
+    group('recompute', () {
+      test('reflects in-place favourite mutation when favourites-only', () {
+        final drinks = _sampleDrinks();
+        controller.setSource(drinks);
+        controller.setShowFavoritesOnly(true);
+        expect(controller.filteredDrinks, isEmpty);
+
+        // Simulate BeerProvider mutating the drink in place, then asking the
+        // controller to re-run the pipeline.
+        drinks[1].isFavorite = true;
+        controller.recompute();
+        expect(controller.filteredDrinks.map((d) => d.name), ['Beta Bitter']);
+      });
+    });
+
+    group('clearCategoryStyleSearch', () {
+      test('resets category, styles and search but keeps sort/visibility', () {
+        controller.setSource(_sampleDrinks());
+        controller.setCategory('beer');
+        controller.toggleStyle('IPA');
+        controller.setSearchQuery('alpha');
+        controller.setSort(DrinkSort.nameDesc);
+        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
+
+        controller.clearCategoryStyleSearch();
+
+        expect(controller.selectedCategory, isNull);
+        expect(controller.selectedStyles, isEmpty);
+        expect(controller.searchQuery, isEmpty);
+        // Preserved
+        expect(controller.currentSort, DrinkSort.nameDesc);
+        expect(controller.visibilityFilters,
+            contains(DrinkVisibilityFilter.notTasted));
+        expect(controller.filteredDrinks, hasLength(4));
+      });
+    });
+
+    group('hydrate', () {
+      test('seeds persisted filters without needing a source', () {
+        controller.hydrate(
+          visibilityFilters: {DrinkVisibilityFilter.availableOnly},
+          excludedAllergens: {'gluten'},
+        );
+        expect(controller.visibilityFilters,
+            {DrinkVisibilityFilter.availableOnly});
+        expect(controller.excludedAllergens, {'gluten'});
+        expect(controller.hideUnavailable, isTrue);
+      });
+
+      test('applies once a source is set', () {
+        controller.hydrate(excludedAllergens: {'gluten'});
+        controller.setSource([
+          _drink(id: 'a', name: 'Gluten', category: 'beer', allergens: {
+            'gluten': 1,
+          }),
+          _drink(id: 'b', name: 'Clean', category: 'beer'),
+        ]);
+        expect(controller.filteredDrinks.map((d) => d.name), ['Clean']);
+      });
+
+      test('null arguments leave existing state unchanged', () {
+        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
+        controller.hydrate();
+        expect(controller.visibilityFilters, {DrinkVisibilityFilter.notTasted});
+      });
+    });
+  });
+}


### PR DESCRIPTION
BeerProvider had grown into a god object mixing data-loading, festival
lifecycle, per-drink ops, theme, error mapping AND all filter/sort/search
state plus the derived facet views. Extract the filtering concern into a
dedicated pure-Dart DrinkFilterController.

The controller owns the filter/sort/search criteria, the source list, the
computed filtered list, and the category/style/allergen facet getters. It
has no Flutter, persistence, async, or analytics dependencies, so it is
unit-testable in isolation.

BeerProvider composes the controller, feeds it loaded drinks via
setSource, and keeps the cross-cutting concerns around it (persistence,
analytics, change notification). Its public API is unchanged, so the
existing provider test suite and drinks_screen.dart are untouched and act
as the integration regression net.

Adds test/domain/controllers/drink_filter_controller_test.dart (31 tests).

Closes #350