### PR TITLE
chore: bump dart dependencies group with 10 updates

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -85,8 +85,9 @@ ThemeData buildAppTheme(Brightness brightness) {
   final colorScheme = ColorScheme.fromSeed(
     seedColor: appSeedColor,
     brightness: brightness,
-    primary:
-        brightness == Brightness.light ? appSeedColor : const Color(0xFF8FA3E8),
+    primary: brightness == Brightness.light
+        ? appSeedColor
+        : const Color(0xFF8FA3E8),
     onPrimary: Colors.white,
   );
   final textTheme = buildAppTextTheme(colorScheme);
@@ -95,10 +96,12 @@ ThemeData buildAppTheme(Brightness brightness) {
     textTheme: textTheme,
     useMaterial3: true,
     appBarTheme: AppBarTheme(
-      backgroundColor:
-          brightness == Brightness.light ? appSeedColor : colorScheme.surface,
-      foregroundColor:
-          brightness == Brightness.light ? Colors.white : colorScheme.onSurface,
+      backgroundColor: brightness == Brightness.light
+          ? appSeedColor
+          : colorScheme.surface,
+      foregroundColor: brightness == Brightness.light
+          ? Colors.white
+          : colorScheme.onSurface,
       elevation: 0,
       centerTitle: false,
       titleTextStyle: GoogleFonts.playfairDisplay(

--- a/lib/domain/controllers/drink_filter_controller.dart
+++ b/lib/domain/controllers/drink_filter_controller.dart
@@ -20,8 +20,8 @@ class DrinkFilterController {
   DrinkFilterController({
     DrinkFilterService? filterService,
     DrinkSortService? sortService,
-  })  : _filterService = filterService ?? DrinkFilterService(),
-        _sortService = sortService ?? DrinkSortService();
+  }) : _filterService = filterService ?? DrinkFilterService(),
+       _sortService = sortService ?? DrinkSortService();
 
   List<Drink> _source = [];
   List<Drink> _filtered = [];

--- a/lib/domain/models/drink_sort.dart
+++ b/lib/domain/models/drink_sort.dart
@@ -1,9 +1,2 @@
 /// Sort options for the drinks list
-enum DrinkSort {
-  nameAsc,
-  nameDesc,
-  abvHigh,
-  abvLow,
-  brewery,
-  style,
-}
+enum DrinkSort { nameAsc, nameDesc, abvHigh, abvLow, brewery, style }

--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -22,12 +22,12 @@ class ApiDrinkRepository implements DrinkRepository {
     required TastingLogService tastingLogService,
     required DrinkCacheService cacheService,
     required AnalyticsService analyticsService,
-  })  : _apiService = apiService,
-        _favoritesService = favoritesService,
-        _ratingsService = ratingsService,
-        _tastingLogService = tastingLogService,
-        _cacheService = cacheService,
-        _analyticsService = analyticsService;
+  }) : _apiService = apiService,
+       _favoritesService = favoritesService,
+       _ratingsService = ratingsService,
+       _tastingLogService = tastingLogService,
+       _cacheService = cacheService,
+       _analyticsService = analyticsService;
 
   @override
   Future<List<Drink>> getDrinks(Festival festival) async {
@@ -43,13 +43,15 @@ class ApiDrinkRepository implements DrinkRepository {
     // route persistence failures through analytics rather than letting them
     // surface as unhandled async errors.
     final update = _cacheService.merge(festival.id, result.drinksByType);
-    unawaited(update.written.catchError((Object e, StackTrace s) {
-      return _analyticsService.logError(
-        e,
-        s,
-        reason: 'Drink cache write failed for festival: ${festival.id}',
-      );
-    }));
+    unawaited(
+      update.written.catchError((Object e, StackTrace s) {
+        return _analyticsService.logError(
+          e,
+          s,
+          reason: 'Drink cache write failed for festival: ${festival.id}',
+        );
+      }),
+    );
 
     _applyUserState(update.drinks, festival.id);
     return update.drinks;

--- a/lib/domain/repositories/api_festival_repository.dart
+++ b/lib/domain/repositories/api_festival_repository.dart
@@ -17,10 +17,10 @@ class ApiFestivalRepository implements FestivalRepository {
     required FestivalStorageService festivalStorageService,
     required FestivalCacheService cacheService,
     required AnalyticsService analyticsService,
-  })  : _festivalService = festivalService,
-        _festivalStorageService = festivalStorageService,
-        _cacheService = cacheService,
-        _analyticsService = analyticsService;
+  }) : _festivalService = festivalService,
+       _festivalStorageService = festivalStorageService,
+       _cacheService = cacheService,
+       _analyticsService = analyticsService;
 
   @override
   Future<FestivalsResponse> getFestivals() async {
@@ -28,13 +28,15 @@ class ApiFestivalRepository implements FestivalRepository {
     // Persist in the background so caching stays off the load critical path;
     // surface persistence failures via analytics rather than letting them
     // become unhandled async errors.
-    unawaited(_cacheService.save(response).catchError((Object e, StackTrace s) {
-      return _analyticsService.logError(
-        e,
-        s,
-        reason: 'Festival cache write failed',
-      );
-    }));
+    unawaited(
+      _cacheService.save(response).catchError((Object e, StackTrace s) {
+        return _analyticsService.logError(
+          e,
+          s,
+          reason: 'Festival cache write failed',
+        );
+      }),
+    );
     return response;
   }
 

--- a/lib/domain/services/drink_filter_service.dart
+++ b/lib/domain/services/drink_filter_service.dart
@@ -10,10 +10,7 @@ class DrinkFilterService {
   ///
   /// Returns all drinks if [category] is null
   /// Uses lazy evaluation - call .toList() to materialize
-  Iterable<Drink> filterByCategory(
-    Iterable<Drink> drinks,
-    String? category,
-  ) {
+  Iterable<Drink> filterByCategory(Iterable<Drink> drinks, String? category) {
     if (category == null) return drinks;
     return drinks.where((d) => d.category == category);
   }
@@ -22,10 +19,7 @@ class DrinkFilterService {
   ///
   /// Returns all drinks if [styles] is empty
   /// Uses lazy evaluation - call .toList() to materialize
-  Iterable<Drink> filterByStyles(
-    Iterable<Drink> drinks,
-    Set<String> styles,
-  ) {
+  Iterable<Drink> filterByStyles(Iterable<Drink> drinks, Set<String> styles) {
     if (styles.isEmpty) return drinks;
     return drinks.where((d) => d.style != null && styles.contains(d.style));
   }
@@ -52,9 +46,11 @@ class DrinkFilterService {
     bool hideUnavailable,
   ) {
     if (!hideUnavailable) return drinks;
-    return drinks.where((d) =>
-        d.availabilityStatus != AvailabilityStatus.out &&
-        d.availabilityStatus != AvailabilityStatus.notYetAvailable);
+    return drinks.where(
+      (d) =>
+          d.availabilityStatus != AvailabilityStatus.out &&
+          d.availabilityStatus != AvailabilityStatus.notYetAvailable,
+    );
   }
 
   /// Filter drinks to hide ones already tasted
@@ -75,10 +71,7 @@ class DrinkFilterService {
   /// Drinks with null (unknown) vegan status are excluded.
   /// Returns all drinks if [veganOnly] is false
   /// Uses lazy evaluation - call .toList() to materialize
-  Iterable<Drink> filterByVegan(
-    Iterable<Drink> drinks,
-    bool veganOnly,
-  ) {
+  Iterable<Drink> filterByVegan(Iterable<Drink> drinks, bool veganOnly) {
     if (!veganOnly) return drinks;
     return drinks.where((d) => d.isVegan == true);
   }
@@ -96,7 +89,8 @@ class DrinkFilterService {
   ) {
     if (excludedAllergens.isEmpty) return drinks;
     return drinks.where(
-        (d) => excludedAllergens.every((a) => (d.allergens[a] ?? 0) == 0));
+      (d) => excludedAllergens.every((a) => (d.allergens[a] ?? 0) == 0),
+    );
   }
 
   /// Filter drinks by search query
@@ -105,10 +99,7 @@ class DrinkFilterService {
   /// Case-insensitive search
   /// Returns all drinks if [query] is empty
   /// Uses lazy evaluation - call .toList() to materialize
-  Iterable<Drink> filterBySearch(
-    Iterable<Drink> drinks,
-    String query,
-  ) {
+  Iterable<Drink> filterBySearch(Iterable<Drink> drinks, String query) {
     if (query.isEmpty) return drinks;
     final lowerQuery = query.toLowerCase();
     return drinks.where((d) {
@@ -155,9 +146,11 @@ class DrinkFilterService {
     }
 
     if (visibilityFilters.contains(DrinkVisibilityFilter.availableOnly)) {
-      result = result.where((d) =>
-          d.availabilityStatus != AvailabilityStatus.out &&
-          d.availabilityStatus != AvailabilityStatus.notYetAvailable);
+      result = result.where(
+        (d) =>
+            d.availabilityStatus != AvailabilityStatus.out &&
+            d.availabilityStatus != AvailabilityStatus.notYetAvailable,
+      );
     }
     if (visibilityFilters.contains(DrinkVisibilityFilter.notTasted)) {
       result = result.where((d) => !d.isTasted);
@@ -168,7 +161,8 @@ class DrinkFilterService {
 
     if (excludedAllergens.isNotEmpty) {
       result = result.where(
-          (d) => excludedAllergens.every((a) => (d.allergens[a] ?? 0) == 0));
+        (d) => excludedAllergens.every((a) => (d.allergens[a] ?? 0) == 0),
+      );
     }
 
     if (searchQuery.isNotEmpty) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -220,10 +220,12 @@ class _ProviderInitializerState extends State<ProviderInitializer>
       // If first segment is not a valid festival ID, redirect
       if (!provider.isValidFestivalId(firstSegment)) {
         // Preserve the rest of the path and query parameters
-        final restOfPath =
-            segments.length > 1 ? '/${segments.sublist(1).join('/')}' : '';
-        final queryString =
-            currentUri.query.isNotEmpty ? '?${currentUri.query}' : '';
+        final restOfPath = segments.length > 1
+            ? '/${segments.sublist(1).join('/')}'
+            : '';
+        final queryString = currentUri.query.isNotEmpty
+            ? '?${currentUri.query}'
+            : '';
         router.go('/${provider.currentFestival.id}$restOfPath$queryString');
       }
     } catch (e, stackTrace) {
@@ -371,12 +373,7 @@ class _BeerFestivalHomeState extends State<BeerFestivalHome> {
         _handleExitConfirmation();
       },
       child: Scaffold(
-        body: Stack(
-          children: [
-            widget.child,
-            const EnvironmentBadge(),
-          ],
-        ),
+        body: Stack(children: [widget.child, const EnvironmentBadge()]),
         bottomNavigationBar: NavigationBar(
           height: 60,
           labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
@@ -427,10 +424,7 @@ class _BeerFestivalHomeState extends State<BeerFestivalHome> {
 
 /// Screen showing favorited drinks
 class FavoritesScreen extends StatelessWidget {
-  const FavoritesScreen({
-    required this.festivalId,
-    super.key,
-  });
+  const FavoritesScreen({required this.festivalId, super.key});
 
   final String festivalId;
 
@@ -445,15 +439,17 @@ class FavoritesScreen extends StatelessWidget {
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(provider.currentFestival.name,
-                style: theme.textTheme.titleMedium),
-            Text('${favorites.length} favorites',
-                style: theme.textTheme.bodySmall),
+            Text(
+              provider.currentFestival.name,
+              style: theme.textTheme.titleMedium,
+            ),
+            Text(
+              '${favorites.length} favorites',
+              style: theme.textTheme.bodySmall,
+            ),
           ],
         ),
-        actions: [
-          buildOverflowMenu(context),
-        ],
+        actions: [buildOverflowMenu(context)],
       ),
       body: favorites.isEmpty
           ? Semantics(
@@ -463,8 +459,11 @@ class FavoritesScreen extends StatelessWidget {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    const Icon(Icons.favorite_border,
-                        size: 64, color: Colors.grey),
+                    const Icon(
+                      Icons.favorite_border,
+                      size: 64,
+                      color: Colors.grey,
+                    ),
                     const SizedBox(height: 16),
                     Text('No favorites yet', style: theme.textTheme.titleLarge),
                     const SizedBox(height: 8),
@@ -482,9 +481,9 @@ class FavoritesScreen extends StatelessWidget {
                   key: ValueKey(drink.id),
                   drink: drink,
                   onTap: () => navigateToRoute(
-                      context,
-                      buildDrinkDetailPath(
-                          festivalId, drink.category, drink.id)),
+                    context,
+                    buildDrinkDetailPath(festivalId, drink.category, drink.id),
+                  ),
                   onFavoriteTap: () => provider.toggleFavorite(drink),
                 );
               },

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -32,7 +32,8 @@ class Producer {
       location: (json['location'] ?? '').toString(),
       yearFounded: yearFounded,
       notes: json['notes']?.toString(),
-      products: (json['products'] as List<dynamic>?)
+      products:
+          (json['products'] as List<dynamic>?)
               ?.map((p) => Product.fromJson(p as Map<String, dynamic>))
               .toList() ??
           [],
@@ -210,9 +211,10 @@ class Product {
     final allergenList = allergens.entries
         .where((e) => e.value == 1 && e.key.isNotEmpty)
         .map((e) {
-      // Capitalize first letter
-      return e.key[0].toUpperCase() + e.key.substring(1);
-    }).toList();
+          // Capitalize first letter
+          return e.key[0].toUpperCase() + e.key.substring(1);
+        })
+        .toList();
     if (allergenList.isEmpty) return null;
     return allergenList.join(', ');
   }
@@ -223,12 +225,7 @@ class Product {
 }
 
 /// Availability status for a product
-enum AvailabilityStatus {
-  plenty,
-  low,
-  out,
-  notYetAvailable,
-}
+enum AvailabilityStatus { plenty, low, out, notYetAvailable }
 
 /// Extended drink model that includes producer information
 class Drink {

--- a/lib/models/festival.dart
+++ b/lib/models/festival.dart
@@ -70,13 +70,14 @@ class Festival {
       longitude: (json['longitude'] as num?)?.toDouble(),
       description: json['description'] as String?,
       websiteUrl: json['website_url'] as String?,
-      hours: (json['hours'] as Map<String, dynamic>?)
-          ?.map((key, value) => MapEntry(key, value as String)),
+      hours: (json['hours'] as Map<String, dynamic>?)?.map(
+        (key, value) => MapEntry(key, value as String),
+      ),
       availableBeverageTypes:
           (json['available_beverage_types'] as List<dynamic>?)
-                  ?.map((e) => e as String)
-                  .toList() ??
-              const ['beer'],
+              ?.map((e) => e as String)
+              .toList() ??
+          const ['beer'],
       dataBaseUrl: json['data_base_url'] as String,
       isActive: json['is_active'] as bool? ?? false,
       charityPartnerName: json['charity_partner_name'] as String?,
@@ -131,7 +132,7 @@ class Festival {
       'Sep',
       'Oct',
       'Nov',
-      'Dec'
+      'Dec',
     ];
 
     if (end == null) {
@@ -237,8 +238,10 @@ class Festival {
   /// Get the status of a festival in the context of a sorted list
   /// The first past festival in a sorted list gets mostRecent status
   static FestivalStatus getStatusInContext(
-      Festival festival, List<Festival> sortedFestivals,
-      [DateTime? now]) {
+    Festival festival,
+    List<Festival> sortedFestivals, [
+    DateTime? now,
+  ]) {
     final basicStatus = festival.getBasicStatus(now);
     if (basicStatus != FestivalStatus.past) {
       return basicStatus;
@@ -318,7 +321,7 @@ class DefaultFestivals {
       'international-beer',
       'cider',
       'perry',
-      'low-no'
+      'low-no',
     ],
     dataBaseUrl: 'https://data.cambeerfestival.app/cbfw2025',
     isActive: false,
@@ -346,6 +349,10 @@ class DefaultFestivals {
     isActive: false,
   );
 
-  static List<Festival> get all =>
-      [cambridge2026, cambridge2025, cambridgeWinter2025, cambridge2024];
+  static List<Festival> get all => [
+    cambridge2026,
+    cambridge2025,
+    cambridgeWinter2025,
+    cambridge2024,
+  ];
 }

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -62,13 +62,13 @@ class BeerProvider extends ChangeNotifier {
     DrinkSortService? sortService,
     DrinkRepository? drinkRepository,
     FestivalRepository? festivalRepository,
-  })  : _analyticsService = analyticsService ?? AnalyticsService(),
-        _filter = DrinkFilterController(
-          filterService: filterService,
-          sortService: sortService,
-        ),
-        _drinkRepository = drinkRepository,
-        _festivalRepository = festivalRepository;
+  }) : _analyticsService = analyticsService ?? AnalyticsService(),
+       _filter = DrinkFilterController(
+         filterService: filterService,
+         sortService: sortService,
+       ),
+       _drinkRepository = drinkRepository,
+       _festivalRepository = festivalRepository;
 
   // Getters
   List<Drink> get drinks => _filter.filteredDrinks;
@@ -79,8 +79,10 @@ class BeerProvider extends ChangeNotifier {
   List<Festival> get sortedFestivals => Festival.sortByDate(_festivals);
   Festival get currentFestival =>
       _currentFestival ??
-      DefaultFestivals.all.firstWhere((f) => f.isActive,
-          orElse: () => DefaultFestivals.all.first);
+      DefaultFestivals.all.firstWhere(
+        (f) => f.isActive,
+        orElse: () => DefaultFestivals.all.first,
+      );
   bool get isLoading => _isLoading;
 
   /// True while a background refresh runs with data already on screen.
@@ -231,7 +233,8 @@ class BeerProvider extends ChangeNotifier {
 
     // Load excluded allergens preference
     final excludedAllergens = Set<String>.from(
-        prefs.getStringList(PreferenceKeys.excludedAllergens) ?? []);
+      prefs.getStringList(PreferenceKeys.excludedAllergens) ?? [],
+    );
 
     _filter.hydrate(
       visibilityFilters: visibilityFilters,
@@ -258,8 +261,9 @@ class BeerProvider extends ChangeNotifier {
     // so we don't clobber a default already set by loadFestivals above.
     final savedFestivalId = await _festivalRepository!.getSelectedFestivalId();
     if (savedFestivalId != null) {
-      final saved =
-          _festivals.where((f) => f.id == savedFestivalId).firstOrNull;
+      final saved = _festivals
+          .where((f) => f.id == savedFestivalId)
+          .firstOrNull;
       if (saved != null) _currentFestival = saved;
     }
     if (_currentFestival == null && cachedFestivals?.defaultFestival != null) {
@@ -326,8 +330,10 @@ class BeerProvider extends ChangeNotifier {
       if (_festivals.isEmpty) {
         await loadFestivals();
       }
-      _currentFestival ??= DefaultFestivals.all.firstWhere((f) => f.isActive,
-          orElse: () => DefaultFestivals.all.first);
+      _currentFestival ??= DefaultFestivals.all.firstWhere(
+        (f) => f.isActive,
+        orElse: () => DefaultFestivals.all.first,
+      );
     }
 
     final festival = currentFestival;
@@ -436,11 +442,13 @@ class BeerProvider extends ChangeNotifier {
       // always log non-connectivity failures so a silent never-load bug
       // (e.g. a server or parsing error masked by the cache) still surfaces.
       if (!haveData || !_isConnectivityError(e)) {
-        unawaited(_analyticsService.logError(
-          e,
-          stackTrace,
-          reason: 'Failed to load drinks for festival: ${festival.id}',
-        ));
+        unawaited(
+          _analyticsService.logError(
+            e,
+            stackTrace,
+            reason: 'Failed to load drinks for festival: ${festival.id}',
+          ),
+        );
       }
     } finally {
       if (token == _drinksLoadToken) {
@@ -482,14 +490,16 @@ class BeerProvider extends ChangeNotifier {
     // This prevents hammering the network on every app-resume while offline.
     // DateTime.now() is evaluated separately for each check so that a slow
     // loadFestivals() await doesn't cause the drinks check to use a stale time.
-    final festivalsRetryReady = _lastFestivalsRefreshAttempt == null ||
+    final festivalsRetryReady =
+        _lastFestivalsRefreshAttempt == null ||
         DateTime.now().difference(_lastFestivalsRefreshAttempt!) >
             _refreshRetryThreshold;
     if (isFestivalsDataStale && festivalsRetryReady) {
       await loadFestivals();
     }
 
-    final drinksRetryReady = _lastDrinksRefreshAttempt == null ||
+    final drinksRetryReady =
+        _lastDrinksRefreshAttempt == null ||
         DateTime.now().difference(_lastDrinksRefreshAttempt!) >
             _refreshRetryThreshold;
     if (isDrinksDataStale && drinksRetryReady) {
@@ -582,7 +592,9 @@ class BeerProvider extends ChangeNotifier {
 
   /// Set a visibility filter on or off and persist the preference
   Future<void> setVisibilityFilter(
-      DrinkVisibilityFilter filter, bool active) async {
+    DrinkVisibilityFilter filter,
+    bool active,
+  ) async {
     _filter.setVisibilityFilter(filter, active);
     notifyListeners();
     await _persistVisibilityFilters();
@@ -622,7 +634,9 @@ class BeerProvider extends ChangeNotifier {
   Future<void> _persistExcludedAllergens() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setStringList(
-        PreferenceKeys.excludedAllergens, _filter.excludedAllergens.toList());
+      PreferenceKeys.excludedAllergens,
+      _filter.excludedAllergens.toList(),
+    );
   }
 
   /// Set theme mode and persist preference
@@ -664,17 +678,10 @@ class BeerProvider extends ChangeNotifier {
     if (_drinkRepository == null) return;
 
     if (rating == null) {
-      await _drinkRepository!.removeRating(
-        currentFestival.id,
-        drink.id,
-      );
+      await _drinkRepository!.removeRating(currentFestival.id, drink.id);
       drink.rating = null;
     } else {
-      await _drinkRepository!.setRating(
-        currentFestival.id,
-        drink.id,
-        rating,
-      );
+      await _drinkRepository!.setRating(currentFestival.id, drink.id, rating);
       drink.rating = rating;
       // Log analytics event for rating (fire and forget)
       unawaited(_analyticsService.logRatingGiven(drink, rating));

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -56,10 +56,7 @@ final GoRouter appRouter = GoRouter(
   routes: [
     // Global routes FIRST (before festival routes)
     // Must come before /:festivalId to avoid being caught as festival ID
-    GoRoute(
-      path: '/about',
-      builder: (context, state) => const AboutScreen(),
-    ),
+    GoRoute(path: '/about', builder: (context, state) => const AboutScreen()),
     // Parent shell - Ensures provider initialization for ALL routes
     // This fixes deep linking by initializing data before any screen renders
     ShellRoute(
@@ -87,8 +84,9 @@ final GoRouter appRouter = GoRouter(
                 context,
                 state,
                 onInvalidFestival: (currentId) {
-                  final queryString =
-                      state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+                  final queryString = state.uri.query.isNotEmpty
+                      ? '?${state.uri.query}'
+                      : '';
                   return '/$currentId$queryString';
                 },
               ),
@@ -127,10 +125,7 @@ final GoRouter appRouter = GoRouter(
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             final id = state.pathParameters['id']!;
-            return DrinkDetailScreen(
-              festivalId: festivalId,
-              drinkId: id,
-            );
+            return DrinkDetailScreen(festivalId: festivalId, drinkId: id);
           },
         ),
         GoRoute(
@@ -144,10 +139,7 @@ final GoRouter appRouter = GoRouter(
           builder: (context, state) {
             final festivalId = state.pathParameters['festivalId']!;
             final id = state.pathParameters['id']!;
-            return BreweryScreen(
-              festivalId: festivalId,
-              breweryId: id,
-            );
+            return BreweryScreen(festivalId: festivalId, breweryId: id);
           },
         ),
         GoRoute(

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -22,16 +22,26 @@ class _AboutScreenState extends State<AboutScreen> {
   static const String appName = 'Cambridge Beer Festival';
 
   // Git version info (injected at build time via --dart-define)
-  static const String gitTag =
-      String.fromEnvironment('GIT_TAG', defaultValue: '');
-  static const String gitCommit =
-      String.fromEnvironment('GIT_COMMIT', defaultValue: '');
-  static const String gitBranch =
-      String.fromEnvironment('GIT_BRANCH', defaultValue: '');
-  static const String buildVersion =
-      String.fromEnvironment('BUILD_VERSION', defaultValue: '');
-  static const String buildTime =
-      String.fromEnvironment('BUILD_TIME', defaultValue: '');
+  static const String gitTag = String.fromEnvironment(
+    'GIT_TAG',
+    defaultValue: '',
+  );
+  static const String gitCommit = String.fromEnvironment(
+    'GIT_COMMIT',
+    defaultValue: '',
+  );
+  static const String gitBranch = String.fromEnvironment(
+    'GIT_BRANCH',
+    defaultValue: '',
+  );
+  static const String buildVersion = String.fromEnvironment(
+    'BUILD_VERSION',
+    defaultValue: '',
+  );
+  static const String buildTime = String.fromEnvironment(
+    'BUILD_TIME',
+    defaultValue: '',
+  );
 
   @override
   void initState() {
@@ -47,8 +57,9 @@ class _AboutScreenState extends State<AboutScreen> {
         if (buildVersion.isNotEmpty) {
           // coverage:ignore-start
           appVersion = buildVersion;
-          buildNumber =
-              gitCommit.isNotEmpty ? gitCommit : packageInfo.buildNumber;
+          buildNumber = gitCommit.isNotEmpty
+              ? gitCommit
+              : packageInfo.buildNumber;
           // coverage:ignore-end
         } else {
           appVersion = packageInfo.version;
@@ -124,8 +135,9 @@ class _AboutScreenState extends State<AboutScreen> {
           SelectableText(
             'Version $appVersion ($buildNumber)',
             style: theme.textTheme.bodyMedium?.copyWith(
-              color:
-                  theme.colorScheme.onPrimaryContainer.withValues(alpha: 0.8),
+              color: theme.colorScheme.onPrimaryContainer.withValues(
+                alpha: 0.8,
+              ),
             ),
           ),
         ],

--- a/lib/screens/brewery_screen.dart
+++ b/lib/screens/brewery_screen.dart
@@ -71,13 +71,15 @@ class _BreweryScreenState extends State<BreweryScreen> {
       body: CustomScrollView(
         slivers: [
           // Header section
-          SliverToBoxAdapter(
-            child: _buildHeader(context, producer, theme),
-          ),
+          SliverToBoxAdapter(child: _buildHeader(context, producer, theme)),
           // Hero info card
           SliverToBoxAdapter(
-            child:
-                _buildHeroCard(context, producer, breweryDrinks.length, theme),
+            child: _buildHeroCard(
+              context,
+              producer,
+              breweryDrinks.length,
+              theme,
+            ),
           ),
           // Drinks list
           ...DrinkListSection.buildSlivers(
@@ -106,7 +108,10 @@ class _BreweryScreenState extends State<BreweryScreen> {
 
   /// Build clean white header with brewery name and location
   Widget _buildHeader(
-      BuildContext context, Producer producer, ThemeData theme) {
+    BuildContext context,
+    Producer producer,
+    ThemeData theme,
+  ) {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24.0),
@@ -151,10 +156,7 @@ class _BreweryScreenState extends State<BreweryScreen> {
     final rows = <HeroInfoRow>[
       // Location
       if (producer.location.isNotEmpty)
-        HeroInfoRow(
-          icon: Icons.location_on,
-          text: producer.location,
-        ),
+        HeroInfoRow(icon: Icons.location_on, text: producer.location),
       // Drink count
       HeroInfoRow(
         icon: Icons.local_bar,

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -70,18 +70,14 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
             child: CustomScrollView(
               slivers: [
                 // Header section
-                SliverToBoxAdapter(
-                  child: _buildHeader(context, drink, theme),
-                ),
+                SliverToBoxAdapter(child: _buildHeader(context, drink, theme)),
                 // Hero info card
                 SliverToBoxAdapter(
                   child: _buildHeroCard(context, drink, theme),
                 ),
                 // Style chip for navigation
                 if (drink.style != null)
-                  SliverToBoxAdapter(
-                    child: _buildStyleChip(context, drink),
-                  ),
+                  SliverToBoxAdapter(child: _buildStyleChip(context, drink)),
                 // Description
                 if (drink.notes != null && drink.notes!.isNotEmpty)
                   SliverToBoxAdapter(
@@ -93,9 +89,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
                     child: _buildAllergens(context, drink, theme),
                   ),
                 // Brewery section
-                SliverToBoxAdapter(
-                  child: _buildBrewerySection(context, drink),
-                ),
+                SliverToBoxAdapter(child: _buildBrewerySection(context, drink)),
                 // Similar drinks
                 ..._buildSimilarDrinksSlivers(context, drink, provider),
                 const SliverPadding(padding: EdgeInsets.only(bottom: 16)),
@@ -110,7 +104,10 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
   }
 
   Widget _buildAppBarTitle(
-      BuildContext context, BeerProvider provider, Drink drink) {
+    BuildContext context,
+    BeerProvider provider,
+    Drink drink,
+  ) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -173,8 +170,9 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
           HeroInfoRow(
             icon: isSoldOut ? Icons.cancel : Icons.check_circle,
             text: isSoldOut ? 'Sold Out' : 'Available at ${drink.bar}',
-            iconColor:
-                isSoldOut ? theme.colorScheme.error : theme.colorScheme.primary,
+            iconColor: isSoldOut
+                ? theme.colorScheme.error
+                : theme.colorScheme.primary,
           ),
         // Vegan indicator
         if (drink.isVegan == true)
@@ -255,10 +253,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
         const SectionHeader(title: 'About This Drink'),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: SelectableText(
-            drink.notes!,
-            style: theme.textTheme.bodyLarge,
-          ),
+          child: SelectableText(drink.notes!, style: theme.textTheme.bodyLarge),
         ),
       ],
     );
@@ -311,8 +306,10 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
                     ? Text(drink.breweryLocation)
                     : null,
                 trailing: const Icon(Icons.chevron_right),
-                onTap: () => navigateToRoute(context,
-                    buildBreweryPath(widget.festivalId, drink.producer.id)),
+                onTap: () => navigateToRoute(
+                  context,
+                  buildBreweryPath(widget.festivalId, drink.producer.id),
+                ),
               ),
             ),
           ),
@@ -322,9 +319,14 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
   }
 
   List<Widget> _buildSimilarDrinksSlivers(
-      BuildContext context, Drink drink, BeerProvider provider) {
-    final similarDrinksWithReasons =
-        _getSimilarDrinksWithReasons(drink, provider.allDrinks);
+    BuildContext context,
+    Drink drink,
+    BeerProvider provider,
+  ) {
+    final similarDrinksWithReasons = _getSimilarDrinksWithReasons(
+      drink,
+      provider.allDrinks,
+    );
 
     return DrinkListSection.buildSliversWithSubtitles(
       context: context,
@@ -336,7 +338,9 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
   }
 
   List<(Drink, String)> _getSimilarDrinksWithReasons(
-      Drink drink, List<Drink> allDrinks) {
+    Drink drink,
+    List<Drink> allDrinks,
+  ) {
     final results = <(Drink, String)>[];
 
     for (final d in allDrinks) {
@@ -359,13 +363,17 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
   }
 
   Widget _buildBottomActionBar(
-      BuildContext context, Drink drink, BeerProvider provider) {
+    BuildContext context,
+    Drink drink,
+    BeerProvider provider,
+  ) {
     return BottomActionBar(
       actions: [
         // Tasted checkbox
         ActionButton(
-          icon:
-              drink.isTasted ? Icons.check_box : Icons.check_box_outline_blank,
+          icon: drink.isTasted
+              ? Icons.check_box
+              : Icons.check_box_outline_blank,
           label: 'Tasted',
           isActive: drink.isTasted,
           onPressed: () => provider.toggleTasted(drink),
@@ -382,8 +390,10 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
             onTap: () => _showRatingDialog(context, drink, provider),
             borderRadius: BorderRadius.circular(8.0),
             child: Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12.0,
+                vertical: 8.0,
+              ),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -398,13 +408,13 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
                   Text(
                     drink.rating != null ? '${drink.rating}/5' : 'Rate',
                     style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: drink.rating != null
-                              ? Theme.of(context).colorScheme.primary
-                              : Theme.of(context).colorScheme.onSurfaceVariant,
-                          fontWeight: drink.rating != null
-                              ? FontWeight.w600
-                              : FontWeight.normal,
-                        ),
+                      color: drink.rating != null
+                          ? Theme.of(context).colorScheme.primary
+                          : Theme.of(context).colorScheme.onSurfaceVariant,
+                      fontWeight: drink.rating != null
+                          ? FontWeight.w600
+                          : FontWeight.normal,
+                    ),
                   ),
                 ],
               ),
@@ -425,7 +435,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
         ActionButton(
           icon: Icons.share,
           label: 'Share',
-          onPressed: () => _shareDrink(context, drink),
+          onPressed: () => unawaited(_shareDrink(context, drink)),
           semanticLabel: 'Share ${drink.name}',
         ),
       ],
@@ -433,7 +443,10 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
   }
 
   void _showRatingDialog(
-      BuildContext context, Drink drink, BeerProvider provider) {
+    BuildContext context,
+    Drink drink,
+    BeerProvider provider,
+  ) {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -470,7 +483,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
     );
   }
 
-  void _shareDrink(BuildContext context, Drink drink) {
+  Future<void> _shareDrink(BuildContext context, Drink drink) async {
     final provider = context.read<BeerProvider>();
     // Use the drink's own festivalId rather than provider.currentFestival, which
     // can lag on deep-link entry before the provider catches up to the route.
@@ -480,7 +493,9 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
         festival.hashtag ?? '#${festival.id.replaceAll(_hashtagSafeRegex, '')}';
     final url =
         'https://cambeerfestival.app${buildDrinkDetailPath(drink.festivalId, drink.category, drink.id)}';
-    Share.share(drink.getShareMessage(hashtag, url: url));
+    await SharePlus.instance.share(
+      ShareParams(text: drink.getShareMessage(hashtag, url: url)),
+    );
     unawaited(provider.analyticsService.logDrinkShared(drink));
   }
 }

--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -11,10 +11,7 @@ import '../widgets/widgets.dart';
 
 /// Main screen showing the list of drinks
 class DrinksScreen extends StatefulWidget {
-  const DrinksScreen({
-    required this.festivalId,
-    super.key,
-  });
+  const DrinksScreen({required this.festivalId, super.key});
 
   final String festivalId;
 
@@ -58,9 +55,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
                     floating: true,
                     snap: true,
                     title: _buildFestivalHeader(context, provider),
-                    actions: [
-                      buildOverflowMenu(context),
-                    ],
+                    actions: [buildOverflowMenu(context)],
                   ),
                   SliverToBoxAdapter(
                     child: _buildFestivalBanner(context, provider),
@@ -117,8 +112,10 @@ class _DrinksScreenState extends State<DrinksScreen> {
             borderRadius: BorderRadius.circular(28),
             borderSide: BorderSide.none,
           ),
-          contentPadding:
-              const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
+          ),
         ),
         onChanged: _onSearchChanged,
       ),
@@ -130,8 +127,8 @@ class _DrinksScreenState extends State<DrinksScreen> {
     final styleLabel = provider.selectedStyles.isEmpty
         ? 'Style'
         : provider.selectedStyles.length == 1
-            ? provider.selectedStyles.first
-            : '${provider.selectedStyles.length} styles';
+        ? provider.selectedStyles.first
+        : '${provider.selectedStyles.length} styles';
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
@@ -175,7 +172,8 @@ class _DrinksScreenState extends State<DrinksScreen> {
           ),
           const SizedBox(width: 6),
           _VisibilityFilterButton(
-            activeCount: provider.visibilityFilters.length +
+            activeCount:
+                provider.visibilityFilters.length +
                 provider.excludedAllergens.length,
             onPressed: () => _showVisibilityFilter(context, provider),
           ),
@@ -502,8 +500,10 @@ class _DrinksScreenState extends State<DrinksScreen> {
             children: [
               const Icon(Icons.error_outline, size: 64, color: Colors.red),
               const SizedBox(height: 16),
-              Text('Error loading drinks',
-                  style: Theme.of(context).textTheme.titleLarge),
+              Text(
+                'Error loading drinks',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
               const SizedBox(height: 8),
               Text(provider.error!, textAlign: TextAlign.center),
               const SizedBox(height: 16),
@@ -530,8 +530,11 @@ class _DrinksScreenState extends State<DrinksScreen> {
             children: [
               Opacity(
                 opacity: 0.5,
-                child:
-                    Image.asset('assets/app_icon.png', width: 80, height: 80),
+                child: Image.asset(
+                  'assets/app_icon.png',
+                  width: 80,
+                  height: 80,
+                ),
               ),
               const SizedBox(height: 16),
               Text(
@@ -561,26 +564,28 @@ class _DrinksScreenState extends State<DrinksScreen> {
     return SliverPadding(
       padding: const EdgeInsets.only(bottom: 16),
       sliver: SliverList(
-        delegate: SliverChildBuilderDelegate(
-          (context, index) {
-            final drink = provider.drinks[index];
-            return DrinkCard(
-              key: ValueKey(drink.id),
-              drink: drink,
-              onTap: () => _navigateToDetail(context, drink.id, drink.category),
-              onFavoriteTap: () => provider.toggleFavorite(drink),
-            );
-          },
-          childCount: provider.drinks.length,
-        ),
+        delegate: SliverChildBuilderDelegate((context, index) {
+          final drink = provider.drinks[index];
+          return DrinkCard(
+            key: ValueKey(drink.id),
+            drink: drink,
+            onTap: () => _navigateToDetail(context, drink.id, drink.category),
+            onFavoriteTap: () => provider.toggleFavorite(drink),
+          );
+        }, childCount: provider.drinks.length),
       ),
     );
   }
 
   void _navigateToDetail(
-      BuildContext context, String drinkId, String category) {
+    BuildContext context,
+    String drinkId,
+    String category,
+  ) {
     navigateToRoute(
-        context, buildDrinkDetailPath(widget.festivalId, category, drinkId));
+      context,
+      buildDrinkDetailPath(widget.festivalId, category, drinkId),
+    );
   }
 
   void _showCategoryFilter(BuildContext context, BeerProvider provider) {
@@ -652,8 +657,9 @@ class _FilterButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final effectiveLabel = semanticLabel ?? label;
-    final semanticHint =
-        isActive ? 'Double tap to clear filter' : 'Double tap to select filter';
+    final semanticHint = isActive
+        ? 'Double tap to clear filter'
+        : 'Double tap to select filter';
 
     return Semantics(
       label: effectiveLabel,
@@ -715,13 +721,11 @@ class _SearchButton extends StatelessWidget {
         style: FilledButton.styleFrom(
           padding: const EdgeInsets.all(12),
           minimumSize: const Size(48, 48),
-          backgroundColor:
-              hasQuery && !isActive ? theme.colorScheme.primaryContainer : null,
+          backgroundColor: hasQuery && !isActive
+              ? theme.colorScheme.primaryContainer
+              : null,
         ),
-        child: Icon(
-          isActive ? Icons.search_off : Icons.search,
-          size: 20,
-        ),
+        child: Icon(isActive ? Icons.search_off : Icons.search, size: 20),
       ),
     );
   }
@@ -1037,7 +1041,9 @@ class _StyleFilterSheet extends StatelessWidget {
                 child: selectedStyles.isNotEmpty
                     ? Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 8),
+                          horizontal: 12,
+                          vertical: 8,
+                        ),
                         decoration: BoxDecoration(
                           color: theme.colorScheme.primaryContainer,
                           borderRadius: BorderRadius.circular(8),
@@ -1165,8 +1171,9 @@ class _VisibilityFilterSheet extends StatelessWidget {
                         label: 'Available only',
                         subtitle: 'Hide sold out & not yet arrived drinks',
                         icon: Icons.check_circle_outline,
-                        isChecked: active
-                            .contains(DrinkVisibilityFilter.availableOnly),
+                        isChecked: active.contains(
+                          DrinkVisibilityFilter.availableOnly,
+                        ),
                         onChanged: (value) => beerProvider.setVisibilityFilter(
                           DrinkVisibilityFilter.availableOnly,
                           value ?? false,
@@ -1176,8 +1183,9 @@ class _VisibilityFilterSheet extends StatelessWidget {
                         label: 'Not tasted',
                         subtitle: 'Hide drinks you\'ve already tasted',
                         icon: Icons.remove_circle_outline,
-                        isChecked:
-                            active.contains(DrinkVisibilityFilter.notTasted),
+                        isChecked: active.contains(
+                          DrinkVisibilityFilter.notTasted,
+                        ),
                         onChanged: (value) => beerProvider.setVisibilityFilter(
                           DrinkVisibilityFilter.notTasted,
                           value ?? false,
@@ -1187,8 +1195,9 @@ class _VisibilityFilterSheet extends StatelessWidget {
                         label: 'Vegan only',
                         subtitle: 'Show only drinks marked as vegan',
                         icon: Icons.eco_outlined,
-                        isChecked:
-                            active.contains(DrinkVisibilityFilter.veganOnly),
+                        isChecked: active.contains(
+                          DrinkVisibilityFilter.veganOnly,
+                        ),
                         onChanged: (value) => beerProvider.setVisibilityFilter(
                           DrinkVisibilityFilter.veganOnly,
                           value ?? false,
@@ -1203,13 +1212,11 @@ class _VisibilityFilterSheet extends StatelessWidget {
                           ),
                           child: Text(
                             'Allergen-free',
-                            style: Theme.of(context)
-                                .textTheme
-                                .labelMedium
+                            style: Theme.of(context).textTheme.labelMedium
                                 ?.copyWith(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSurfaceVariant,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
                                 ),
                           ),
                         ),
@@ -1220,13 +1227,11 @@ class _VisibilityFilterSheet extends StatelessWidget {
                             label: _formatAllergenName(allergen),
                             subtitle: 'Hide drinks containing $allergen',
                             icon: Icons.no_meals_outlined,
-                            isChecked: beerProvider.excludedAllergens
-                                .contains(allergen),
-                            onChanged: (value) =>
-                                beerProvider.setAllergenFilter(
+                            isChecked: beerProvider.excludedAllergens.contains(
                               allergen,
-                              value ?? false,
                             ),
+                            onChanged: (value) => beerProvider
+                                .setAllergenFilter(allergen, value ?? false),
                           ),
                       ],
                     ],

--- a/lib/screens/festival_info_screen.dart
+++ b/lib/screens/festival_info_screen.dart
@@ -8,10 +8,7 @@ import '../utils/utils.dart';
 
 /// Screen showing detailed festival information
 class FestivalInfoScreen extends StatelessWidget {
-  const FestivalInfoScreen({
-    required this.festivalId,
-    super.key,
-  });
+  const FestivalInfoScreen({required this.festivalId, super.key});
 
   final String festivalId;
 
@@ -73,15 +70,17 @@ class FestivalInfoScreen extends StatelessWidget {
                 Icon(
                   Icons.calendar_today,
                   size: 18,
-                  color: theme.colorScheme.onPrimaryContainer
-                      .withValues(alpha: 0.7),
+                  color: theme.colorScheme.onPrimaryContainer.withValues(
+                    alpha: 0.7,
+                  ),
                 ),
                 const SizedBox(width: 8),
                 SelectableText(
                   festival.formattedDates,
                   style: theme.textTheme.titleMedium?.copyWith(
-                    color: theme.colorScheme.onPrimaryContainer
-                        .withValues(alpha: 0.9),
+                    color: theme.colorScheme.onPrimaryContainer.withValues(
+                      alpha: 0.9,
+                    ),
                   ),
                 ),
               ],
@@ -92,8 +91,9 @@ class FestivalInfoScreen extends StatelessWidget {
             SelectableText(
               festival.hashtag!,
               style: theme.textTheme.bodyMedium?.copyWith(
-                color:
-                    theme.colorScheme.onPrimaryContainer.withValues(alpha: 0.7),
+                color: theme.colorScheme.onPrimaryContainer.withValues(
+                  alpha: 0.7,
+                ),
               ),
             ),
           ],
@@ -135,8 +135,10 @@ class FestivalInfoScreen extends StatelessWidget {
             children: festival.availableBeverageTypes.map((type) {
               return Chip(
                 label: Text(BeverageTypeHelper.formatBeverageType(type)),
-                avatar:
-                    Icon(BeverageTypeHelper.getBeverageIcon(type), size: 18),
+                avatar: Icon(
+                  BeverageTypeHelper.getBeverageIcon(type),
+                  size: 18,
+                ),
               );
             }).toList(),
           ),
@@ -158,8 +160,9 @@ class FestivalInfoScreen extends StatelessWidget {
             child: ListTile(
               leading: const Icon(Icons.location_on),
               title: Text(festival.location ?? 'Location TBA'),
-              subtitle:
-                  festival.address != null ? Text(festival.address!) : null,
+              subtitle: festival.address != null
+                  ? Text(festival.address!)
+                  : null,
               trailing: festival.latitude != null && festival.longitude != null
                   ? Semantics(
                       label: 'Open location in maps',

--- a/lib/screens/style_screen.dart
+++ b/lib/screens/style_screen.dart
@@ -11,11 +11,7 @@ class StyleScreen extends StatefulWidget {
   final String festivalId;
   final String style;
 
-  const StyleScreen({
-    required this.festivalId,
-    required this.style,
-    super.key,
-  });
+  const StyleScreen({required this.festivalId, required this.style, super.key});
 
   @override
   State<StyleScreen> createState() => _StyleScreenState();
@@ -43,8 +39,10 @@ class _StyleScreenState extends State<StyleScreen> {
 
     // Get all drinks with this style
     final styleDrinks = provider.allDrinks
-        .where((drink) =>
-            drink.product.style?.toLowerCase() == widget.style.toLowerCase())
+        .where(
+          (drink) =>
+              drink.product.style?.toLowerCase() == widget.style.toLowerCase(),
+        )
         .toList();
 
     if (styleDrinks.isEmpty) {
@@ -68,9 +66,7 @@ class _StyleScreenState extends State<StyleScreen> {
       body: CustomScrollView(
         slivers: [
           // Header section
-          SliverToBoxAdapter(
-            child: _buildHeader(context, theme, displayStyle),
-          ),
+          SliverToBoxAdapter(child: _buildHeader(context, theme, displayStyle)),
           // Hero info card
           SliverToBoxAdapter(
             child: _buildHeroCard(context, styleDrinks, theme),
@@ -114,7 +110,10 @@ class _StyleScreenState extends State<StyleScreen> {
 
   /// Build clean white header with style name
   Widget _buildHeader(
-      BuildContext context, ThemeData theme, String displayStyle) {
+    BuildContext context,
+    ThemeData theme,
+    String displayStyle,
+  ) {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24.0),
@@ -144,7 +143,7 @@ class _StyleScreenState extends State<StyleScreen> {
     final avgABV = styleDrinks.isEmpty
         ? 0.0
         : styleDrinks.map((d) => d.product.abv).reduce((a, b) => a + b) /
-            styleDrinks.length;
+              styleDrinks.length;
 
     final rows = <HeroInfoRow>[
       // Drink count
@@ -176,10 +175,7 @@ class _StyleScreenState extends State<StyleScreen> {
         const SectionHeader(title: 'About This Style'),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: SelectableText(
-            description,
-            style: theme.textTheme.bodyLarge,
-          ),
+          child: SelectableText(description, style: theme.textTheme.bodyLarge),
         ),
       ],
     );

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -21,13 +21,16 @@ class AnalyticsService {
   bool get _isAnalyticsEnabled => EnvironmentService.isProduction();
 
   /// Helper method to execute analytics calls only when enabled
-  Future<void> _logIfEnabled(Future<void> Function() analyticsCall,
-      {bool showDebug = false}) async {
+  Future<void> _logIfEnabled(
+    Future<void> Function() analyticsCall, {
+    bool showDebug = false,
+  }) async {
     if (!_isAnalyticsEnabled) {
       // coverage:ignore-start
       if (showDebug) {
         debugPrint(
-            'Analytics disabled in ${EnvironmentService.getEnvironmentName()} environment');
+          'Analytics disabled in ${EnvironmentService.getEnvironmentName()} environment',
+        );
       }
       // coverage:ignore-end
       return;
@@ -46,15 +49,17 @@ class AnalyticsService {
 
   /// Log festival selection
   Future<void> logFestivalSelected(Festival festival) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'festival_selected',
-          // coverage:ignore-start
-          parameters: {
-            'festival_id': festival.id,
-            'festival_name': festival.name,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'festival_selected',
+        // coverage:ignore-start
+        parameters: {
+          'festival_id': festival.id,
+          'festival_name': festival.name,
+        },
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log search usage
@@ -64,167 +69,174 @@ class AnalyticsService {
 
   /// Log category filter usage
   Future<void> logCategoryFilter(String? category) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'filter_category',
-          // coverage:ignore-start
-          parameters: {
-            'category': category ?? 'all',
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'filter_category',
+        // coverage:ignore-start
+        parameters: {'category': category ?? 'all'},
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log style filter usage
   Future<void> logStyleFilter(Set<String> styles) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'filter_style',
-          // coverage:ignore-start
-          parameters: {
-            'style_count': styles.length,
-            'styles': styles.join(','),
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'filter_style',
+        // coverage:ignore-start
+        parameters: {'style_count': styles.length, 'styles': styles.join(',')},
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log sort change
   Future<void> logSortChange(String sortType) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'sort_changed',
-          // coverage:ignore-start
-          parameters: {
-            'sort_type': sortType,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'sort_changed',
+        // coverage:ignore-start
+        parameters: {'sort_type': sortType},
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log favorite added
   Future<void> logFavoriteAdded(Drink drink) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'favorite_added',
-          // coverage:ignore-start
-          parameters: {
-            'drink_id': drink.id,
-            'drink_name': drink.name,
-            'brewery': drink.breweryName,
-            'category': drink.category,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'favorite_added',
+        // coverage:ignore-start
+        parameters: {
+          'drink_id': drink.id,
+          'drink_name': drink.name,
+          'brewery': drink.breweryName,
+          'category': drink.category,
+        },
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log favorite removed
   Future<void> logFavoriteRemoved(Drink drink) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'favorite_removed',
-          // coverage:ignore-start
-          parameters: {
-            'drink_id': drink.id,
-            'drink_name': drink.name,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'favorite_removed',
+        // coverage:ignore-start
+        parameters: {'drink_id': drink.id, 'drink_name': drink.name},
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log drink marked as tasted
   Future<void> logTastedAdded(Drink drink) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'tasted_added',
-          // coverage:ignore-start
-          parameters: {
-            'drink_id': drink.id,
-            'drink_name': drink.name,
-            'brewery': drink.breweryName,
-            'category': drink.category,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'tasted_added',
+        // coverage:ignore-start
+        parameters: {
+          'drink_id': drink.id,
+          'drink_name': drink.name,
+          'brewery': drink.breweryName,
+          'category': drink.category,
+        },
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log drink unmarked as tasted
   Future<void> logTastedRemoved(Drink drink) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'tasted_removed',
-          // coverage:ignore-start
-          parameters: {
-            'drink_id': drink.id,
-            'drink_name': drink.name,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'tasted_removed',
+        // coverage:ignore-start
+        parameters: {'drink_id': drink.id, 'drink_name': drink.name},
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log drink details viewed
   Future<void> logDrinkViewed(Drink drink) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'drink_viewed',
-          // coverage:ignore-start
-          parameters: {
-            'drink_id': drink.id,
-            'drink_name': drink.name,
-            'brewery': drink.breweryName,
-            'category': drink.category,
-            'abv': drink.abv,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'drink_viewed',
+        // coverage:ignore-start
+        parameters: {
+          'drink_id': drink.id,
+          'drink_name': drink.name,
+          'brewery': drink.breweryName,
+          'category': drink.category,
+          'abv': drink.abv,
+        },
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log brewery details viewed
   Future<void> logBreweryViewed(String breweryName) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'brewery_viewed',
-          // coverage:ignore-start
-          parameters: {
-            'brewery_name': breweryName,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'brewery_viewed',
+        // coverage:ignore-start
+        parameters: {'brewery_name': breweryName},
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log style details viewed
   Future<void> logStyleViewed(String style) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'style_viewed',
-          // coverage:ignore-start
-          parameters: {
-            'style': style,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'style_viewed',
+        // coverage:ignore-start
+        parameters: {'style': style},
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log rating given
   Future<void> logRatingGiven(Drink drink, int rating) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'rating_given',
-          // coverage:ignore-start
-          parameters: {
-            'drink_id': drink.id,
-            'drink_name': drink.name,
-            'rating': rating,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'rating_given',
+        // coverage:ignore-start
+        parameters: {
+          'drink_id': drink.id,
+          'drink_name': drink.name,
+          'rating': rating,
+        },
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log drink shared
   Future<void> logDrinkShared(Drink drink) async {
-    await _logIfEnabled(() => analytics.logEvent(
-          name: 'drink_shared',
-          // coverage:ignore-start
-          parameters: {
-            'drink_id': drink.id,
-            'drink_name': drink.name,
-          },
-          // coverage:ignore-end
-        ));
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'drink_shared',
+        // coverage:ignore-start
+        parameters: {'drink_id': drink.id, 'drink_name': drink.name},
+        // coverage:ignore-end
+      ),
+    );
   }
 
   /// Log error to Crashlytics (non-fatal)
-  Future<void> logError(Object error, StackTrace? stackTrace,
-      {String? reason}) async {
+  Future<void> logError(
+    Object error,
+    StackTrace? stackTrace, {
+    String? reason,
+  }) async {
     try {
       await crashlytics.recordError(
         error,
@@ -240,7 +252,8 @@ class AnalyticsService {
   /// Set user property (e.g., preferred theme)
   Future<void> setUserProperty(String name, String? value) async {
     await _logIfEnabled(
-        () => analytics.setUserProperty(name: name, value: value));
+      () => analytics.setUserProperty(name: name, value: value),
+    );
   }
 
   /// Set user ID for tracking across sessions

--- a/lib/services/beer_api_service.dart
+++ b/lib/services/beer_api_service.dart
@@ -19,7 +19,9 @@ class BeerApiService {
   /// Callers that need to distinguish "no data" from "type not offered" (the
   /// per-type cache) should use [fetchDrinksByType] instead.
   Future<List<Drink>> fetchDrinks(
-      Festival festival, String beverageType) async {
+    Festival festival,
+    String beverageType,
+  ) async {
     return (await _fetchDrinksOrNull(festival, beverageType)) ?? <Drink>[];
   }
 
@@ -27,7 +29,9 @@ class BeerApiService {
   /// responded 404 (meaning "not offered, or transiently unavailable").
   /// Throws [BeerApiException] for non-200/404 statuses or other I/O errors.
   Future<List<Drink>?> _fetchDrinksOrNull(
-      Festival festival, String beverageType) async {
+    Festival festival,
+    String beverageType,
+  ) async {
     final url = festival.getBeverageUrl(beverageType);
     final response = await _client.get(Uri.parse(url)).timeout(timeout);
 
@@ -103,7 +107,9 @@ class BeerApiService {
   /// Public and static so the local data cache can deserialize stored payloads
   /// through the exact same logic used for live API responses.
   static List<Drink> parseProducers(
-      Map<String, dynamic> data, String festivalId) {
+    Map<String, dynamic> data,
+    String festivalId,
+  ) {
     final drinks = <Drink>[];
     final producers = data['producers'] as List<dynamic>? ?? [];
 
@@ -112,11 +118,9 @@ class BeerApiService {
       if (producer.id.isEmpty) continue;
       for (final product in producer.products) {
         if (product.id.isEmpty) continue;
-        drinks.add(Drink(
-          product: product,
-          producer: producer,
-          festivalId: festivalId,
-        ));
+        drinks.add(
+          Drink(product: product, producer: producer, festivalId: festivalId),
+        );
       }
     }
 
@@ -144,8 +148,9 @@ class FestivalDrinksResult {
   });
 
   /// All successfully fetched drinks, flattened across beverage types.
-  List<Drink> get allDrinks =>
-      [for (final drinks in drinksByType.values) ...drinks];
+  List<Drink> get allDrinks => [
+    for (final drinks in drinksByType.values) ...drinks,
+  ];
 
   /// True when every beverage type errored and nothing was fetched.
   bool get isCompleteFailure => drinksByType.isEmpty && failedTypes.isNotEmpty;
@@ -157,8 +162,9 @@ class FestivalDrinksResult {
   /// can recognise the wrapped offline case and skip noisy analytics logging.
   void throwIfCompleteFailure() {
     if (!isCompleteFailure) return;
-    final details =
-        failedTypes.entries.map((e) => '${e.key}: ${e.value}').join('\n');
+    final details = failedTypes.entries
+        .map((e) => '${e.key}: ${e.value}')
+        .join('\n');
     final allConnectivity = failedTypes.values.every(isConnectivityFailure);
     throw BeerApiException(
       'Failed to load any drinks. This may be a network or CORS issue.\n\nDetails:\n$details',

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -46,7 +46,9 @@ class DrinkCacheService {
   /// (e.g. tests) can await [DrinkCacheUpdate.written]; the app intentionally
   /// does not, to keep persistence off the load critical path.
   DrinkCacheUpdate merge(
-      String festivalId, Map<String, List<Drink>> freshByType) {
+    String festivalId,
+    Map<String, List<Drink>> freshByType,
+  ) {
     final types = Map<String, dynamic>.from(_readRawTypes(festivalId) ?? {});
     freshByType.forEach((type, drinks) {
       types[type] = _producersJson(drinks);
@@ -115,7 +117,9 @@ class DrinkCacheService {
   }
 
   Future<void> _persistTypes(
-      String festivalId, Map<String, dynamic> types) async {
+    String festivalId,
+    Map<String, dynamic> types,
+  ) async {
     final payload = {
       'timestamp': DateTime.now().millisecondsSinceEpoch,
       'beverageTypes': types,
@@ -127,8 +131,10 @@ class DrinkCacheService {
   /// Drop the oldest festival snapshots once more than [_maxCachedFestivals]
   /// are stored, so the cache cannot grow without bound across festivals.
   Future<void> _evictOldCaches() async {
-    final keys =
-        _prefs.getKeys().where((k) => k.startsWith('${_keyPrefix}_')).toList();
+    final keys = _prefs
+        .getKeys()
+        .where((k) => k.startsWith('${_keyPrefix}_'))
+        .toList();
     if (keys.length <= _maxCachedFestivals) return;
 
     int timestampOf(String key) {

--- a/lib/services/festival_service.dart
+++ b/lib/services/festival_service.dart
@@ -19,14 +19,17 @@ class FestivalsResponse {
   });
 
   factory FestivalsResponse.fromJson(
-      Map<String, dynamic> json, String baseUrl) {
+    Map<String, dynamic> json,
+    String baseUrl,
+  ) {
     final rawFestivals = json['festivals'];
     final festivalsList =
         (rawFestivals is List ? rawFestivals : const <dynamic>[])
             .map<Festival?>((f) {
               try {
-                final festivalJson =
-                    Map<String, dynamic>.from(f as Map<String, dynamic>);
+                final festivalJson = Map<String, dynamic>.from(
+                  f as Map<String, dynamic>,
+                );
                 // Resolve relative URLs to absolute URLs
                 if (festivalJson['data_base_url'] != null) {
                   final dataBaseUrl = festivalJson['data_base_url'] as String;
@@ -81,14 +84,17 @@ class FestivalService {
 
   /// Fetches the list of available festivals
   Future<FestivalsResponse> fetchFestivals() async {
-    final response =
-        await _client.get(Uri.parse(_festivalsUrl)).timeout(timeout);
+    final response = await _client
+        .get(Uri.parse(_festivalsUrl))
+        .timeout(timeout);
 
     if (response.statusCode == 200) {
       final data = json.decode(response.body) as Map<String, dynamic>;
       // Extract base URL from the festivals URL (remove /festivals.json)
-      final baseUrl =
-          _festivalsUrl.replaceAll(RegExp(r'/festivals\.json$'), '');
+      final baseUrl = _festivalsUrl.replaceAll(
+        RegExp(r'/festivals\.json$'),
+        '',
+      );
       return FestivalsResponse.fromJson(data, baseUrl);
     } else {
       throw FestivalServiceException(

--- a/lib/services/tasting_log_service.dart
+++ b/lib/services/tasting_log_service.dart
@@ -15,7 +15,7 @@ class TastingLogService {
 
   /// Get the storage key for a drink's tasting log
   String _getKey(String festivalId, String drinkId) {
-    return '$_tastingLogPrefix${festivalId}|$drinkId';
+    return '$_tastingLogPrefix$festivalId|$drinkId';
   }
 
   /// Check if a drink has been tasted at a specific festival
@@ -77,8 +77,10 @@ class TastingLogService {
 
   /// Clear all tasting logs across all festivals
   Future<void> clearAllLogs() async {
-    final keys =
-        _prefs.getKeys().where((k) => k.startsWith(_tastingLogPrefix)).toList();
+    final keys = _prefs
+        .getKeys()
+        .where((k) => k.startsWith(_tastingLogPrefix))
+        .toList();
     for (final key in keys) {
       await _prefs.remove(key);
     }

--- a/lib/utils/navigation_helpers.dart
+++ b/lib/utils/navigation_helpers.dart
@@ -90,7 +90,10 @@ String buildFestivalInfoPath(String festivalId) {
 /// buildDrinkDetailPath('cbf2025', 'foreign beer', 'drink-456') // Returns: '/cbf2025/drink/foreign%20beer/drink-456'
 /// ```
 String buildDrinkDetailPath(
-    String festivalId, String category, String drinkId) {
+  String festivalId,
+  String category,
+  String drinkId,
+) {
   assert(category.isNotEmpty, 'Category cannot be empty');
   assert(drinkId.isNotEmpty, 'Drink ID cannot be empty');
   final encodedCategory = Uri.encodeComponent(category);

--- a/lib/utils/style_description_helper.dart
+++ b/lib/utils/style_description_helper.dart
@@ -20,8 +20,9 @@ class StyleDescriptionHelper {
     if (_isLoaded) return;
 
     try {
-      final jsonString =
-          await rootBundle.loadString('assets/style_descriptions.json');
+      final jsonString = await rootBundle.loadString(
+        'assets/style_descriptions.json',
+      );
       final Map<String, dynamic> jsonData =
           json.decode(jsonString) as Map<String, dynamic>;
 

--- a/lib/utils/url_launcher_helper.dart
+++ b/lib/utils/url_launcher_helper.dart
@@ -30,18 +30,18 @@ class UrlLauncherHelper {
         return true;
       } else {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(errorMessage)),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(errorMessage)));
         }
         return false;
       }
     } catch (e) {
       debugPrint('Error launching URL $url: $e');
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(errorMessage)),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(errorMessage)));
       }
       return false;
     }

--- a/lib/widgets/breadcrumb_bar.dart
+++ b/lib/widgets/breadcrumb_bar.dart
@@ -126,10 +126,7 @@ class BreadcrumbBar extends StatelessWidget {
       label: 'Navigate to $text',
       button: true,
       hint: 'Double tap to navigate',
-      child: InkWell(
-        onTap: onTap,
-        child: textWidget,
-      ),
+      child: InkWell(onTap: onTap, child: textWidget),
     );
   }
 }

--- a/lib/widgets/drink_card.dart
+++ b/lib/widgets/drink_card.dart
@@ -128,7 +128,8 @@ class DrinkCard extends StatelessWidget {
                       ExcludeSemantics(
                         child: InfoChip(
                           label: StringFormattingHelper.capitalizeFirst(
-                              drink.dispense),
+                            drink.dispense,
+                          ),
                           icon: Icons.liquor,
                         ),
                       ),
@@ -250,11 +251,7 @@ class _RatingChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StarRating(
-      rating: rating,
-      isEditable: false,
-      starSize: 14,
-    );
+    return StarRating(rating: rating, isEditable: false, starSize: 14);
   }
 }
 

--- a/lib/widgets/drink_list_section.dart
+++ b/lib/widgets/drink_list_section.dart
@@ -54,26 +54,22 @@ class DrinkListSection {
       SliverToBoxAdapter(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Text(
-            displayTitle,
-            style: theme.textTheme.titleMedium,
-          ),
+          child: Text(displayTitle, style: theme.textTheme.titleMedium),
         ),
       ),
       SliverList(
-        delegate: SliverChildBuilderDelegate(
-          (context, index) {
-            final drink = drinks[index];
-            return DrinkCard(
-              key: ValueKey(drink.id),
-              drink: drink,
-              onTap: () => navigateToRoute(context,
-                  buildDrinkDetailPath(festivalId, drink.category, drink.id)),
-              onFavoriteTap: () => provider.toggleFavorite(drink),
-            );
-          },
-          childCount: drinks.length,
-        ),
+        delegate: SliverChildBuilderDelegate((context, index) {
+          final drink = drinks[index];
+          return DrinkCard(
+            key: ValueKey(drink.id),
+            drink: drink,
+            onTap: () => navigateToRoute(
+              context,
+              buildDrinkDetailPath(festivalId, drink.category, drink.id),
+            ),
+            onFavoriteTap: () => provider.toggleFavorite(drink),
+          );
+        }, childCount: drinks.length),
       ),
     ];
   }
@@ -99,34 +95,31 @@ class DrinkListSection {
 
     final theme = Theme.of(context);
     final provider = context.read<BeerProvider>();
-    final displayTitle =
-        showCount ? '$title (${drinksWithSubtitles.length})' : title;
+    final displayTitle = showCount
+        ? '$title (${drinksWithSubtitles.length})'
+        : title;
 
     return [
       SliverToBoxAdapter(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Text(
-            displayTitle,
-            style: theme.textTheme.titleMedium,
-          ),
+          child: Text(displayTitle, style: theme.textTheme.titleMedium),
         ),
       ),
       SliverList(
-        delegate: SliverChildBuilderDelegate(
-          (context, index) {
-            final (drink, subtitle) = drinksWithSubtitles[index];
-            return _DrinkCardWithSubtitle(
-              key: ValueKey(drink.id),
-              drink: drink,
-              subtitle: subtitle,
-              onTap: () => navigateToRoute(context,
-                  buildDrinkDetailPath(festivalId, drink.category, drink.id)),
-              onFavoriteTap: () => provider.toggleFavorite(drink),
-            );
-          },
-          childCount: drinksWithSubtitles.length,
-        ),
+        delegate: SliverChildBuilderDelegate((context, index) {
+          final (drink, subtitle) = drinksWithSubtitles[index];
+          return _DrinkCardWithSubtitle(
+            key: ValueKey(drink.id),
+            drink: drink,
+            subtitle: subtitle,
+            onTap: () => navigateToRoute(
+              context,
+              buildDrinkDetailPath(festivalId, drink.category, drink.id),
+            ),
+            onFavoriteTap: () => provider.toggleFavorite(drink),
+          );
+        }, childCount: drinksWithSubtitles.length),
       ),
     ];
   }
@@ -154,11 +147,7 @@ class _DrinkCardWithSubtitle extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        DrinkCard(
-          drink: drink,
-          onTap: onTap,
-          onFavoriteTap: onFavoriteTap,
-        ),
+        DrinkCard(drink: drink, onTap: onTap, onFavoriteTap: onFavoriteTap),
         Padding(
           padding: const EdgeInsets.fromLTRB(32, 0, 32, 8),
           child: Row(

--- a/lib/widgets/environment_badge.dart
+++ b/lib/widgets/environment_badge.dart
@@ -79,11 +79,7 @@ class EnvironmentBadge extends StatelessWidget {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(
-                  Icons.science_outlined,
-                  size: 16,
-                  color: textColor,
-                ),
+                Icon(Icons.science_outlined, size: 16, color: textColor),
                 const SizedBox(width: 6),
                 Text(
                   _toTitleCase(envName),

--- a/lib/widgets/festival_menu_sheets.dart
+++ b/lib/widgets/festival_menu_sheets.dart
@@ -19,10 +19,8 @@ void showFestivalBrowser(BuildContext context) {
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
-    builder: (context) => FestivalSelectorSheet(
-      provider: provider,
-      currentPath: currentPath,
-    ),
+    builder: (context) =>
+        FestivalSelectorSheet(provider: provider, currentPath: currentPath),
   );
 }
 
@@ -185,8 +183,10 @@ class FestivalSelectorSheet extends StatelessWidget {
                     )
                   else
                     ...festivals.map((festival) {
-                      final status =
-                          Festival.getStatusInContext(festival, festivals);
+                      final status = Festival.getStatusInContext(
+                        festival,
+                        festivals,
+                      );
                       final statusLabel = _getStatusLabel(status);
                       final isSelected =
                           festival.id == provider.currentFestival.id;
@@ -379,20 +379,22 @@ class FestivalCard extends StatelessWidget {
                   runSpacing: 4,
                   children: festival.availableBeverageTypes
                       .take(5) // Show max 5 types
-                      .map((type) => Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 2,
-                            ),
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.surfaceContainerHighest,
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                            child: Text(
-                              BeverageTypeHelper.formatBeverageType(type),
-                              style: theme.textTheme.labelSmall,
-                            ),
-                          ))
+                      .map(
+                        (type) => Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            BeverageTypeHelper.formatBeverageType(type),
+                            style: theme.textTheme.labelSmall,
+                          ),
+                        ),
+                      )
                       .toList(),
                 ),
               ],
@@ -414,29 +416,30 @@ class FestivalCard extends StatelessWidget {
 
         switch (status) {
           case FestivalStatus.live:
-            backgroundColor =
-                isDark ? const Color(0xFF4CAF50) : const Color(0xFF2E7D32);
+            backgroundColor = isDark
+                ? const Color(0xFF4CAF50)
+                : const Color(0xFF2E7D32);
             label = 'LIVE';
           case FestivalStatus.upcoming:
-            backgroundColor =
-                isDark ? const Color(0xFF42A5F5) : const Color(0xFF1976D2);
+            backgroundColor = isDark
+                ? const Color(0xFF42A5F5)
+                : const Color(0xFF1976D2);
             label = 'COMING SOON';
           case FestivalStatus.mostRecent:
-            backgroundColor =
-                isDark ? const Color(0xFFFF9800) : const Color(0xFFEF6C00);
+            backgroundColor = isDark
+                ? const Color(0xFFFF9800)
+                : const Color(0xFFEF6C00);
             label = 'MOST RECENT';
           case FestivalStatus.past:
-            backgroundColor =
-                isDark ? const Color(0xFF9E9E9E) : const Color(0xFF616161);
+            backgroundColor = isDark
+                ? const Color(0xFF9E9E9E)
+                : const Color(0xFF616161);
             label = 'PAST';
         }
 
         return Container(
           margin: const EdgeInsets.only(right: 8),
-          padding: const EdgeInsets.symmetric(
-            horizontal: 8,
-            vertical: 2,
-          ),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
           decoration: BoxDecoration(
             color: backgroundColor,
             borderRadius: BorderRadius.circular(12),

--- a/lib/widgets/hero_info_card.dart
+++ b/lib/widgets/hero_info_card.dart
@@ -11,11 +11,7 @@ class HeroInfoCard extends StatelessWidget {
   /// Optional padding around the card content
   final EdgeInsets? padding;
 
-  const HeroInfoCard({
-    required this.rows,
-    this.padding,
-    super.key,
-  });
+  const HeroInfoCard({required this.rows, this.padding, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -84,12 +80,7 @@ class HeroInfoRow extends StatelessWidget {
           color: iconColor ?? theme.colorScheme.onPrimaryContainer,
         ),
         const SizedBox(width: 12),
-        Expanded(
-          child: SelectableText(
-            text,
-            style: textStyle ?? defaultStyle,
-          ),
-        ),
+        Expanded(child: SelectableText(text, style: textStyle ?? defaultStyle)),
       ],
     );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: ff0a84a2734d9e1089f8aedd5c0af0061b82fb94e95260d943404e0ef2134b11
+      sha256: "8f89e371e2883de35cdc78f648e725fa4da5f3b6c927269f00fa68f1ea92b598"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.59"
+    version: "1.3.71"
   analyzer:
     dependency: transitive
     description:
@@ -245,66 +245,66 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_analytics
-      sha256: "4f85b161772e1d54a66893ef131c0a44bd9e552efa78b33d5f4f60d2caa5c8a3"
+      sha256: "56641bc6dd7b6a8c63ad5f5d46664af5b66db452f1c5ad052b1eec0188cf3183"
       url: "https://pub.dev"
     source: hosted
-    version: "11.6.0"
+    version: "12.4.1"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: a44b6d1155ed5cae7641e3de7163111cfd9f6f6c954ca916dc6a3bdfa86bf845
+      sha256: "432492ba57024a35dfb67ebcf0c64bac31e19d2c46b3dd222bccbc05f8839efe"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.3"
+    version: "6.0.1"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: c7d1ed1f86ae64215757518af5576ff88341c8ce5741988c05cc3b2e07b0b273
+      sha256: e613fca6511ab8f13adb355f7bc486c49fa6aea72fb6703cfb34df29b3b568a6
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.10+16"
+    version: "0.6.1+7"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "7be63a3f841fc9663342f7f3a011a42aef6a61066943c90b1c434d79d5c995c5"
+      sha256: "93a5bde9775fd5adcc937f39dfa04ae0bc89c4d79bea6abc49de3f7b049d9ff6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.15.2"
+    version: "4.9.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "0ecda14c1bfc9ed8cac303dd0f8d04a320811b479362a9a4efb14fd331a473ce"
+      sha256: "4a120366dbf7d5a8ee9438978530b664b855728fb8dcc3a201017660817e555b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "7.0.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "0ed0dc292e8f9ac50992e2394e9d336a0275b6ae400d64163fdf0a8a8b556c37"
+      sha256: "7c98f10b8c8e5adedc0b810b66a877120696675e2c22d9ca9caca092da0d9e57"
       url: "https://pub.dev"
     source: hosted
-    version: "2.24.1"
+    version: "3.7.0"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
-      sha256: "662ae6443da91bca1fb0be8aeeac026fa2975e8b7ddfca36e4d90ebafa35dde1"
+      sha256: "9935ea36aaae0dfc789b80a1981fd70c6c7e9956791e9e7c2210ab83f9c963bd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.10"
+    version: "5.2.2"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: "7222a8a40077c79f6b8b3f3439241c9f2b34e9ddfde8381ffc512f7b2e61f7eb"
+      sha256: ade20d7d86698ded596bf16ab0e7060ef1dae9258ab6705536a39ae047ccef59
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.10"
+    version: "3.8.22"
   fixnum:
     dependency: transitive
     description:
@@ -343,10 +343,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "6.0.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -382,18 +382,18 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      sha256: "92d8cee7c57dff0a6c409c05597b460002434eccf7424a712283225b3962d03f"
       url: "https://pub.dev"
     source: hosted
-    version: "14.8.1"
+    version: "17.2.3"
   google_fonts:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: ba03d03bcaa2f6cb7bd920e3b5027181db75ab524f8891c8bc3aa603885b8055
+      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "8.1.0"
   graphs:
     dependency: transitive
     description:
@@ -443,10 +443,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -507,10 +507,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "6.1.0"
   logging:
     dependency: transitive
     description:
@@ -587,10 +587,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -747,18 +747,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.4"
+    version: "12.0.2"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 2026.5.8+2026051708
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -13,24 +13,24 @@ dependencies:
   http: ^1.1.0
   provider: ^6.1.1
   shared_preferences: ^2.2.2
-  intl: ^0.19.0
+  intl: ^0.20.2
   url_launcher: ^6.2.2
   cached_network_image: ^3.3.1
   flutter_svg: ^2.0.9
-  share_plus: ^10.1.4
-  firebase_core: ^3.6.0
-  firebase_crashlytics: ^4.1.3
-  firebase_analytics: ^11.3.3
-  package_info_plus: ^8.1.2
-  go_router: ^14.6.2
-  google_fonts: ^6.2.1
+  share_plus: ^12.0.2
+  firebase_core: ^4.9.0
+  firebase_crashlytics: ^5.2.2
+  firebase_analytics: ^12.4.1
+  package_info_plus: ^9.0.1
+  go_router: ^17.2.3
+  google_fonts: ^8.1.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^6.0.0
   mockito: ^5.4.4
   build_runner: ^2.4.8
   url_launcher_platform_interface: ^2.3.0

--- a/test/abv_strength_helper_test.dart
+++ b/test/abv_strength_helper_test.dart
@@ -47,26 +47,30 @@ void main() {
         return (result, scheme);
       }
 
-      testWidgets('low ABV uses the primary colour (light theme)',
-          (tester) async {
+      testWidgets('low ABV uses the primary colour (light theme)', (
+        tester,
+      ) async {
         final (result, scheme) = await resolve(tester, Brightness.light, 3.0);
         expect(result, scheme.primary);
       });
 
-      testWidgets('low ABV dims the primary colour (dark theme)',
-          (tester) async {
+      testWidgets('low ABV dims the primary colour (dark theme)', (
+        tester,
+      ) async {
         final (result, scheme) = await resolve(tester, Brightness.dark, 3.0);
         expect(result, scheme.primary.withValues(alpha: 0.7));
       });
 
-      testWidgets('medium ABV uses the secondary colour (light theme)',
-          (tester) async {
+      testWidgets('medium ABV uses the secondary colour (light theme)', (
+        tester,
+      ) async {
         final (result, scheme) = await resolve(tester, Brightness.light, 5.0);
         expect(result, scheme.secondary);
       });
 
-      testWidgets('medium ABV dims the secondary colour (dark theme)',
-          (tester) async {
+      testWidgets('medium ABV dims the secondary colour (dark theme)', (
+        tester,
+      ) async {
         final (result, scheme) = await resolve(tester, Brightness.dark, 5.0);
         expect(result, scheme.secondary.withValues(alpha: 0.8));
       });
@@ -76,8 +80,9 @@ void main() {
         expect(result, const Color(0xFFE64A19));
       });
 
-      testWidgets('high ABV uses translucent deep orange (dark theme)',
-          (tester) async {
+      testWidgets('high ABV uses translucent deep orange (dark theme)', (
+        tester,
+      ) async {
         final (result, _) = await resolve(tester, Brightness.dark, 8.0);
         expect(result, const Color(0xFFFF5722).withValues(alpha: 0.85));
       });

--- a/test/accessibility_test.dart
+++ b/test/accessibility_test.dart
@@ -26,25 +26,29 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: DrinkCard(
-              drink: drink,
-              onFavoriteTap: () {},
-            ),
+            body: DrinkCard(drink: drink, onFavoriteTap: () {}),
           ),
         ),
       );
 
       // Verify favorite button exists
-      expect(find.byType(IconButton), findsWidgets,
-          reason: 'DrinkCard should have interactive buttons');
+      expect(
+        find.byType(IconButton),
+        findsWidgets,
+        reason: 'DrinkCard should have interactive buttons',
+      );
 
       // Verify Semantics widgets are present
-      expect(find.byType(Semantics), findsWidgets,
-          reason: 'DrinkCard should have semantic labels');
+      expect(
+        find.byType(Semantics),
+        findsWidgets,
+        reason: 'DrinkCard should have semantic labels',
+      );
     });
 
-    testWidgets('decorative ABV chip is excluded from semantics',
-        (tester) async {
+    testWidgets('decorative ABV chip is excluded from semantics', (
+      tester,
+    ) async {
       final drink = Drink(
         product: const Product(
           id: '1',
@@ -64,15 +68,16 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: DrinkCard(drink: drink),
-          ),
+          home: Scaffold(body: DrinkCard(drink: drink)),
         ),
       );
 
       // Verify ExcludeSemantics is used for decorative info chips
-      expect(find.byType(ExcludeSemantics), findsWidgets,
-          reason: 'Decorative elements should use ExcludeSemantics');
+      expect(
+        find.byType(ExcludeSemantics),
+        findsWidgets,
+        reason: 'Decorative elements should use ExcludeSemantics',
+      );
     });
 
     testWidgets('card has semantic structure', (tester) async {
@@ -96,30 +101,33 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: DrinkCard(drink: drink),
-          ),
+          home: Scaffold(body: DrinkCard(drink: drink)),
         ),
       );
 
       // Verify Card and Semantics widgets exist
-      expect(find.byType(Card), findsOneWidget,
-          reason: 'DrinkCard should use Card widget');
-      expect(find.byType(Semantics), findsWidgets,
-          reason: 'DrinkCard should have semantic structure');
+      expect(
+        find.byType(Card),
+        findsOneWidget,
+        reason: 'DrinkCard should use Card widget',
+      );
+      expect(
+        find.byType(Semantics),
+        findsWidgets,
+        reason: 'DrinkCard should have semantic structure',
+      );
     });
   });
 
   group('Accessibility - EnvironmentBadge Semantics', () {
-    testWidgets('environment badge renders with semantic labels',
-        (tester) async {
+    testWidgets('environment badge renders with semantic labels', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
             body: Stack(
-              children: [
-                EnvironmentBadge(environmentName: 'staging'),
-              ],
+              children: [EnvironmentBadge(environmentName: 'staging')],
             ),
           ),
         ),
@@ -128,12 +136,18 @@ void main() {
       await tester.pumpAndSettle();
 
       // Verify badge renders
-      expect(find.byType(EnvironmentBadge), findsOneWidget,
-          reason: 'Environment badge should render');
+      expect(
+        find.byType(EnvironmentBadge),
+        findsOneWidget,
+        reason: 'Environment badge should render',
+      );
 
       // Verify it has Semantics
-      expect(find.byType(Semantics), findsWidgets,
-          reason: 'Environment badge should have semantic labels');
+      expect(
+        find.byType(Semantics),
+        findsWidgets,
+        reason: 'Environment badge should have semantic labels',
+      );
     });
   });
 
@@ -156,9 +170,7 @@ void main() {
 
       // Find our custom Semantics wrapper
       final allSemantics = tester
-          .widgetList<Semantics>(
-            find.byType(Semantics),
-          )
+          .widgetList<Semantics>(find.byType(Semantics))
           .toList();
 
       // Find the one with our specific label
@@ -166,12 +178,16 @@ void main() {
         (s) => s.properties.label == 'Test button',
       );
 
-      expect(ourSemantics.properties.button, isTrue,
-          reason: 'Interactive buttons must set button: true in Semantics');
+      expect(
+        ourSemantics.properties.button,
+        isTrue,
+        reason: 'Interactive buttons must set button: true in Semantics',
+      );
     });
 
-    testWidgets('hints provide usage instructions when present',
-        (tester) async {
+    testWidgets('hints provide usage instructions when present', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -190,9 +206,7 @@ void main() {
 
       // Find our custom Semantics wrapper
       final allSemantics = tester
-          .widgetList<Semantics>(
-            find.byType(Semantics),
-          )
+          .widgetList<Semantics>(find.byType(Semantics))
           .toList();
 
       // Find the one with our specific label
@@ -200,12 +214,16 @@ void main() {
         (s) => s.properties.label == 'Add to favorites',
       );
 
-      expect(ourSemantics.properties.hint, 'Double tap to toggle',
-          reason: 'Hint should match expected instruction');
+      expect(
+        ourSemantics.properties.hint,
+        'Double tap to toggle',
+        reason: 'Hint should match expected instruction',
+      );
     });
 
-    testWidgets('ExcludeSemantics is used for decorative elements',
-        (tester) async {
+    testWidgets('ExcludeSemantics is used for decorative elements', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -213,11 +231,7 @@ void main() {
               children: [
                 const Text('Content'),
                 ExcludeSemantics(
-                  child: Container(
-                    width: 50,
-                    height: 50,
-                    color: Colors.blue,
-                  ),
+                  child: Container(width: 50, height: 50, color: Colors.blue),
                 ),
               ],
             ),
@@ -225,14 +239,18 @@ void main() {
         ),
       );
 
-      expect(find.byType(ExcludeSemantics), findsAtLeastNWidgets(1),
-          reason: 'Decorative elements should be wrapped in ExcludeSemantics');
+      expect(
+        find.byType(ExcludeSemantics),
+        findsAtLeastNWidgets(1),
+        reason: 'Decorative elements should be wrapped in ExcludeSemantics',
+      );
     });
   });
 
   group('Accessibility - Semantic State Communication', () {
-    testWidgets('filter selection state is communicated via semantics',
-        (tester) async {
+    testWidgets('filter selection state is communicated via semantics', (
+      tester,
+    ) async {
       const isSelected = true;
 
       await tester.pumpWidget(
@@ -255,9 +273,7 @@ void main() {
 
       // Find our custom Semantics wrapper (not the ones Material adds)
       final allSemantics = tester
-          .widgetList<Semantics>(
-            find.byType(Semantics),
-          )
+          .widgetList<Semantics>(find.byType(Semantics))
           .toList();
 
       // Find the one with our specific label
@@ -265,10 +281,16 @@ void main() {
         (s) => s.properties.label == 'Filter by IPA',
       );
 
-      expect(ourSemantics.properties.value, 'Selected',
-          reason: 'Selected state should be communicated via value property');
-      expect(ourSemantics.properties.selected, isTrue,
-          reason: 'Selected property should be set to true');
+      expect(
+        ourSemantics.properties.value,
+        'Selected',
+        reason: 'Selected state should be communicated via value property',
+      );
+      expect(
+        ourSemantics.properties.selected,
+        isTrue,
+        reason: 'Selected property should be set to true',
+      );
     });
 
     testWidgets('retry button has descriptive label and hint', (tester) async {
@@ -290,9 +312,7 @@ void main() {
 
       // Find our custom Semantics wrapper
       final allSemantics = tester
-          .widgetList<Semantics>(
-            find.byType(Semantics),
-          )
+          .widgetList<Semantics>(find.byType(Semantics))
           .toList();
 
       // Find the one with our specific label
@@ -300,12 +320,21 @@ void main() {
         (s) => s.properties.label == 'Retry loading drinks',
       );
 
-      expect(ourSemantics.properties.label, 'Retry loading drinks',
-          reason: 'Retry button should clearly state what will be retried');
-      expect(ourSemantics.properties.hint, contains('Double tap'),
-          reason: 'Hint should explain the interaction method');
-      expect(ourSemantics.properties.button, isTrue,
-          reason: 'Button property must be set');
+      expect(
+        ourSemantics.properties.label,
+        'Retry loading drinks',
+        reason: 'Retry button should clearly state what will be retried',
+      );
+      expect(
+        ourSemantics.properties.hint,
+        contains('Double tap'),
+        reason: 'Hint should explain the interaction method',
+      );
+      expect(
+        ourSemantics.properties.button,
+        isTrue,
+        reason: 'Button property must be set',
+      );
     });
   });
 }

--- a/test/app_theme_test.dart
+++ b/test/app_theme_test.dart
@@ -9,38 +9,49 @@ void main() {
   });
 
   group('buildAppTheme', () {
-    testWidgets('light theme uses navy seed colour as AppBar background',
-        (WidgetTester tester) async {
+    testWidgets('light theme uses navy seed colour as AppBar background', (
+      WidgetTester tester,
+    ) async {
       final theme = buildAppTheme(Brightness.light);
       expect(theme.appBarTheme.backgroundColor, equals(appSeedColor));
     });
 
-    testWidgets('light theme uses white as AppBar foreground',
-        (WidgetTester tester) async {
+    testWidgets('light theme uses white as AppBar foreground', (
+      WidgetTester tester,
+    ) async {
       final theme = buildAppTheme(Brightness.light);
       expect(theme.appBarTheme.foregroundColor, equals(Colors.white));
     });
 
-    testWidgets('light theme primary colour equals seed colour',
-        (WidgetTester tester) async {
+    testWidgets('light theme primary colour equals seed colour', (
+      WidgetTester tester,
+    ) async {
       final theme = buildAppTheme(Brightness.light);
       expect(theme.colorScheme.primary, equals(appSeedColor));
     });
 
-    testWidgets('dark theme AppBar background is surface (not navy)',
-        (WidgetTester tester) async {
+    testWidgets('dark theme AppBar background is surface (not navy)', (
+      WidgetTester tester,
+    ) async {
       final lightTheme = buildAppTheme(Brightness.light);
       final darkTheme = buildAppTheme(Brightness.dark);
       expect(
-          darkTheme.appBarTheme.backgroundColor, isNot(equals(appSeedColor)));
-      expect(darkTheme.appBarTheme.backgroundColor,
-          equals(darkTheme.colorScheme.surface));
-      expect(darkTheme.appBarTheme.backgroundColor,
-          isNot(equals(lightTheme.appBarTheme.backgroundColor)));
+        darkTheme.appBarTheme.backgroundColor,
+        isNot(equals(appSeedColor)),
+      );
+      expect(
+        darkTheme.appBarTheme.backgroundColor,
+        equals(darkTheme.colorScheme.surface),
+      );
+      expect(
+        darkTheme.appBarTheme.backgroundColor,
+        isNot(equals(lightTheme.appBarTheme.backgroundColor)),
+      );
     });
 
-    testWidgets('dark theme primary colour is lighter blue (not navy)',
-        (WidgetTester tester) async {
+    testWidgets('dark theme primary colour is lighter blue (not navy)', (
+      WidgetTester tester,
+    ) async {
       final darkTheme = buildAppTheme(Brightness.dark);
       expect(darkTheme.colorScheme.primary, isNot(equals(appSeedColor)));
     });
@@ -62,8 +73,9 @@ void main() {
   });
 
   group('buildAppTextTheme', () {
-    testWidgets('returns a TextTheme with display styles set',
-        (WidgetTester tester) async {
+    testWidgets('returns a TextTheme with display styles set', (
+      WidgetTester tester,
+    ) async {
       final colorScheme = ColorScheme.fromSeed(
         seedColor: appSeedColor,
         brightness: Brightness.light,
@@ -73,8 +85,9 @@ void main() {
       expect(textTheme.displayLarge!.fontSize, equals(57));
     });
 
-    testWidgets('titleLarge has correct font size',
-        (WidgetTester tester) async {
+    testWidgets('titleLarge has correct font size', (
+      WidgetTester tester,
+    ) async {
       final colorScheme = ColorScheme.fromSeed(
         seedColor: appSeedColor,
         brightness: Brightness.light,
@@ -83,8 +96,9 @@ void main() {
       expect(textTheme.titleLarge!.fontSize, equals(22));
     });
 
-    testWidgets('bodyMedium has correct font size',
-        (WidgetTester tester) async {
+    testWidgets('bodyMedium has correct font size', (
+      WidgetTester tester,
+    ) async {
       final colorScheme = ColorScheme.fromSeed(
         seedColor: appSeedColor,
         brightness: Brightness.light,

--- a/test/beer_api_service_test.dart
+++ b/test/beer_api_service_test.dart
@@ -46,14 +46,15 @@ void main() {
                   'style': 'IPA',
                   'dispense': 'cask',
                   'abv': '5.5',
-                }
+                },
               ],
             },
           ],
         });
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response(responseBody, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response(responseBody, 200));
 
         final drinks = await service.fetchDrinks(festival, 'beer');
 
@@ -85,14 +86,14 @@ void main() {
                   'name': 'Beer 1',
                   'category': 'beer',
                   'dispense': 'cask',
-                  'abv': '4.0'
+                  'abv': '4.0',
                 },
                 {
                   'id': 'drink-2',
                   'name': 'Beer 2',
                   'category': 'beer',
                   'dispense': 'cask',
-                  'abv': '5.0'
+                  'abv': '5.0',
                 },
               ],
             },
@@ -106,15 +107,16 @@ void main() {
                   'name': 'Beer 3',
                   'category': 'beer',
                   'dispense': 'keg',
-                  'abv': '6.0'
+                  'abv': '6.0',
                 },
               ],
             },
           ],
         });
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response(responseBody, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response(responseBody, 200));
 
         final drinks = await service.fetchDrinks(festival, 'beer');
 
@@ -134,8 +136,9 @@ void main() {
           availableBeverageTypes: ['mead'],
         );
 
-        when(mockClient.get(Uri.parse('https://example.com/mead.json')))
-            .thenAnswer((_) async => http.Response('Not found', 404));
+        when(
+          mockClient.get(Uri.parse('https://example.com/mead.json')),
+        ).thenAnswer((_) async => http.Response('Not found', 404));
 
         final drinks = await service.fetchDrinks(festival, 'mead');
 
@@ -152,16 +155,19 @@ void main() {
           availableBeverageTypes: ['beer'],
         );
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response('Server error', 500));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response('Server error', 500));
 
         expect(
           () => service.fetchDrinks(festival, 'beer'),
-          throwsA(isA<BeerApiException>().having(
-            (e) => e.statusCode,
-            'statusCode',
-            500,
-          )),
+          throwsA(
+            isA<BeerApiException>().having(
+              (e) => e.statusCode,
+              'statusCode',
+              500,
+            ),
+          ),
         );
       });
 
@@ -177,8 +183,9 @@ void main() {
 
         final responseBody = json.encode({'producers': []});
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response(responseBody, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response(responseBody, 200));
 
         final drinks = await service.fetchDrinks(festival, 'beer');
 
@@ -197,8 +204,9 @@ void main() {
 
         final responseBody = json.encode({});
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response(responseBody, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response(responseBody, 200));
 
         final drinks = await service.fetchDrinks(festival, 'beer');
 
@@ -227,15 +235,16 @@ void main() {
                   'name': 'Beer',
                   'category': 'beer',
                   'dispense': 'cask',
-                  'abv': '4.0'
+                  'abv': '4.0',
                 },
               ],
             },
           ],
         });
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response(responseBody, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response(responseBody, 200));
 
         final drinks = await service.fetchDrinks(festival, 'beer');
 
@@ -278,8 +287,9 @@ void main() {
           ],
         });
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response(responseBody, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response(responseBody, 200));
 
         final drinks = await service.fetchDrinks(festival, 'beer');
 
@@ -330,8 +340,9 @@ void main() {
           ],
         });
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response(responseBody, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response(responseBody, 200));
 
         final drinks = await service.fetchDrinks(festival, 'beer');
 
@@ -364,7 +375,7 @@ void main() {
                   'name': 'Test Beer',
                   'category': 'beer',
                   'dispense': 'cask',
-                  'abv': '4.0'
+                  'abv': '4.0',
                 },
               ],
             },
@@ -383,17 +394,19 @@ void main() {
                   'name': 'Test Cider',
                   'category': 'cider',
                   'dispense': 'bag in box',
-                  'abv': '5.0'
+                  'abv': '5.0',
                 },
               ],
             },
           ],
         });
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response(beerResponse, 200));
-        when(mockClient.get(Uri.parse('https://example.com/cider.json')))
-            .thenAnswer((_) async => http.Response(ciderResponse, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response(beerResponse, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/cider.json')),
+        ).thenAnswer((_) async => http.Response(ciderResponse, 200));
 
         final drinks = await service.fetchAllDrinks(festival);
 
@@ -424,17 +437,19 @@ void main() {
                   'name': 'Test Beer',
                   'category': 'beer',
                   'dispense': 'cask',
-                  'abv': '4.0'
+                  'abv': '4.0',
                 },
               ],
             },
           ],
         });
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response(beerResponse, 200));
-        when(mockClient.get(Uri.parse('https://example.com/mead.json')))
-            .thenAnswer((_) async => http.Response('Not found', 404));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer((_) async => http.Response(beerResponse, 200));
+        when(
+          mockClient.get(Uri.parse('https://example.com/mead.json')),
+        ).thenAnswer((_) async => http.Response('Not found', 404));
 
         final drinks = await service.fetchAllDrinks(festival);
 
@@ -453,10 +468,12 @@ void main() {
           availableBeverageTypes: ['beer', 'cider'],
         );
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenThrow(Exception('Network error'));
-        when(mockClient.get(Uri.parse('https://example.com/cider.json')))
-            .thenThrow(Exception('Network error'));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenThrow(Exception('Network error'));
+        when(
+          mockClient.get(Uri.parse('https://example.com/cider.json')),
+        ).thenThrow(Exception('Network error'));
 
         expect(
           () => service.fetchAllDrinks(festival),
@@ -464,25 +481,28 @@ void main() {
         );
       });
 
-      test('returns empty list without error when all types return 404',
-          () async {
-        service = BeerApiService(client: mockClient);
+      test(
+        'returns empty list without error when all types return 404',
+        () async {
+          service = BeerApiService(client: mockClient);
 
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Test Festival',
-          dataBaseUrl: 'https://example.com',
-          availableBeverageTypes: ['beer'],
-        );
+          const festival = Festival(
+            id: 'cbf2025',
+            name: 'Test Festival',
+            dataBaseUrl: 'https://example.com',
+            availableBeverageTypes: ['beer'],
+          );
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) async => http.Response('Not found', 404));
+          when(
+            mockClient.get(Uri.parse('https://example.com/beer.json')),
+          ).thenAnswer((_) async => http.Response('Not found', 404));
 
-        final drinks = await service.fetchAllDrinks(festival);
+          final drinks = await service.fetchAllDrinks(festival);
 
-        // 404s return empty list, not errors, so no exception should be thrown
-        expect(drinks, isEmpty);
-      });
+          // 404s return empty list, not errors, so no exception should be thrown
+          expect(drinks, isEmpty);
+        },
+      );
     });
 
     group('timeout', () {
@@ -499,11 +519,14 @@ void main() {
           availableBeverageTypes: ['beer'],
         );
 
-        when(mockClient.get(Uri.parse('https://example.com/beer.json')))
-            .thenAnswer((_) => Future.delayed(
-                  const Duration(milliseconds: 100),
-                  () => http.Response('{}', 200),
-                ));
+        when(
+          mockClient.get(Uri.parse('https://example.com/beer.json')),
+        ).thenAnswer(
+          (_) => Future.delayed(
+            const Duration(milliseconds: 100),
+            () => http.Response('{}', 200),
+          ),
+        );
 
         expect(
           () => service.fetchDrinks(festival, 'beer'),

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -103,8 +103,9 @@ void main() {
           baseUrl: 'https://data.cambeerfestival.app',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
     });
 
@@ -131,8 +132,10 @@ void main() {
           analyticsService: mockAnalyticsService,
         );
 
-        expect(provider.currentFestival.id,
-            DefaultFestivals.all.firstWhere((f) => f.isActive).id);
+        expect(
+          provider.currentFestival.id,
+          DefaultFestivals.all.firstWhere((f) => f.isActive).id,
+        );
       });
 
       test('isLoading is false initially', () {
@@ -166,8 +169,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
 
         await provider.loadDrinks();
 
@@ -185,14 +189,16 @@ void main() {
         await provider.initialize();
 
         // First, cause an error
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(BeerApiException('Error', 500));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(BeerApiException('Error', 500));
         await provider.loadDrinks();
         expect(provider.error, isNotNull);
 
         // Then load successfully
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => <Drink>[]);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => <Drink>[]);
         await provider.loadDrinks();
         expect(provider.error, isNull);
       });
@@ -208,8 +214,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setCategory('beer');
@@ -227,8 +234,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setCategory('beer');
@@ -247,8 +255,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.toggleStyle('IPA');
@@ -267,8 +276,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         final categories = provider.availableCategories;
@@ -285,8 +295,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         final counts = provider.categoryCountsMap;
@@ -305,8 +316,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.toggleStyle('IPA');
@@ -325,8 +337,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.toggleStyle('IPA');
@@ -345,8 +358,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.toggleStyle('IPA');
@@ -365,8 +379,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.toggleStyle('IPA');
@@ -386,8 +401,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setCategory('beer');
@@ -408,8 +424,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSort(DrinkSort.nameAsc);
@@ -427,8 +444,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSort(DrinkSort.nameDesc);
@@ -446,8 +464,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSort(DrinkSort.abvHigh);
@@ -465,8 +484,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSort(DrinkSort.abvLow);
@@ -484,8 +504,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSort(DrinkSort.brewery);
@@ -503,8 +524,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSort(DrinkSort.style);
@@ -525,8 +547,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSearchQuery('alpha');
@@ -544,15 +567,18 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSearchQuery('another');
 
         expect(provider.drinks.length, 2);
-        expect(provider.drinks.every((d) => d.breweryName == 'Another Brewery'),
-            isTrue);
+        expect(
+          provider.drinks.every((d) => d.breweryName == 'Another Brewery'),
+          isTrue,
+        );
       });
 
       test('setSearchQuery filters by style', () async {
@@ -564,8 +590,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSearchQuery('ipa');
@@ -583,8 +610,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSearchQuery('fruity');
@@ -602,8 +630,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSearchQuery('ALPHA');
@@ -621,8 +650,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setSearchQuery('alpha');
@@ -644,14 +674,16 @@ void main() {
 
         final sampleDrinks = createSampleDrinks();
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         // Mock toggleFavorite to properly toggle state
         final favorites = <String>{};
-        when(mockDrinkRepository.toggleFavorite(any, any))
-            .thenAnswer((invocation) async {
+        when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer((
+          invocation,
+        ) async {
           final drinkId = invocation.positionalArguments[1] as String;
           if (favorites.contains(drinkId)) {
             favorites.remove(drinkId);
@@ -682,14 +714,16 @@ void main() {
 
         final sampleDrinks = createSampleDrinks();
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         // Mock toggleFavorite to properly toggle state
         final favorites = <String>{};
-        when(mockDrinkRepository.toggleFavorite(any, any))
-            .thenAnswer((invocation) async {
+        when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer((
+          invocation,
+        ) async {
           final drinkId = invocation.positionalArguments[1] as String;
           if (favorites.contains(drinkId)) {
             favorites.remove(drinkId);
@@ -766,8 +800,9 @@ void main() {
 
         final sampleDrinks = [availableDrink, soldOutDrink, lowStockDrink];
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         // Initially, all drinks should be visible
@@ -826,8 +861,9 @@ void main() {
 
         final sampleDrinks = [availableDrink, notYetDrink];
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         // Initially, both drinks should be visible
@@ -839,7 +875,9 @@ void main() {
         // Not yet available drink should be filtered out
         expect(provider.drinks.length, 1);
         expect(
-            provider.drinks.any((d) => d.name == 'Coming Soon Cider'), isFalse);
+          provider.drinks.any((d) => d.name == 'Coming Soon Cider'),
+          isFalse,
+        );
         expect(provider.drinks.any((d) => d.name == 'Available Ale'), isTrue);
       });
 
@@ -852,23 +890,27 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         // Set hide unavailable via convenience wrapper
         await provider.setHideUnavailable(true);
         expect(provider.hideUnavailable, isTrue);
         expect(
-          provider.visibilityFilters
-              .contains(DrinkVisibilityFilter.availableOnly),
+          provider.visibilityFilters.contains(
+            DrinkVisibilityFilter.availableOnly,
+          ),
           isTrue,
         );
 
         // Verify it was persisted as the new visibilityFilters key, not the legacy key
         final prefs = await SharedPreferences.getInstance();
-        expect(prefs.getStringList('visibilityFilters'),
-            contains('availableOnly'));
+        expect(
+          prefs.getStringList('visibilityFilters'),
+          contains('availableOnly'),
+        );
         expect(prefs.getBool('hideUnavailable'), isNull);
 
         // Disable it
@@ -881,72 +923,91 @@ void main() {
       });
 
       test(
-          'hideUnavailable preference is loaded on initialization (legacy migration)',
-          () async {
-        // Set legacy preference
-        SharedPreferences.setMockInitialValues({'hideUnavailable': true});
+        'hideUnavailable preference is loaded on initialization (legacy migration)',
+        () async {
+          // Set legacy preference
+          SharedPreferences.setMockInitialValues({'hideUnavailable': true});
 
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        expect(provider.hideUnavailable, isTrue);
-      });
+          expect(provider.hideUnavailable, isTrue);
+        },
+      );
 
-      test('visibilityFilters preference is loaded on initialization',
-          () async {
-        // Set new-style preference
-        SharedPreferences.setMockInitialValues({
-          'visibilityFilters': ['availableOnly', 'notTasted'],
-        });
+      test(
+        'visibilityFilters preference is loaded on initialization',
+        () async {
+          // Set new-style preference
+          SharedPreferences.setMockInitialValues({
+            'visibilityFilters': ['availableOnly', 'notTasted'],
+          });
 
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        expect(
-          provider.visibilityFilters,
-          containsAll([
-            DrinkVisibilityFilter.availableOnly,
+          expect(
+            provider.visibilityFilters,
+            containsAll([
+              DrinkVisibilityFilter.availableOnly,
+              DrinkVisibilityFilter.notTasted,
+            ]),
+          );
+        },
+      );
+
+      test(
+        'setVisibilityFilter toggles individual filters independently',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+
+          await provider.setVisibilityFilter(
+            DrinkVisibilityFilter.veganOnly,
+            true,
+          );
+          await provider.setVisibilityFilter(
             DrinkVisibilityFilter.notTasted,
-          ]),
-        );
-      });
+            true,
+          );
 
-      test('setVisibilityFilter toggles individual filters independently',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+          expect(
+            provider.visibilityFilters,
+            contains(DrinkVisibilityFilter.veganOnly),
+          );
+          expect(
+            provider.visibilityFilters,
+            contains(DrinkVisibilityFilter.notTasted),
+          );
+          expect(provider.hideUnavailable, isFalse);
 
-        await provider.setVisibilityFilter(
-            DrinkVisibilityFilter.veganOnly, true);
-        await provider.setVisibilityFilter(
-            DrinkVisibilityFilter.notTasted, true);
-
-        expect(provider.visibilityFilters,
-            contains(DrinkVisibilityFilter.veganOnly));
-        expect(provider.visibilityFilters,
-            contains(DrinkVisibilityFilter.notTasted));
-        expect(provider.hideUnavailable, isFalse);
-
-        // Turn off vegan only, notTasted should remain
-        await provider.setVisibilityFilter(
-            DrinkVisibilityFilter.veganOnly, false);
-        expect(provider.visibilityFilters,
-            isNot(contains(DrinkVisibilityFilter.veganOnly)));
-        expect(provider.visibilityFilters,
-            contains(DrinkVisibilityFilter.notTasted));
-      });
+          // Turn off vegan only, notTasted should remain
+          await provider.setVisibilityFilter(
+            DrinkVisibilityFilter.veganOnly,
+            false,
+          );
+          expect(
+            provider.visibilityFilters,
+            isNot(contains(DrinkVisibilityFilter.veganOnly)),
+          );
+          expect(
+            provider.visibilityFilters,
+            contains(DrinkVisibilityFilter.notTasted),
+          );
+        },
+      );
 
       test('notTasted filter hides already-tasted drinks', () async {
         provider = BeerProvider(
@@ -958,49 +1019,59 @@ void main() {
 
         final sampleDrinks = createSampleDrinks();
         sampleDrinks[0].isTasted = true;
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         expect(provider.drinks.length, sampleDrinks.length);
 
         await provider.setVisibilityFilter(
-            DrinkVisibilityFilter.notTasted, true);
+          DrinkVisibilityFilter.notTasted,
+          true,
+        );
 
         expect(provider.drinks.any((d) => d.isTasted), isFalse);
       });
 
       test(
-          'toggleTasted refreshes filtered list while notTasted filter is active',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+        'toggleTasted refreshes filtered list while notTasted filter is active',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
-        await provider.loadDrinks();
+          final sampleDrinks = createSampleDrinks();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => sampleDrinks);
+          await provider.loadDrinks();
 
-        await provider.setVisibilityFilter(
-            DrinkVisibilityFilter.notTasted, true);
-        expect(provider.drinks.length, sampleDrinks.length);
+          await provider.setVisibilityFilter(
+            DrinkVisibilityFilter.notTasted,
+            true,
+          );
+          expect(provider.drinks.length, sampleDrinks.length);
 
-        // Mark the first visible drink as tasted via the provider.
-        final target = provider.drinks.first;
-        when(mockDrinkRepository.toggleTasted(
-                provider.currentFestival.id, target.id))
-            .thenAnswer((_) async => true);
-        await provider.toggleTasted(target);
+          // Mark the first visible drink as tasted via the provider.
+          final target = provider.drinks.first;
+          when(
+            mockDrinkRepository.toggleTasted(
+              provider.currentFestival.id,
+              target.id,
+            ),
+          ).thenAnswer((_) async => true);
+          await provider.toggleTasted(target);
 
-        // With the not-tasted filter active the drink must drop out
-        // of the visible list immediately.
-        expect(provider.drinks.length, sampleDrinks.length - 1);
-        expect(provider.drinks.any((d) => d.id == target.id), isFalse);
-      });
+          // With the not-tasted filter active the drink must drop out
+          // of the visible list immediately.
+          expect(provider.drinks.length, sampleDrinks.length - 1);
+          expect(provider.drinks.any((d) => d.id == target.id), isFalse);
+        },
+      );
 
       test('veganOnly filter shows only vegan drinks', () async {
         provider = BeerProvider(
@@ -1034,17 +1105,23 @@ void main() {
         final drinks = [
           Drink(product: veganProduct, producer: producer, festivalId: 'test'),
           Drink(
-              product: nonVeganProduct, producer: producer, festivalId: 'test'),
+            product: nonVeganProduct,
+            producer: producer,
+            festivalId: 'test',
+          ),
         ];
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => drinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => drinks);
         await provider.loadDrinks();
 
         expect(provider.drinks.length, 2);
 
         await provider.setVisibilityFilter(
-            DrinkVisibilityFilter.veganOnly, true);
+          DrinkVisibilityFilter.veganOnly,
+          true,
+        );
 
         expect(provider.drinks.length, 1);
         expect(provider.drinks[0].isVegan, isTrue);
@@ -1109,32 +1186,44 @@ void main() {
         );
       });
 
-      test('availableAllergens returns all allergen keys from loaded drinks',
-          () async {
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [glutenDrink, sulphiteDrink, cleanDrink]);
-        await provider.loadDrinks();
+      test(
+        'availableAllergens returns all allergen keys from loaded drinks',
+        () async {
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => [glutenDrink, sulphiteDrink, cleanDrink]);
+          await provider.loadDrinks();
 
-        expect(
-            provider.availableAllergens, containsAll(['gluten', 'sulphites']));
-      });
+          expect(
+            provider.availableAllergens,
+            containsAll(['gluten', 'sulphites']),
+          );
+        },
+      );
 
-      test('setAllergenFilter gluten excludes drinks containing gluten',
-          () async {
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [glutenDrink, sulphiteDrink, cleanDrink]);
-        await provider.loadDrinks();
+      test(
+        'setAllergenFilter gluten excludes drinks containing gluten',
+        () async {
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => [glutenDrink, sulphiteDrink, cleanDrink]);
+          await provider.loadDrinks();
 
-        expect(provider.drinks.length, 3);
-        await provider.setAllergenFilter('gluten', true);
+          expect(provider.drinks.length, 3);
+          await provider.setAllergenFilter('gluten', true);
 
-        expect(provider.drinks.length, 2);
-        expect(provider.drinks.any((d) => d.allergens['gluten'] == 1), isFalse);
-      });
+          expect(provider.drinks.length, 2);
+          expect(
+            provider.drinks.any((d) => d.allergens['gluten'] == 1),
+            isFalse,
+          );
+        },
+      );
 
       test('multiple allergen filters are ANDed', () async {
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [glutenDrink, sulphiteDrink, cleanDrink]);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [glutenDrink, sulphiteDrink, cleanDrink]);
         await provider.loadDrinks();
 
         await provider.setAllergenFilter('gluten', true);
@@ -1145,8 +1234,9 @@ void main() {
       });
 
       test('clearAllergenFilters removes all allergen filters', () async {
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [glutenDrink, cleanDrink]);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [glutenDrink, cleanDrink]);
         await provider.loadDrinks();
 
         await provider.setAllergenFilter('gluten', true);
@@ -1157,25 +1247,32 @@ void main() {
         expect(provider.excludedAllergens, isEmpty);
       });
 
-      test('setAllergenFilter false removes allergen from exclusion set',
-          () async {
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [glutenDrink, cleanDrink]);
-        await provider.loadDrinks();
+      test(
+        'setAllergenFilter false removes allergen from exclusion set',
+        () async {
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => [glutenDrink, cleanDrink]);
+          await provider.loadDrinks();
 
-        await provider.setAllergenFilter('gluten', true);
-        expect(provider.drinks.length, 1);
+          await provider.setAllergenFilter('gluten', true);
+          expect(provider.drinks.length, 1);
 
-        await provider.setAllergenFilter('gluten', false);
-        expect(provider.drinks.length, 2);
-        expect(provider.excludedAllergens, isEmpty);
-      });
+          await provider.setAllergenFilter('gluten', false);
+          expect(provider.drinks.length, 2);
+          expect(provider.excludedAllergens, isEmpty);
+        },
+      );
 
       test('clearVisibilityFilters removes all visibility filters', () async {
         await provider.setVisibilityFilter(
-            DrinkVisibilityFilter.availableOnly, true);
+          DrinkVisibilityFilter.availableOnly,
+          true,
+        );
         await provider.setVisibilityFilter(
-            DrinkVisibilityFilter.notTasted, true);
+          DrinkVisibilityFilter.notTasted,
+          true,
+        );
         expect(provider.visibilityFilters.length, 2);
 
         await provider.clearVisibilityFilters();
@@ -1186,24 +1283,30 @@ void main() {
         expect(prefs.getStringList('visibilityFilters'), isEmpty);
       });
 
-      test('excludedAllergens persisted and restored on initialization',
-          () async {
-        await provider.setAllergenFilter('gluten', true);
-        await provider.setAllergenFilter('sulphites', true);
+      test(
+        'excludedAllergens persisted and restored on initialization',
+        () async {
+          await provider.setAllergenFilter('gluten', true);
+          await provider.setAllergenFilter('sulphites', true);
 
-        final prefs = await SharedPreferences.getInstance();
-        expect(prefs.getStringList('excludedAllergens'),
-            containsAll(['gluten', 'sulphites']));
+          final prefs = await SharedPreferences.getInstance();
+          expect(
+            prefs.getStringList('excludedAllergens'),
+            containsAll(['gluten', 'sulphites']),
+          );
 
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
-        expect(
-            provider.excludedAllergens, containsAll(['gluten', 'sulphites']));
-      });
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          expect(
+            provider.excludedAllergens,
+            containsAll(['gluten', 'sulphites']),
+          );
+        },
+      );
     });
 
     group('getDrinkById', () {
@@ -1216,8 +1319,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         final drink = provider.getDrinkById('drink-1');
@@ -1234,8 +1338,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         final drink = provider.getDrinkById('non-existent');
@@ -1275,8 +1380,9 @@ void main() {
             version: '1.0.0',
           ),
         );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
         await provider.loadFestivals();
         expect(provider.hasFestivals, isTrue);
@@ -1293,8 +1399,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setCategory('beer');
@@ -1313,8 +1420,9 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
         provider.setCategory('beer');
@@ -1352,15 +1460,18 @@ void main() {
             version: '1.0.0',
           ),
         );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => <Drink>[]);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => <Drink>[]);
 
         // Mock setSelectedFestivalId to actually save to SharedPreferences
-        when(mockFestivalRepository.setSelectedFestivalId(any))
-            .thenAnswer((invocation) async {
+        when(mockFestivalRepository.setSelectedFestivalId(any)).thenAnswer((
+          invocation,
+        ) async {
           final festivalId = invocation.positionalArguments[0] as String;
           final prefs = await SharedPreferences.getInstance();
           await prefs.setString('selected_festival_id', festivalId);
@@ -1368,8 +1479,9 @@ void main() {
 
         await provider.initialize();
 
-        final festival2024 =
-            provider.festivals.firstWhere((f) => f.id == 'cbf2024');
+        final festival2024 = provider.festivals.firstWhere(
+          (f) => f.id == 'cbf2024',
+        );
         await provider.setFestival(festival2024);
 
         final prefs = await SharedPreferences.getInstance();
@@ -1378,29 +1490,33 @@ void main() {
         expect(savedId, 'cbf2024');
       });
 
-      test('setFestival does not wait for analytics before continuing',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
+      test(
+        'setFestival does not wait for analytics before continuing',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
 
-        await provider.initialize();
+          await provider.initialize();
 
-        final analyticsCompleter = Completer<void>();
-        when(mockAnalyticsService.logFestivalSelected(any))
-            .thenAnswer((_) => analyticsCompleter.future);
+          final analyticsCompleter = Completer<void>();
+          when(
+            mockAnalyticsService.logFestivalSelected(any),
+          ).thenAnswer((_) => analyticsCompleter.future);
 
-        final festival2024 = DefaultFestivals.cambridge2024;
-        await provider
-            .setFestival(festival2024)
-            .timeout(const Duration(milliseconds: 200));
+          final festival2024 = DefaultFestivals.cambridge2024;
+          await provider
+              .setFestival(festival2024)
+              .timeout(const Duration(milliseconds: 200));
 
-        verify(mockFestivalRepository.setSelectedFestivalId(festival2024.id))
-            .called(1);
-        analyticsCompleter.complete();
-      });
+          verify(
+            mockFestivalRepository.setSelectedFestivalId(festival2024.id),
+          ).called(1);
+          analyticsCompleter.complete();
+        },
+      );
 
       test('initialize restores previously selected festival', () async {
         // Pre-populate SharedPreferences with a saved festival
@@ -1434,8 +1550,9 @@ void main() {
           ),
         );
         // Mock getSelectedFestivalId to read from SharedPreferences
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async {
+        when(mockFestivalRepository.getSelectedFestivalId()).thenAnswer((
+          _,
+        ) async {
           final prefs = await SharedPreferences.getInstance();
           return prefs.getString('selected_festival_id');
         });
@@ -1472,8 +1589,9 @@ void main() {
             version: '1.0.0',
           ),
         );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
         await provider.initialize();
 
@@ -1501,8 +1619,9 @@ void main() {
             version: '1.0.0',
           ),
         );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
         await provider.initialize();
 
@@ -1511,102 +1630,107 @@ void main() {
     });
 
     group('festival switch race condition', () {
-      test('rapid festival switches show only last-selected festival drinks',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
+      test(
+        'rapid festival switches show only last-selected festival drinks',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
 
-        const festivalA = Festival(
-          id: 'cbf2024',
-          name: 'Cambridge 2024',
-          dataBaseUrl: 'https://example.com/cbf2024',
-        );
-        const festivalB = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge 2025',
-          dataBaseUrl: 'https://example.com/cbf2025',
-        );
-        // festivalC is the default so that setFestival(A) doesn't hit the
-        // early-return guard (_currentFestival?.id == festival.id) and both
-        // race competitors actually initiate a getDrinks call.
-        const festivalC = Festival(
-          id: 'cbf2023',
-          name: 'Cambridge 2023',
-          dataBaseUrl: 'https://example.com/cbf2023',
-        );
+          const festivalA = Festival(
+            id: 'cbf2024',
+            name: 'Cambridge 2024',
+            dataBaseUrl: 'https://example.com/cbf2024',
+          );
+          const festivalB = Festival(
+            id: 'cbf2025',
+            name: 'Cambridge 2025',
+            dataBaseUrl: 'https://example.com/cbf2025',
+          );
+          // festivalC is the default so that setFestival(A) doesn't hit the
+          // early-return guard (_currentFestival?.id == festival.id) and both
+          // race competitors actually initiate a getDrinks call.
+          const festivalC = Festival(
+            id: 'cbf2023',
+            name: 'Cambridge 2023',
+            dataBaseUrl: 'https://example.com/cbf2023',
+          );
 
-        when(mockFestivalRepository.getFestivals()).thenAnswer(
-          (_) async => FestivalsResponse(
-            festivals: [festivalA, festivalB, festivalC],
-            defaultFestivalId: 'cbf2023',
-            baseUrl: 'https://example.com',
-            version: '1.0.0',
-          ),
-        );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+          when(mockFestivalRepository.getFestivals()).thenAnswer(
+            (_) async => FestivalsResponse(
+              festivals: [festivalA, festivalB, festivalC],
+              defaultFestivalId: 'cbf2023',
+              baseUrl: 'https://example.com',
+              version: '1.0.0',
+            ),
+          );
+          when(
+            mockFestivalRepository.getSelectedFestivalId(),
+          ).thenAnswer((_) async => null);
 
-        final producerA = Producer.fromJson({
-          'id': 'brewery-a',
-          'name': 'Brewery A',
-          'location': 'City',
-          'products': [],
-        });
-        final producerB = Producer.fromJson({
-          'id': 'brewery-b',
-          'name': 'Brewery B',
-          'location': 'City',
-          'products': [],
-        });
-        final drinkA = Drink(
-          product: Product.fromJson({
-            'id': 'drink-a',
-            'name': 'Ale A',
-            'category': 'beer',
-            'dispense': 'cask',
-            'abv': '4.0',
-          }),
-          producer: producerA,
-          festivalId: 'cbf2024',
-        );
-        final drinkB = Drink(
-          product: Product.fromJson({
-            'id': 'drink-b',
-            'name': 'Ale B',
-            'category': 'beer',
-            'dispense': 'cask',
-            'abv': '5.0',
-          }),
-          producer: producerB,
-          festivalId: 'cbf2025',
-        );
+          final producerA = Producer.fromJson({
+            'id': 'brewery-a',
+            'name': 'Brewery A',
+            'location': 'City',
+            'products': [],
+          });
+          final producerB = Producer.fromJson({
+            'id': 'brewery-b',
+            'name': 'Brewery B',
+            'location': 'City',
+            'products': [],
+          });
+          final drinkA = Drink(
+            product: Product.fromJson({
+              'id': 'drink-a',
+              'name': 'Ale A',
+              'category': 'beer',
+              'dispense': 'cask',
+              'abv': '4.0',
+            }),
+            producer: producerA,
+            festivalId: 'cbf2024',
+          );
+          final drinkB = Drink(
+            product: Product.fromJson({
+              'id': 'drink-b',
+              'name': 'Ale B',
+              'category': 'beer',
+              'dispense': 'cask',
+              'abv': '5.0',
+            }),
+            producer: producerB,
+            festivalId: 'cbf2025',
+          );
 
-        // Festival A's load is slow; B's is instant
-        when(mockDrinkRepository.getDrinks(any)).thenAnswer((invocation) async {
-          final festival = invocation.positionalArguments[0] as Festival;
-          if (festival.id == 'cbf2024') {
-            await Future.delayed(const Duration(milliseconds: 100));
-            return [drinkA];
-          }
-          return [drinkB];
-        });
+          // Festival A's load is slow; B's is instant
+          when(mockDrinkRepository.getDrinks(any)).thenAnswer((
+            invocation,
+          ) async {
+            final festival = invocation.positionalArguments[0] as Festival;
+            if (festival.id == 'cbf2024') {
+              await Future.delayed(const Duration(milliseconds: 100));
+              return [drinkA];
+            }
+            return [drinkB];
+          });
 
-        await provider.initialize();
+          await provider.initialize();
 
-        // Switch to A (slow), then immediately to B (fast) — don't await A
-        final futureA = provider.setFestival(festivalA);
-        final futureB = provider.setFestival(festivalB);
-        await Future.wait([futureA, futureB]);
+          // Switch to A (slow), then immediately to B (fast) — don't await A
+          final futureA = provider.setFestival(festivalA);
+          final futureB = provider.setFestival(festivalB);
+          await Future.wait([futureA, futureB]);
 
-        // B's result must win; A's stale response must be discarded
-        expect(provider.currentFestival.id, 'cbf2025');
-        expect(provider.drinks.length, 1);
-        expect(provider.drinks.first.name, 'Ale B');
-        expect(provider.isLoading, isFalse);
-      });
+          // B's result must win; A's stale response must be discarded
+          expect(provider.currentFestival.id, 'cbf2025');
+          expect(provider.drinks.length, 1);
+          expect(provider.drinks.first.name, 'Ale B');
+          expect(provider.isLoading, isFalse);
+        },
+      );
     });
 
     group('automatic refresh', () {
@@ -1630,54 +1754,59 @@ void main() {
         expect(provider.isFestivalsDataStale, isTrue);
       });
 
-      test('isDrinksDataStale returns false immediately after loading drinks',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'isDrinksDataStale returns false immediately after loading drinks',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+          final sampleDrinks = createSampleDrinks();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => sampleDrinks);
 
-        await provider.loadDrinks();
+          await provider.loadDrinks();
 
-        expect(provider.isDrinksDataStale, isFalse);
-      });
+          expect(provider.isDrinksDataStale, isFalse);
+        },
+      );
 
       test(
-          'isFestivalsDataStale returns false immediately after loading festivals',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
+        'isFestivalsDataStale returns false immediately after loading festivals',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
 
-        when(mockFestivalRepository.getFestivals()).thenAnswer(
-          (_) async => FestivalsResponse(
-            festivals: [
-              const Festival(
-                id: 'cbf2025',
-                name: 'Cambridge 2025',
-                dataBaseUrl: 'https://example.com/cbf2025',
-              ),
-            ],
-            defaultFestivalId: 'cbf2025',
-            baseUrl: 'https://example.com',
-            version: '1.0.0',
-          ),
-        );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+          when(mockFestivalRepository.getFestivals()).thenAnswer(
+            (_) async => FestivalsResponse(
+              festivals: [
+                const Festival(
+                  id: 'cbf2025',
+                  name: 'Cambridge 2025',
+                  dataBaseUrl: 'https://example.com/cbf2025',
+                ),
+              ],
+              defaultFestivalId: 'cbf2025',
+              baseUrl: 'https://example.com',
+              version: '1.0.0',
+            ),
+          );
+          when(
+            mockFestivalRepository.getSelectedFestivalId(),
+          ).thenAnswer((_) async => null);
 
-        await provider.loadFestivals();
+          await provider.loadFestivals();
 
-        expect(provider.isFestivalsDataStale, isFalse);
-      });
+          expect(provider.isFestivalsDataStale, isFalse);
+        },
+      );
 
       test('refreshIfStale does nothing when already loading', () async {
         provider = BeerProvider(
@@ -1700,11 +1829,13 @@ void main() {
             version: '1.0.0',
           ),
         );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
 
         await provider.initialize();
 
@@ -1734,8 +1865,9 @@ void main() {
             version: '1.0.0',
           ),
         );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
         // Start loading (don't await)
         final loadFuture = provider.loadDrinks();
@@ -1771,14 +1903,16 @@ void main() {
             version: '1.0.0',
           ),
         );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => sampleDrinks);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => sampleDrinks);
 
         await provider.loadDrinks();
 
@@ -1820,11 +1954,13 @@ void main() {
             version: '1.0.0',
           ),
         );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => null);
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
 
         await provider.initialize();
         await provider.loadDrinks();
@@ -1833,150 +1969,176 @@ void main() {
         expect(provider.isDrinksDataStale, isFalse);
 
         // Change festival (which loads drinks internally)
-        final festival2024 =
-            provider.festivals.firstWhere((f) => f.id == 'cbf2024');
+        final festival2024 = provider.festivals.firstWhere(
+          (f) => f.id == 'cbf2024',
+        );
         await provider.setFestival(festival2024);
 
         // Data should still be fresh after festival change
         expect(provider.isDrinksDataStale, isFalse);
       });
 
-      test('loadFestivals stamps attempt timestamp even when network fails',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(Exception('offline'));
-        when(mockFestivalRepository.getCachedFestivals())
-            .thenAnswer((_) async => null);
+      test(
+        'loadFestivals stamps attempt timestamp even when network fails',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          when(
+            mockFestivalRepository.getFestivals(),
+          ).thenThrow(Exception('offline'));
+          when(
+            mockFestivalRepository.getCachedFestivals(),
+          ).thenAnswer((_) async => null);
 
-        expect(provider.lastFestivalsRefreshAttempt, isNull);
-        await provider.loadFestivals();
-        expect(provider.lastFestivalsRefreshAttempt, isNotNull);
-      });
-
-      test('refreshIfStale skips festivals retry when last attempt was recent',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(Exception('offline'));
-        when(mockFestivalRepository.getCachedFestivals())
-            .thenAnswer((_) async => null);
-
-        // First attempt fails and stamps the attempt timestamp.
-        await provider.loadFestivals();
-        expect(provider.isFestivalsDataStale, isTrue);
-
-        reset(mockFestivalRepository);
-
-        // Suppress drinks retry too: loadDrinks() would internally call
-        // loadFestivals() when _currentFestival is null and _festivals is empty.
-        provider.lastDrinksRefreshAttempt = DateTime.now();
-
-        // Immediate retry via refreshIfStale must be suppressed.
-        await provider.refreshIfStale();
-        verifyNever(mockFestivalRepository.getFestivals());
-      });
+          expect(provider.lastFestivalsRefreshAttempt, isNull);
+          await provider.loadFestivals();
+          expect(provider.lastFestivalsRefreshAttempt, isNotNull);
+        },
+      );
 
       test(
-          'refreshIfStale retries festivals when last attempt is past threshold',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(Exception('offline'));
-        when(mockFestivalRepository.getCachedFestivals())
-            .thenAnswer((_) async => null);
+        'refreshIfStale skips festivals retry when last attempt was recent',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          when(
+            mockFestivalRepository.getFestivals(),
+          ).thenThrow(Exception('offline'));
+          when(
+            mockFestivalRepository.getCachedFestivals(),
+          ).thenAnswer((_) async => null);
 
-        // Simulate a stale attempt by backdating the timestamp.
-        provider.lastFestivalsRefreshAttempt =
-            DateTime.now().subtract(const Duration(minutes: 2));
-        // Suppress drinks retry so loadDrinks() doesn't re-trigger loadFestivals().
-        provider.lastDrinksRefreshAttempt = DateTime.now();
+          // First attempt fails and stamps the attempt timestamp.
+          await provider.loadFestivals();
+          expect(provider.isFestivalsDataStale, isTrue);
 
-        expect(provider.isFestivalsDataStale, isTrue);
+          reset(mockFestivalRepository);
 
-        await provider.refreshIfStale();
-        verify(mockFestivalRepository.getFestivals()).called(1);
-      });
+          // Suppress drinks retry too: loadDrinks() would internally call
+          // loadFestivals() when _currentFestival is null and _festivals is empty.
+          provider.lastDrinksRefreshAttempt = DateTime.now();
+
+          // Immediate retry via refreshIfStale must be suppressed.
+          await provider.refreshIfStale();
+          verifyNever(mockFestivalRepository.getFestivals());
+        },
+      );
 
       test(
-          '_refreshDrinksFromNetwork stamps attempt timestamp even when network fails',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(Exception('offline'));
+        'refreshIfStale retries festivals when last attempt is past threshold',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          when(
+            mockFestivalRepository.getFestivals(),
+          ).thenThrow(Exception('offline'));
+          when(
+            mockFestivalRepository.getCachedFestivals(),
+          ).thenAnswer((_) async => null);
 
-        expect(provider.lastDrinksRefreshAttempt, isNull);
-        await provider.loadDrinks();
-        expect(provider.lastDrinksRefreshAttempt, isNotNull);
-      });
+          // Simulate a stale attempt by backdating the timestamp.
+          provider.lastFestivalsRefreshAttempt = DateTime.now().subtract(
+            const Duration(minutes: 2),
+          );
+          // Suppress drinks retry so loadDrinks() doesn't re-trigger loadFestivals().
+          provider.lastDrinksRefreshAttempt = DateTime.now();
 
-      test('refreshIfStale skips drinks retry when last attempt was recent',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(Exception('offline'));
+          expect(provider.isFestivalsDataStale, isTrue);
 
-        // First attempt fails and stamps the attempt timestamp.
-        await provider.loadDrinks();
-        expect(provider.isDrinksDataStale, isTrue);
+          await provider.refreshIfStale();
+          verify(mockFestivalRepository.getFestivals()).called(1);
+        },
+      );
 
-        reset(mockDrinkRepository);
+      test(
+        '_refreshDrinksFromNetwork stamps attempt timestamp even when network fails',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenThrow(Exception('offline'));
 
-        // Immediate retry via refreshIfStale must be suppressed.
-        await provider.refreshIfStale();
-        verifyNever(mockDrinkRepository.getDrinks(any));
-      });
+          expect(provider.lastDrinksRefreshAttempt, isNull);
+          await provider.loadDrinks();
+          expect(provider.lastDrinksRefreshAttempt, isNotNull);
+        },
+      );
 
-      test('refreshIfStale retries drinks when last attempt is past threshold',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(Exception('offline'));
+      test(
+        'refreshIfStale skips drinks retry when last attempt was recent',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenThrow(Exception('offline'));
 
-        // Simulate a stale attempt by backdating the attempt timestamp.
-        provider.lastDrinksRefreshAttempt =
-            DateTime.now().subtract(const Duration(minutes: 2));
+          // First attempt fails and stamps the attempt timestamp.
+          await provider.loadDrinks();
+          expect(provider.isDrinksDataStale, isTrue);
 
-        expect(provider.isDrinksDataStale, isTrue);
+          reset(mockDrinkRepository);
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        await provider.refreshIfStale();
-        verify(mockDrinkRepository.getDrinks(any)).called(1);
-      });
+          // Immediate retry via refreshIfStale must be suppressed.
+          await provider.refreshIfStale();
+          verifyNever(mockDrinkRepository.getDrinks(any));
+        },
+      );
+
+      test(
+        'refreshIfStale retries drinks when last attempt is past threshold',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenThrow(Exception('offline'));
+
+          // Simulate a stale attempt by backdating the attempt timestamp.
+          provider.lastDrinksRefreshAttempt = DateTime.now().subtract(
+            const Duration(minutes: 2),
+          );
+
+          expect(provider.isDrinksDataStale, isTrue);
+
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          await provider.refreshIfStale();
+          verify(mockDrinkRepository.getDrinks(any)).called(1);
+        },
+      );
     });
 
     group('tasted, refresh and favourite filtering', () {
@@ -1987,105 +2149,119 @@ void main() {
           analyticsService: mockAnalyticsService,
         );
         await provider.initialize();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
         await provider.loadDrinks();
         final drink = provider.allDrinks.first;
 
-        when(mockDrinkRepository.toggleTasted(any, any))
-            .thenAnswer((_) async => true);
+        when(
+          mockDrinkRepository.toggleTasted(any, any),
+        ).thenAnswer((_) async => true);
         await provider.toggleTasted(drink);
         expect(drink.isTasted, isTrue);
         verify(mockAnalyticsService.logTastedAdded(drink)).called(1);
 
-        when(mockDrinkRepository.toggleTasted(any, any))
-            .thenAnswer((_) async => false);
+        when(
+          mockDrinkRepository.toggleTasted(any, any),
+        ).thenAnswer((_) async => false);
         await provider.toggleTasted(drink);
         expect(drink.isTasted, isFalse);
         verify(mockAnalyticsService.logTastedRemoved(drink)).called(1);
       });
 
-      test('refreshIfStale reloads festivals and drinks when both are stale',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
+      test(
+        'refreshIfStale reloads festivals and drinks when both are stale',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
 
-        // Without initialize()/loadDrinks() both refresh timestamps are null,
-        // so both data sets report as stale.
-        expect(provider.isFestivalsDataStale, isTrue);
-        expect(provider.isDrinksDataStale, isTrue);
+          // Without initialize()/loadDrinks() both refresh timestamps are null,
+          // so both data sets report as stale.
+          expect(provider.isFestivalsDataStale, isTrue);
+          expect(provider.isDrinksDataStale, isTrue);
 
-        await provider.refreshIfStale();
+          await provider.refreshIfStale();
 
-        verify(mockFestivalRepository.getFestivals()).called(1);
-        verify(mockDrinkRepository.getDrinks(any)).called(1);
-        expect(provider.allDrinks, isNotEmpty);
-      });
-
-      test('refreshIfStale skips a duplicate fetch while SWR refresh in flight',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
-
-        // Cache renders instantly; the network refresh hangs so isRefreshing
-        // stays true while we attempt a resume-triggered refreshIfStale.
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        final pending = Completer<List<Drink>>();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) => pending.future);
-
-        final firstLoad = provider.loadDrinks();
-        await Future<void>.delayed(Duration.zero);
-        expect(provider.isRefreshing, isTrue);
-
-        // refreshIfStale while a refresh is mid-flight must not kick a second
-        // getDrinks call — _isRefreshing guards against the duplicate.
-        await provider.refreshIfStale();
-        verify(mockDrinkRepository.getDrinks(any)).called(1);
-
-        pending.complete(createSampleDrinks());
-        await firstLoad;
-      });
-
-      test('setFestival on the current festival retries when a notice is up',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
-
-        // Get into the "showing saved data" state.
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(TimeoutException('offline'));
-        await provider.loadDrinks();
-        expect(provider.refreshNotice, isNotNull);
-        clearInteractions(mockDrinkRepository);
-
-        // Re-tapping the current festival in the switcher must fire a retry.
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        await provider.setFestival(provider.currentFestival);
-
-        verify(mockDrinkRepository.getDrinks(any)).called(1);
-        expect(provider.refreshNotice, isNull);
-      });
+          verify(mockFestivalRepository.getFestivals()).called(1);
+          verify(mockDrinkRepository.getDrinks(any)).called(1);
+          expect(provider.allDrinks, isNotEmpty);
+        },
+      );
 
       test(
-          'initialize ignores a retired saved festival id rather than '
+        'refreshIfStale skips a duplicate fetch while SWR refresh in flight',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+
+          // Cache renders instantly; the network refresh hangs so isRefreshing
+          // stays true while we attempt a resume-triggered refreshIfStale.
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          final pending = Completer<List<Drink>>();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) => pending.future);
+
+          final firstLoad = provider.loadDrinks();
+          await Future<void>.delayed(Duration.zero);
+          expect(provider.isRefreshing, isTrue);
+
+          // refreshIfStale while a refresh is mid-flight must not kick a second
+          // getDrinks call — _isRefreshing guards against the duplicate.
+          await provider.refreshIfStale();
+          verify(mockDrinkRepository.getDrinks(any)).called(1);
+
+          pending.complete(createSampleDrinks());
+          await firstLoad;
+        },
+      );
+
+      test(
+        'setFestival on the current festival retries when a notice is up',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+
+          // Get into the "showing saved data" state.
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenThrow(TimeoutException('offline'));
+          await provider.loadDrinks();
+          expect(provider.refreshNotice, isNotNull);
+          clearInteractions(mockDrinkRepository);
+
+          // Re-tapping the current festival in the switcher must fire a retry.
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          await provider.setFestival(provider.currentFestival);
+
+          verify(mockDrinkRepository.getDrinks(any)).called(1);
+          expect(provider.refreshNotice, isNull);
+        },
+      );
+
+      test('initialize ignores a retired saved festival id rather than '
           'resurrecting it from DefaultFestivals', () async {
         // Saved id matches an active DefaultFestival but no longer exists in
         // the live registry; the user should land on the registry default,
@@ -2107,10 +2283,12 @@ void main() {
             version: '1.0.0',
           ),
         );
-        when(mockFestivalRepository.getSelectedFestivalId())
-            .thenAnswer((_) async => retired.id);
-        when(mockFestivalRepository.getCachedFestivals())
-            .thenAnswer((_) async => null);
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => retired.id);
+        when(
+          mockFestivalRepository.getCachedFestivals(),
+        ).thenAnswer((_) async => null);
 
         provider = BeerProvider(
           drinkRepository: mockDrinkRepository,
@@ -2122,30 +2300,34 @@ void main() {
         expect(provider.currentFestival.id, liveFestival.id);
       });
 
-      test('toggleFavorite re-applies filters when showing favourites only',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        await provider.loadDrinks();
+      test(
+        'toggleFavorite re-applies filters when showing favourites only',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          await provider.loadDrinks();
 
-        provider.setShowFavoritesOnly(true);
-        expect(provider.showFavoritesOnly, isTrue);
-        expect(provider.drinks, isEmpty);
+          provider.setShowFavoritesOnly(true);
+          expect(provider.showFavoritesOnly, isTrue);
+          expect(provider.drinks, isEmpty);
 
-        final drink = provider.allDrinks.first;
-        when(mockDrinkRepository.toggleFavorite(any, any))
-            .thenAnswer((_) async => true);
-        await provider.toggleFavorite(drink);
+          final drink = provider.allDrinks.first;
+          when(
+            mockDrinkRepository.toggleFavorite(any, any),
+          ).thenAnswer((_) async => true);
+          await provider.toggleFavorite(drink);
 
-        // The favourites-only list is refreshed in place by toggleFavorite.
-        expect(provider.drinks, contains(drink));
-      });
+          // The favourites-only list is refreshed in place by toggleFavorite.
+          expect(provider.drinks, contains(drink));
+        },
+      );
 
       test('styleCountsMap is scoped to the selected category', () async {
         provider = BeerProvider(
@@ -2154,8 +2336,9 @@ void main() {
           analyticsService: mockAnalyticsService,
         );
         await provider.initialize();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
         await provider.loadDrinks();
 
         expect(
@@ -2177,8 +2360,9 @@ void main() {
         await provider.initialize();
         expect(provider.lastDrinksRefresh, isNull);
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
         await provider.loadDrinks();
 
         expect(provider.lastDrinksRefresh, isNotNull);
@@ -2186,51 +2370,62 @@ void main() {
     });
 
     group('stale-while-revalidate', () {
-      test('shows cached drinks and surfaces a notice when refresh fails',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'shows cached drinks and surfaces a notice when refresh fails',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(BeerApiException('boom', 500));
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenThrow(BeerApiException('boom', 500));
 
-        await provider.loadDrinks();
+          await provider.loadDrinks();
 
-        // Cached data stays on screen; no blocking error, just a quiet notice.
-        expect(provider.drinks, isNotEmpty);
-        expect(provider.error, isNull);
-        expect(provider.refreshNotice, isNotNull);
-        expect(provider.isRefreshing, isFalse);
-      });
+          // Cached data stays on screen; no blocking error, just a quiet notice.
+          expect(provider.drinks, isNotEmpty);
+          expect(provider.error, isNull);
+          expect(provider.refreshNotice, isNotNull);
+          expect(provider.isRefreshing, isFalse);
+        },
+      );
 
-      test('logs non-connectivity refresh failures even with cached data',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'logs non-connectivity refresh failures even with cached data',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        final error = BeerApiException('server', 500);
-        when(mockDrinkRepository.getDrinks(any)).thenThrow(error);
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          final error = BeerApiException('server', 500);
+          when(mockDrinkRepository.getDrinks(any)).thenThrow(error);
 
-        await provider.loadDrinks();
+          await provider.loadDrinks();
 
-        // A server/parse error is a real bug that the cache would otherwise
-        // mask, so it must still be logged (catches "silent never-load").
-        verify(mockAnalyticsService.logError(error, any,
-                reason: anyNamed('reason')))
-            .called(1);
-      });
+          // A server/parse error is a real bug that the cache would otherwise
+          // mask, so it must still be logged (catches "silent never-load").
+          verify(
+            mockAnalyticsService.logError(
+              error,
+              any,
+              reason: anyNamed('reason'),
+            ),
+          ).called(1);
+        },
+      );
 
       test('does not log offline refresh failures covered by cache', () async {
         provider = BeerProvider(
@@ -2240,47 +2435,54 @@ void main() {
         );
         await provider.initialize();
 
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(TimeoutException('offline'));
+        when(
+          mockDrinkRepository.getCachedDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(TimeoutException('offline'));
 
         await provider.loadDrinks();
 
         expect(provider.refreshNotice, isNotNull);
-        verifyNever(mockAnalyticsService.logError(any, any,
-            reason: anyNamed('reason')));
+        verifyNever(
+          mockAnalyticsService.logError(any, any, reason: anyNamed('reason')),
+        );
       });
 
-      test('does not log when BeerApiException wraps a connectivity cause',
-          () async {
-        // When every beverage type fails offline, the repository throws a
-        // BeerApiException whose `cause` carries one of the underlying network
-        // errors. _isConnectivityError must unwrap it so analytics stays quiet
-        // for the offline-with-cache case (not just the raw TimeoutException).
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'does not log when BeerApiException wraps a connectivity cause',
+        () async {
+          // When every beverage type fails offline, the repository throws a
+          // BeerApiException whose `cause` carries one of the underlying network
+          // errors. _isConnectivityError must unwrap it so analytics stays quiet
+          // for the offline-with-cache case (not just the raw TimeoutException).
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        when(mockDrinkRepository.getDrinks(any)).thenThrow(
-          BeerApiException(
-            'Failed to load any drinks...',
-            null,
-            TimeoutException('offline'),
-          ),
-        );
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          when(mockDrinkRepository.getDrinks(any)).thenThrow(
+            BeerApiException(
+              'Failed to load any drinks...',
+              null,
+              TimeoutException('offline'),
+            ),
+          );
 
-        await provider.loadDrinks();
+          await provider.loadDrinks();
 
-        expect(provider.refreshNotice, isNotNull);
-        verifyNever(mockAnalyticsService.logError(any, any,
-            reason: anyNamed('reason')));
-      });
+          expect(provider.refreshNotice, isNotNull);
+          verifyNever(
+            mockAnalyticsService.logError(any, any, reason: anyNamed('reason')),
+          );
+        },
+      );
 
       test('shows error when refresh fails and there is no cache', () async {
         provider = BeerProvider(
@@ -2290,8 +2492,9 @@ void main() {
         );
         await provider.initialize();
 
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => null);
+        when(
+          mockDrinkRepository.getCachedDrinks(any),
+        ).thenAnswer((_) async => null);
         final error = TimeoutException('offline');
         when(mockDrinkRepository.getDrinks(any)).thenThrow(error);
 
@@ -2301,41 +2504,42 @@ void main() {
         expect(provider.error, isNotNull);
         expect(provider.refreshNotice, isNull);
         // Fully blocked loads are always logged, even when offline.
-        verify(mockAnalyticsService.logError(error, any,
-                reason: anyNamed('reason')))
-            .called(1);
+        verify(
+          mockAnalyticsService.logError(error, any, reason: anyNamed('reason')),
+        ).called(1);
       });
 
-      test('loadDrinks does not wait for error analytics before updating state',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'loadDrinks does not wait for error analytics before updating state',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => null);
-        final error = TimeoutException('offline');
-        when(mockDrinkRepository.getDrinks(any)).thenThrow(error);
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => null);
+          final error = TimeoutException('offline');
+          when(mockDrinkRepository.getDrinks(any)).thenThrow(error);
 
-        final logErrorCompleter = Completer<void>();
-        when(
-          mockAnalyticsService.logError(
-            any,
-            any,
-            reason: anyNamed('reason'),
-          ),
-        ).thenAnswer((_) => logErrorCompleter.future);
+          final logErrorCompleter = Completer<void>();
+          when(
+            mockAnalyticsService.logError(any, any, reason: anyNamed('reason')),
+          ).thenAnswer((_) => logErrorCompleter.future);
 
-        await provider.loadDrinks().timeout(const Duration(milliseconds: 200));
+          await provider.loadDrinks().timeout(
+            const Duration(milliseconds: 200),
+          );
 
-        expect(provider.error, isNotNull);
-        expect(provider.isLoading, isFalse);
-        expect(provider.isRefreshing, isFalse);
-        logErrorCompleter.complete();
-      });
+          expect(provider.error, isNotNull);
+          expect(provider.isLoading, isFalse);
+          expect(provider.isRefreshing, isFalse);
+          logErrorCompleter.complete();
+        },
+      );
 
       test('successful refresh clears the notice and updates drinks', () async {
         provider = BeerProvider(
@@ -2346,16 +2550,19 @@ void main() {
         await provider.initialize();
 
         // First load shows cache then fails refresh -> notice set.
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(TimeoutException('offline'));
+        when(
+          mockDrinkRepository.getCachedDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(TimeoutException('offline'));
         await provider.loadDrinks();
         expect(provider.refreshNotice, isNotNull);
 
         // Second load succeeds -> notice cleared, drinks refreshed.
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
         await provider.loadDrinks();
 
         expect(provider.refreshNotice, isNull);
@@ -2363,27 +2570,29 @@ void main() {
         expect(provider.drinks, isNotEmpty);
       });
 
-      test('initialize populates festivals from cache without a network call',
-          () async {
-        when(mockFestivalRepository.getCachedFestivals()).thenAnswer(
-          (_) async => FestivalsResponse(
-            festivals: [DefaultFestivals.cambridge2025],
-            defaultFestivalId: DefaultFestivals.cambridge2025.id,
-            version: '1.0',
-            baseUrl: 'https://data.cambeerfestival.app',
-          ),
-        );
+      test(
+        'initialize populates festivals from cache without a network call',
+        () async {
+          when(mockFestivalRepository.getCachedFestivals()).thenAnswer(
+            (_) async => FestivalsResponse(
+              festivals: [DefaultFestivals.cambridge2025],
+              defaultFestivalId: DefaultFestivals.cambridge2025.id,
+              version: '1.0',
+              baseUrl: 'https://data.cambeerfestival.app',
+            ),
+          );
 
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        expect(provider.festivals, isNotEmpty);
-        // Background refresh fires, but the cache populated the list first.
-      });
+          expect(provider.festivals, isNotEmpty);
+          // Background refresh fires, but the cache populated the list first.
+        },
+      );
 
       test('dismissRefreshNotice clears the notice', () async {
         provider = BeerProvider(
@@ -2393,10 +2602,12 @@ void main() {
         );
         await provider.initialize();
 
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(TimeoutException('offline'));
+        when(
+          mockDrinkRepository.getCachedDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(TimeoutException('offline'));
         await provider.loadDrinks();
         expect(provider.refreshNotice, isNotNull);
 
@@ -2404,115 +2615,132 @@ void main() {
         expect(provider.refreshNotice, isNull);
       });
 
-      test('setFestival shows the target festival cached drinks immediately',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'setFestival shows the target festival cached drinks immediately',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        final other = DefaultFestivals.all
-            .firstWhere((f) => f.id != provider.currentFestival.id);
+          final other = DefaultFestivals.all.firstWhere(
+            (f) => f.id != provider.currentFestival.id,
+          );
 
-        // Cached drinks available for the new festival; the network refresh
-        // hangs so only the cache path has resolved when we assert.
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => createSampleDrinks());
-        final pending = Completer<List<Drink>>();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) => pending.future);
+          // Cached drinks available for the new festival; the network refresh
+          // hangs so only the cache path has resolved when we assert.
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          final pending = Completer<List<Drink>>();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) => pending.future);
 
-        final future = provider.setFestival(other);
-        await Future<void>.delayed(Duration.zero);
+          final future = provider.setFestival(other);
+          await Future<void>.delayed(Duration.zero);
 
-        expect(provider.currentFestival.id, other.id);
-        expect(provider.drinks, isNotEmpty); // cached drinks shown
-        expect(provider.isLoading, isFalse); // no blank spinner
-        expect(provider.isRefreshing, isTrue); // background refresh running
+          expect(provider.currentFestival.id, other.id);
+          expect(provider.drinks, isNotEmpty); // cached drinks shown
+          expect(provider.isLoading, isFalse); // no blank spinner
+          expect(provider.isRefreshing, isTrue); // background refresh running
 
-        pending.complete(createSampleDrinks());
-        await future;
-        expect(provider.isRefreshing, isFalse);
-      });
+          pending.complete(createSampleDrinks());
+          await future;
+          expect(provider.isRefreshing, isFalse);
+        },
+      );
 
-      test('setFestival shows a spinner when the target has no cache',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'setFestival shows a spinner when the target has no cache',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        final other = DefaultFestivals.all
-            .firstWhere((f) => f.id != provider.currentFestival.id);
+          final other = DefaultFestivals.all.firstWhere(
+            (f) => f.id != provider.currentFestival.id,
+          );
 
-        when(mockDrinkRepository.getCachedDrinks(any))
-            .thenAnswer((_) async => null);
-        final pending = Completer<List<Drink>>();
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) => pending.future);
+          when(
+            mockDrinkRepository.getCachedDrinks(any),
+          ).thenAnswer((_) async => null);
+          final pending = Completer<List<Drink>>();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) => pending.future);
 
-        final future = provider.setFestival(other);
-        await Future<void>.delayed(Duration.zero);
+          final future = provider.setFestival(other);
+          await Future<void>.delayed(Duration.zero);
 
-        expect(provider.drinks, isEmpty);
-        expect(provider.isLoading, isTrue); // spinner until network resolves
+          expect(provider.drinks, isEmpty);
+          expect(provider.isLoading, isTrue); // spinner until network resolves
 
-        pending.complete(createSampleDrinks());
-        await future;
-        expect(provider.isLoading, isFalse);
-        expect(provider.drinks, isNotEmpty);
-      });
+          pending.complete(createSampleDrinks());
+          await future;
+          expect(provider.isLoading, isFalse);
+          expect(provider.drinks, isNotEmpty);
+        },
+      );
 
-      test('loadFestivals falls back to cached festivals when network fails',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'loadFestivals falls back to cached festivals when network fails',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(FestivalServiceException('boom', 500));
-        when(mockFestivalRepository.getCachedFestivals()).thenAnswer(
-          (_) async => FestivalsResponse(
-            festivals: [DefaultFestivals.cambridge2025],
-            defaultFestivalId: DefaultFestivals.cambridge2025.id,
-            version: '1.0',
-            baseUrl: 'https://data.cambeerfestival.app',
-          ),
-        );
+          when(
+            mockFestivalRepository.getFestivals(),
+          ).thenThrow(FestivalServiceException('boom', 500));
+          when(mockFestivalRepository.getCachedFestivals()).thenAnswer(
+            (_) async => FestivalsResponse(
+              festivals: [DefaultFestivals.cambridge2025],
+              defaultFestivalId: DefaultFestivals.cambridge2025.id,
+              version: '1.0',
+              baseUrl: 'https://data.cambeerfestival.app',
+            ),
+          );
 
-        await provider.loadFestivals();
+          await provider.loadFestivals();
 
-        // Switcher keeps working from cache; no error surfaced.
-        expect(provider.festivals, isNotEmpty);
-        expect(provider.festivalsError, isNull);
-      });
+          // Switcher keeps working from cache; no error surfaced.
+          expect(provider.festivals, isNotEmpty);
+          expect(provider.festivalsError, isNull);
+        },
+      );
 
-      test('loadFestivals surfaces an error when network fails and no cache',
-          () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'loadFestivals surfaces an error when network fails and no cache',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(FestivalServiceException('boom', 500));
-        when(mockFestivalRepository.getCachedFestivals())
-            .thenAnswer((_) async => null);
+          when(
+            mockFestivalRepository.getFestivals(),
+          ).thenThrow(FestivalServiceException('boom', 500));
+          when(
+            mockFestivalRepository.getCachedFestivals(),
+          ).thenAnswer((_) async => null);
 
-        await provider.loadFestivals();
+          await provider.loadFestivals();
 
-        expect(provider.festivals, isEmpty);
-        expect(provider.festivalsError, isNotNull);
-      });
+          expect(provider.festivals, isEmpty);
+          expect(provider.festivalsError, isNotNull);
+        },
+      );
     });
 
     group('dispose', () {

--- a/test/beverage_type_helper_test.dart
+++ b/test/beverage_type_helper_test.dart
@@ -19,8 +19,10 @@ void main() {
 
       test('ignores empty segments from leading/trailing/double dashes', () {
         expect(BeverageTypeHelper.formatBeverageType('--beer--'), 'Beer');
-        expect(BeverageTypeHelper.formatBeverageType('cider--perry'),
-            'Cider Perry');
+        expect(
+          BeverageTypeHelper.formatBeverageType('cider--perry'),
+          'Cider Perry',
+        );
       });
 
       test('returns an empty string for empty input', () {
@@ -31,8 +33,10 @@ void main() {
     group('getBeverageIcon', () {
       test('maps each known beverage type to a distinct icon', () {
         expect(BeverageTypeHelper.getBeverageIcon('beer'), Icons.sports_bar);
-        expect(BeverageTypeHelper.getBeverageIcon('international-beer'),
-            Icons.public);
+        expect(
+          BeverageTypeHelper.getBeverageIcon('international-beer'),
+          Icons.public,
+        );
         expect(BeverageTypeHelper.getBeverageIcon('cider'), Icons.local_drink);
         expect(BeverageTypeHelper.getBeverageIcon('perry'), Icons.eco);
         expect(BeverageTypeHelper.getBeverageIcon('mead'), Icons.emoji_nature);

--- a/test/brewery_screen_test.dart
+++ b/test/brewery_screen_test.dart
@@ -43,10 +43,16 @@ void main() {
       dispense: 'cask',
     );
 
-    final drink1 =
-        Drink(product: product1, producer: producer1, festivalId: 'cbf2025');
-    final drink2 =
-        Drink(product: product2, producer: producer1, festivalId: 'cbf2025');
+    final drink1 = Drink(
+      product: product1,
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
+    final drink2 = Drink(
+      product: product2,
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -66,10 +72,12 @@ void main() {
         baseUrl: 'https://example.com',
         version: '1.0.0',
       );
-      when(mockFestivalRepository.getFestivals())
-          .thenAnswer((_) async => festivalsResponse);
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getFestivals(),
+      ).thenAnswer((_) async => festivalsResponse);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
 
       provider = BeerProvider(
@@ -93,8 +101,9 @@ void main() {
       );
     }
 
-    testWidgets('displays brewery not found when brewery does not exist',
-        (WidgetTester tester) async {
+    testWidgets('displays brewery not found when brewery does not exist', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget('nonexistent'));
       await tester.pumpAndSettle();
 
@@ -102,10 +111,12 @@ void main() {
       expect(find.text('No drinks found from this brewery.'), findsOneWidget);
     });
 
-    testWidgets('displays brewery information when brewery exists',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2]);
+    testWidgets('displays brewery information when brewery exists', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('brewery1'));
@@ -118,10 +129,12 @@ void main() {
       expect(find.text('2 drinks at this festival'), findsOneWidget);
     });
 
-    testWidgets('displays drinks from the brewery',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2]);
+    testWidgets('displays drinks from the brewery', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('brewery1'));
@@ -132,10 +145,12 @@ void main() {
       expect(find.text('Test Beer 2'), findsOneWidget);
     });
 
-    testWidgets('navigates to drink detail when drink card is tapped',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1]);
+    testWidgets('navigates to drink detail when drink card is tapped', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1]);
       await provider.loadDrinks();
 
       final router = GoRouter(
@@ -145,10 +160,12 @@ void main() {
             path: '/brewery',
             builder: (context, state) =>
                 ChangeNotifierProvider<BeerProvider>.value(
-              value: provider,
-              child: const BreweryScreen(
-                  festivalId: 'cbf2025', breweryId: 'brewery1'),
-            ),
+                  value: provider,
+                  child: const BreweryScreen(
+                    festivalId: 'cbf2025',
+                    breweryId: 'brewery1',
+                  ),
+                ),
           ),
           GoRoute(
             path: '/cbf2025/drink/:category/:drinkId',
@@ -163,18 +180,21 @@ void main() {
 
       expect(find.text('Test Beer 1'), findsOneWidget);
 
-      final card =
-          tester.widget<DrinkCard>(find.byKey(const ValueKey('drink1')));
+      final card = tester.widget<DrinkCard>(
+        find.byKey(const ValueKey('drink1')),
+      );
       card.onTap!();
       await tester.pumpAndSettle();
 
       expect(find.text('Drink Detail'), findsOneWidget);
     });
 
-    testWidgets('toggles favorite when favorite button is tapped',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1]);
+    testWidgets('toggles favorite when favorite button is tapped', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('brewery1'));
@@ -184,8 +204,9 @@ void main() {
 
       // Mock toggleFavorite to properly toggle state
       final favorites = <String>{};
-      when(mockDrinkRepository.toggleFavorite(any, any))
-          .thenAnswer((invocation) async {
+      when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer((
+        invocation,
+      ) async {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
@@ -207,10 +228,12 @@ void main() {
       expect(drink1.isFavorite, true);
     });
 
-    testWidgets('displays correct count of drinks',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2]);
+    testWidgets('displays correct count of drinks', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('brewery1'));
@@ -219,8 +242,9 @@ void main() {
       expect(find.text('Drinks (2)'), findsOneWidget);
     });
 
-    testWidgets('does not display year founded when null',
-        (WidgetTester tester) async {
+    testWidgets('does not display year founded when null', (
+      WidgetTester tester,
+    ) async {
       const producerNoYear = Producer(
         id: 'brewery2',
         name: 'New Brewery',
@@ -229,7 +253,10 @@ void main() {
         products: [],
       );
       final drink = Drink(
-          product: product1, producer: producerNoYear, festivalId: 'cbf2025');
+        product: product1,
+        producer: producerNoYear,
+        festivalId: 'cbf2025',
+      );
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -248,9 +275,10 @@ void main() {
         products: [],
       );
       final drink = Drink(
-          product: product1,
-          producer: producerNoLocation,
-          festivalId: 'cbf2025');
+        product: product1,
+        producer: producerNoLocation,
+        festivalId: 'cbf2025',
+      );
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -261,8 +289,9 @@ void main() {
       expect(find.byIcon(Icons.location_on), findsNothing);
     });
 
-    testWidgets('filters drinks to show only from requested brewery',
-        (WidgetTester tester) async {
+    testWidgets('filters drinks to show only from requested brewery', (
+      WidgetTester tester,
+    ) async {
       const producer2 = Producer(
         id: 'brewery2',
         name: 'Other Brewery',
@@ -277,11 +306,15 @@ void main() {
         category: 'beer',
         dispense: 'keg',
       );
-      final drink3 =
-          Drink(product: product3, producer: producer2, festivalId: 'cbf2025');
+      final drink3 = Drink(
+        product: product3,
+        producer: producer2,
+        festivalId: 'cbf2025',
+      );
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2, drink3]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2, drink3]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('brewery1'));

--- a/test/cache_service_test.dart
+++ b/test/cache_service_test.dart
@@ -13,27 +13,26 @@ void main() {
     String category = 'beer',
     Map<String, int> allergens = const {},
     bool? isVegan,
-  }) =>
-      Drink(
-        product: Product(
-          id: productId,
-          name: name,
-          category: category,
-          style: 'IPA',
-          dispense: 'cask',
-          abv: 5.5,
-          allergens: allergens,
-          isVegan: isVegan,
-        ),
-        producer: Producer(
-          id: producerId,
-          name: 'Producer $producerId',
-          location: 'Cambridge',
-          yearFounded: 1990,
-          products: const [],
-        ),
-        festivalId: 'cbf2025',
-      );
+  }) => Drink(
+    product: Product(
+      id: productId,
+      name: name,
+      category: category,
+      style: 'IPA',
+      dispense: 'cask',
+      abv: 5.5,
+      allergens: allergens,
+      isVegan: isVegan,
+    ),
+    producer: Producer(
+      id: producerId,
+      name: 'Producer $producerId',
+      location: 'Cambridge',
+      yearFounded: 1990,
+      products: const [],
+    ),
+    festivalId: 'cbf2025',
+  );
 
   group('DrinkCacheService', () {
     late DrinkCacheService cache;
@@ -206,27 +205,24 @@ void main() {
   group('FestivalCacheService', () {
     late FestivalCacheService cache;
 
-    FestivalsResponse makeResponse() => FestivalsResponse.fromJson(
-          {
-            'festivals': [
-              {
-                'id': 'cbf2025',
-                'name': 'Cambridge Beer Festival 2025',
-                'data_base_url': 'https://example.com/cbf2025',
-                'is_active': true,
-                'available_beverage_types': ['beer', 'cider'],
-              },
-              {
-                'id': 'cbf2024',
-                'name': 'Cambridge Beer Festival 2024',
-                'data_base_url': 'https://example.com/cbf2024',
-              },
-            ],
-            'default_festival_id': 'cbf2025',
-            'version': '2.0.0',
-          },
-          'https://example.com',
-        );
+    FestivalsResponse makeResponse() => FestivalsResponse.fromJson({
+      'festivals': [
+        {
+          'id': 'cbf2025',
+          'name': 'Cambridge Beer Festival 2025',
+          'data_base_url': 'https://example.com/cbf2025',
+          'is_active': true,
+          'available_beverage_types': ['beer', 'cider'],
+        },
+        {
+          'id': 'cbf2024',
+          'name': 'Cambridge Beer Festival 2024',
+          'data_base_url': 'https://example.com/cbf2024',
+        },
+      ],
+      'default_festival_id': 'cbf2025',
+      'version': '2.0.0',
+    }, 'https://example.com');
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -255,9 +251,7 @@ void main() {
     });
 
     test('returns null for corrupt cached data', () async {
-      SharedPreferences.setMockInitialValues({
-        'festivals_cache': '}{ broken',
-      });
+      SharedPreferences.setMockInitialValues({'festivals_cache': '}{ broken'});
       final prefs = await SharedPreferences.getInstance();
       final corruptCache = FestivalCacheService(prefs);
 

--- a/test/category_color_helper_test.dart
+++ b/test/category_color_helper_test.dart
@@ -34,10 +34,14 @@ void main() {
       expect(result, scheme.secondary);
     });
 
-    testWidgets('international-beer still matches the beer branch',
-        (tester) async {
-      final (result, scheme) =
-          await resolve(tester, Brightness.light, 'international-beer');
+    testWidgets('international-beer still matches the beer branch', (
+      tester,
+    ) async {
+      final (result, scheme) = await resolve(
+        tester,
+        Brightness.light,
+        'international-beer',
+      );
       expect(result, scheme.secondary);
     });
 
@@ -65,8 +69,11 @@ void main() {
     });
 
     testWidgets('low-no categories use the primary colour', (tester) async {
-      final (result, scheme) =
-          await resolve(tester, Brightness.light, 'low-no');
+      final (result, scheme) = await resolve(
+        tester,
+        Brightness.light,
+        'low-no',
+      );
       expect(result, scheme.primary);
     });
 
@@ -75,10 +82,14 @@ void main() {
       expect(result, scheme.secondary);
     });
 
-    testWidgets('unknown categories fall back to the outline colour',
-        (tester) async {
-      final (result, scheme) =
-          await resolve(tester, Brightness.light, 'spirits');
+    testWidgets('unknown categories fall back to the outline colour', (
+      tester,
+    ) async {
+      final (result, scheme) = await resolve(
+        tester,
+        Brightness.light,
+        'spirits',
+      );
       expect(result, scheme.outline);
     });
   });

--- a/test/domain/controllers/drink_filter_controller_test.dart
+++ b/test/domain/controllers/drink_filter_controller_test.dart
@@ -52,11 +52,11 @@ Drink _drink({
 }
 
 List<Drink> _sampleDrinks() => [
-      _drink(id: 'd1', name: 'Alpha Ale', category: 'beer', style: 'IPA'),
-      _drink(id: 'd2', name: 'Beta Bitter', category: 'beer', style: 'Bitter'),
-      _drink(id: 'd3', name: 'Crisp Cider', category: 'cider', style: 'Dry'),
-      _drink(id: 'd4', name: 'Zesty Zider', category: 'cider', style: 'Sweet'),
-    ];
+  _drink(id: 'd1', name: 'Alpha Ale', category: 'beer', style: 'IPA'),
+  _drink(id: 'd2', name: 'Beta Bitter', category: 'beer', style: 'Bitter'),
+  _drink(id: 'd3', name: 'Crisp Cider', category: 'cider', style: 'Dry'),
+  _drink(id: 'd4', name: 'Zesty Zider', category: 'cider', style: 'Sweet'),
+];
 
 void main() {
   group('DrinkFilterController', () {
@@ -83,18 +83,21 @@ void main() {
     group('setSource', () {
       test('exposes all drinks sorted by name when no filters active', () {
         controller.setSource(_sampleDrinks());
-        expect(
-          controller.filteredDrinks.map((d) => d.name).toList(),
-          ['Alpha Ale', 'Beta Bitter', 'Crisp Cider', 'Zesty Zider'],
-        );
+        expect(controller.filteredDrinks.map((d) => d.name).toList(), [
+          'Alpha Ale',
+          'Beta Bitter',
+          'Crisp Cider',
+          'Zesty Zider',
+        ]);
       });
 
       test('replacing the source recomputes the filtered list', () {
         controller.setSource(_sampleDrinks());
         expect(controller.filteredDrinks, hasLength(4));
 
-        controller
-            .setSource([_drink(id: 'x', name: 'Only One', category: 'beer')]);
+        controller.setSource([
+          _drink(id: 'x', name: 'Only One', category: 'beer'),
+        ]);
         expect(controller.filteredDrinks, hasLength(1));
         expect(controller.filteredDrinks.single.name, 'Only One');
       });
@@ -110,8 +113,10 @@ void main() {
       test('narrows filtered drinks to the selected category', () {
         controller.setSource(_sampleDrinks());
         controller.setCategory('cider');
-        expect(controller.filteredDrinks.map((d) => d.name),
-            ['Crisp Cider', 'Zesty Zider']);
+        expect(controller.filteredDrinks.map((d) => d.name), [
+          'Crisp Cider',
+          'Zesty Zider',
+        ]);
       });
 
       test('setting category clears any active style filter', () {
@@ -149,8 +154,10 @@ void main() {
         controller.toggleStyle('IPA');
         controller.toggleStyle('Dry');
         expect(controller.selectedStyles, {'IPA', 'Dry'});
-        expect(controller.filteredDrinks.map((d) => d.name),
-            ['Alpha Ale', 'Crisp Cider']);
+        expect(controller.filteredDrinks.map((d) => d.name), [
+          'Alpha Ale',
+          'Crisp Cider',
+        ]);
       });
 
       test('clearStyles removes all style filters', () {
@@ -188,13 +195,19 @@ void main() {
     group('visibility filters', () {
       test('setVisibilityFilter toggles membership and hideUnavailable', () {
         controller.setVisibilityFilter(
-            DrinkVisibilityFilter.availableOnly, true);
-        expect(controller.visibilityFilters,
-            contains(DrinkVisibilityFilter.availableOnly));
+          DrinkVisibilityFilter.availableOnly,
+          true,
+        );
+        expect(
+          controller.visibilityFilters,
+          contains(DrinkVisibilityFilter.availableOnly),
+        );
         expect(controller.hideUnavailable, isTrue);
 
         controller.setVisibilityFilter(
-            DrinkVisibilityFilter.availableOnly, false);
+          DrinkVisibilityFilter.availableOnly,
+          false,
+        );
         expect(controller.visibilityFilters, isEmpty);
         expect(controller.hideUnavailable, isFalse);
       });
@@ -211,8 +224,10 @@ void main() {
         drinks[0].isTasted = true;
         controller.setSource(drinks);
         controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
-        expect(controller.filteredDrinks.map((d) => d.name),
-            isNot(contains('Alpha Ale')));
+        expect(
+          controller.filteredDrinks.map((d) => d.name),
+          isNot(contains('Alpha Ale')),
+        );
         expect(controller.filteredDrinks, hasLength(3));
       });
 
@@ -229,9 +244,12 @@ void main() {
     group('allergen filters', () {
       test('excludes drinks containing an excluded allergen', () {
         controller.setSource([
-          _drink(id: 'a', name: 'Gluten Beer', category: 'beer', allergens: {
-            'gluten': 1,
-          }),
+          _drink(
+            id: 'a',
+            name: 'Gluten Beer',
+            category: 'beer',
+            allergens: {'gluten': 1},
+          ),
           _drink(id: 'b', name: 'Clean Beer', category: 'beer'),
         ]);
         controller.setAllergenFilter('gluten', true);
@@ -250,8 +268,10 @@ void main() {
 
       test('excludedAllergens getter is unmodifiable', () {
         controller.setAllergenFilter('gluten', true);
-        expect(() => controller.excludedAllergens.add('nuts'),
-            throwsUnsupportedError);
+        expect(
+          () => controller.excludedAllergens.add('nuts'),
+          throwsUnsupportedError,
+        );
       });
     });
 
@@ -295,7 +315,11 @@ void main() {
       test('availableAllergens aggregates keys across the source', () {
         controller.setSource([
           _drink(
-              id: 'a', name: 'A', category: 'beer', allergens: {'gluten': 1}),
+            id: 'a',
+            name: 'A',
+            category: 'beer',
+            allergens: {'gluten': 1},
+          ),
           _drink(id: 'b', name: 'B', category: 'beer', allergens: {'nuts': 0}),
         ]);
         expect(controller.availableAllergens, {'gluten', 'nuts'});
@@ -333,8 +357,10 @@ void main() {
         expect(controller.searchQuery, isEmpty);
         // Preserved
         expect(controller.currentSort, DrinkSort.nameDesc);
-        expect(controller.visibilityFilters,
-            contains(DrinkVisibilityFilter.notTasted));
+        expect(
+          controller.visibilityFilters,
+          contains(DrinkVisibilityFilter.notTasted),
+        );
         expect(controller.filteredDrinks, hasLength(4));
       });
     });
@@ -345,8 +371,9 @@ void main() {
           visibilityFilters: {DrinkVisibilityFilter.availableOnly},
           excludedAllergens: {'gluten'},
         );
-        expect(controller.visibilityFilters,
-            {DrinkVisibilityFilter.availableOnly});
+        expect(controller.visibilityFilters, {
+          DrinkVisibilityFilter.availableOnly,
+        });
         expect(controller.excludedAllergens, {'gluten'});
         expect(controller.hideUnavailable, isTrue);
       });
@@ -354,9 +381,12 @@ void main() {
       test('applies once a source is set', () {
         controller.hydrate(excludedAllergens: {'gluten'});
         controller.setSource([
-          _drink(id: 'a', name: 'Gluten', category: 'beer', allergens: {
-            'gluten': 1,
-          }),
+          _drink(
+            id: 'a',
+            name: 'Gluten',
+            category: 'beer',
+            allergens: {'gluten': 1},
+          ),
           _drink(id: 'b', name: 'Clean', category: 'beer'),
         ]);
         expect(controller.filteredDrinks.map((d) => d.name), ['Clean']);

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -8,10 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'api_drink_repository_test.mocks.dart';
 
-@GenerateNiceMocks([
-  MockSpec<BeerApiService>(),
-  MockSpec<AnalyticsService>(),
-])
+@GenerateNiceMocks([MockSpec<BeerApiService>(), MockSpec<AnalyticsService>()])
 void main() {
   const festival = Festival(
     id: 'cbf2025',
@@ -20,21 +17,21 @@ void main() {
   );
 
   Drink makeDrink(String id) => Drink(
-        product: Product(
-          id: id,
-          name: 'Drink $id',
-          category: 'beer',
-          dispense: 'cask',
-          abv: 4.0,
-        ),
-        producer: const Producer(
-          id: 'brewery-1',
-          name: 'Test Brewery',
-          location: 'Cambridge',
-          products: [],
-        ),
-        festivalId: festival.id,
-      );
+    product: Product(
+      id: id,
+      name: 'Drink $id',
+      category: 'beer',
+      dispense: 'cask',
+      abv: 4.0,
+    ),
+    producer: const Producer(
+      id: 'brewery-1',
+      name: 'Test Brewery',
+      location: 'Cambridge',
+      products: [],
+    ),
+    festivalId: festival.id,
+  );
 
   group('ApiDrinkRepository', () {
     late MockBeerApiService apiService;
@@ -71,29 +68,33 @@ void main() {
         );
 
     group('getDrinks', () {
-      test('populates favourite, rating and tasted state in one pass',
-          () async {
-        when(apiService.fetchDrinksByType(festival)).thenAnswer(
-          (_) async => ok([makeDrink('d1'), makeDrink('d2'), makeDrink('d3')]),
-        );
-        await favoritesService.addFavorite(festival.id, 'd1');
-        await ratingsService.setRating(festival.id, 'd2', 4);
-        await tastingLogService.markAsTasted(festival.id, 'd3');
+      test(
+        'populates favourite, rating and tasted state in one pass',
+        () async {
+          when(apiService.fetchDrinksByType(festival)).thenAnswer(
+            (_) async =>
+                ok([makeDrink('d1'), makeDrink('d2'), makeDrink('d3')]),
+          );
+          await favoritesService.addFavorite(festival.id, 'd1');
+          await ratingsService.setRating(festival.id, 'd2', 4);
+          await tastingLogService.markAsTasted(festival.id, 'd3');
 
-        final drinks = await repository.getDrinks(festival);
+          final drinks = await repository.getDrinks(festival);
 
-        final byId = {for (final d in drinks) d.id: d};
-        expect(byId['d1']!.isFavorite, isTrue);
-        expect(byId['d1']!.rating, isNull);
-        expect(byId['d1']!.isTasted, isFalse);
-        expect(byId['d2']!.rating, 4);
-        expect(byId['d2']!.isFavorite, isFalse);
-        expect(byId['d3']!.isTasted, isTrue);
-      });
+          final byId = {for (final d in drinks) d.id: d};
+          expect(byId['d1']!.isFavorite, isTrue);
+          expect(byId['d1']!.rating, isNull);
+          expect(byId['d1']!.isTasted, isFalse);
+          expect(byId['d2']!.rating, 4);
+          expect(byId['d2']!.isFavorite, isFalse);
+          expect(byId['d3']!.isTasted, isTrue);
+        },
+      );
 
       test('leaves all state unset when nothing is stored', () async {
-        when(apiService.fetchDrinksByType(festival))
-            .thenAnswer((_) async => ok([makeDrink('d1')]));
+        when(
+          apiService.fetchDrinksByType(festival),
+        ).thenAnswer((_) async => ok([makeDrink('d1')]));
 
         final drinks = await repository.getDrinks(festival);
 
@@ -103,8 +104,9 @@ void main() {
       });
 
       test('returns an empty list when the API returns no drinks', () async {
-        when(apiService.fetchDrinksByType(festival))
-            .thenAnswer((_) async => ok(<Drink>[]));
+        when(
+          apiService.fetchDrinksByType(festival),
+        ).thenAnswer((_) async => ok(<Drink>[]));
 
         expect(await repository.getDrinks(festival), isEmpty);
       });
@@ -124,8 +126,9 @@ void main() {
       });
 
       test('writes fetched drinks to the cache', () async {
-        when(apiService.fetchDrinksByType(festival))
-            .thenAnswer((_) async => ok([makeDrink('d1'), makeDrink('d2')]));
+        when(
+          apiService.fetchDrinksByType(festival),
+        ).thenAnswer((_) async => ok([makeDrink('d1'), makeDrink('d2')]));
 
         await repository.getDrinks(festival);
         await pumpEventQueue(); // cache write is intentionally backgrounded
@@ -135,98 +138,108 @@ void main() {
         expect(cached!.map((d) => d.id), containsAll(['d1', 'd2']));
       });
 
-      test('keeps cached data for a beverage type that fails to refresh',
-          () async {
-        // First load: both beer and cider succeed and are cached.
-        when(apiService.fetchDrinksByType(festival)).thenAnswer(
-          (_) async => FestivalDrinksResult(
-            drinksByType: {
-              'beer': [makeDrink('beer-1')],
-              'cider': [makeDrink('cider-1')],
-            },
-            failedTypes: const {},
-          ),
-        );
-        await repository.getDrinks(festival);
-        await pumpEventQueue();
+      test(
+        'keeps cached data for a beverage type that fails to refresh',
+        () async {
+          // First load: both beer and cider succeed and are cached.
+          when(apiService.fetchDrinksByType(festival)).thenAnswer(
+            (_) async => FestivalDrinksResult(
+              drinksByType: {
+                'beer': [makeDrink('beer-1')],
+                'cider': [makeDrink('cider-1')],
+              },
+              failedTypes: const {},
+            ),
+          );
+          await repository.getDrinks(festival);
+          await pumpEventQueue();
 
-        // Second load: cider fails (network), only beer refreshes.
-        when(apiService.fetchDrinksByType(festival)).thenAnswer(
-          (_) async => FestivalDrinksResult(
-            drinksByType: {
-              'beer': [makeDrink('beer-2')],
-            },
-            failedTypes: const {'cider': 'network error'},
-          ),
-        );
-        final drinks = await repository.getDrinks(festival);
+          // Second load: cider fails (network), only beer refreshes.
+          when(apiService.fetchDrinksByType(festival)).thenAnswer(
+            (_) async => FestivalDrinksResult(
+              drinksByType: {
+                'beer': [makeDrink('beer-2')],
+              },
+              failedTypes: const {'cider': 'network error'},
+            ),
+          );
+          final drinks = await repository.getDrinks(festival);
 
-        final ids = drinks.map((d) => d.id).toSet();
-        // Stale cider retained; beer refreshed; old beer dropped.
-        expect(ids, containsAll(['beer-2', 'cider-1']));
-        expect(ids.contains('beer-1'), isFalse);
-      });
+          final ids = drinks.map((d) => d.id).toSet();
+          // Stale cider retained; beer refreshed; old beer dropped.
+          expect(ids, containsAll(['beer-2', 'cider-1']));
+          expect(ids.contains('beer-1'), isFalse);
+        },
+      );
 
-      test('keeps cached data for a beverage type that 404s on refresh',
-          () async {
-        // First load: both beer and cider 200 and are cached.
-        when(apiService.fetchDrinksByType(festival)).thenAnswer(
-          (_) async => FestivalDrinksResult(
-            drinksByType: {
-              'beer': [makeDrink('beer-1')],
-              'cider': [makeDrink('cider-1')],
-            },
-            failedTypes: const {},
-          ),
-        );
-        await repository.getDrinks(festival);
-        await pumpEventQueue();
+      test(
+        'keeps cached data for a beverage type that 404s on refresh',
+        () async {
+          // First load: both beer and cider 200 and are cached.
+          when(apiService.fetchDrinksByType(festival)).thenAnswer(
+            (_) async => FestivalDrinksResult(
+              drinksByType: {
+                'beer': [makeDrink('beer-1')],
+                'cider': [makeDrink('cider-1')],
+              },
+              failedTypes: const {},
+            ),
+          );
+          await repository.getDrinks(festival);
+          await pumpEventQueue();
 
-        // Second load: cider responds 404 → omitted from BOTH drinksByType
-        // AND failedTypes (per fetchDrinksByType's contract), so the cache
-        // must preserve cider rather than overwriting it with empty.
-        when(apiService.fetchDrinksByType(festival)).thenAnswer(
-          (_) async => FestivalDrinksResult(
-            drinksByType: {
-              'beer': [makeDrink('beer-2')],
-            },
-            failedTypes: const {},
-          ),
-        );
-        final drinks = await repository.getDrinks(festival);
+          // Second load: cider responds 404 → omitted from BOTH drinksByType
+          // AND failedTypes (per fetchDrinksByType's contract), so the cache
+          // must preserve cider rather than overwriting it with empty.
+          when(apiService.fetchDrinksByType(festival)).thenAnswer(
+            (_) async => FestivalDrinksResult(
+              drinksByType: {
+                'beer': [makeDrink('beer-2')],
+              },
+              failedTypes: const {},
+            ),
+          );
+          final drinks = await repository.getDrinks(festival);
 
-        final ids = drinks.map((d) => d.id).toSet();
-        expect(ids, containsAll(['beer-2', 'cider-1']));
-        expect(ids.contains('beer-1'), isFalse);
-      });
+          final ids = drinks.map((d) => d.id).toSet();
+          expect(ids, containsAll(['beer-2', 'cider-1']));
+          expect(ids.contains('beer-1'), isFalse);
+        },
+      );
 
-      test('logs cache write failures to analytics instead of swallowing them',
-          () async {
-        // SharedPreferences mock can't fail directly, but we can drive the
-        // analytics path by handing back an already-failed `written` future
-        // via a fake cache that always fails on persist.
-        final prefs = await SharedPreferences.getInstance();
-        final failingCache = _FailingDrinkCacheService(prefs);
-        final repo = ApiDrinkRepository(
-          apiService: apiService,
-          favoritesService: favoritesService,
-          ratingsService: ratingsService,
-          tastingLogService: tastingLogService,
-          cacheService: failingCache,
-          analyticsService: analyticsService,
-        );
+      test(
+        'logs cache write failures to analytics instead of swallowing them',
+        () async {
+          // SharedPreferences mock can't fail directly, but we can drive the
+          // analytics path by handing back an already-failed `written` future
+          // via a fake cache that always fails on persist.
+          final prefs = await SharedPreferences.getInstance();
+          final failingCache = _FailingDrinkCacheService(prefs);
+          final repo = ApiDrinkRepository(
+            apiService: apiService,
+            favoritesService: favoritesService,
+            ratingsService: ratingsService,
+            tastingLogService: tastingLogService,
+            cacheService: failingCache,
+            analyticsService: analyticsService,
+          );
 
-        when(apiService.fetchDrinksByType(festival))
-            .thenAnswer((_) async => ok([makeDrink('d1')]));
+          when(
+            apiService.fetchDrinksByType(festival),
+          ).thenAnswer((_) async => ok([makeDrink('d1')]));
 
-        await repo.getDrinks(festival);
-        await pumpEventQueue();
+          await repo.getDrinks(festival);
+          await pumpEventQueue();
 
-        verify(analyticsService.logError(any, any,
-                reason:
-                    argThat(contains('cache write failed'), named: 'reason')))
-            .called(1);
-      });
+          verify(
+            analyticsService.logError(
+              any,
+              any,
+              reason: argThat(contains('cache write failed'), named: 'reason'),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('getCachedDrinks', () {
@@ -235,8 +248,9 @@ void main() {
       });
 
       test('returns cached drinks with user state applied', () async {
-        when(apiService.fetchDrinksByType(festival))
-            .thenAnswer((_) async => ok([makeDrink('d1'), makeDrink('d2')]));
+        when(
+          apiService.fetchDrinksByType(festival),
+        ).thenAnswer((_) async => ok([makeDrink('d1'), makeDrink('d2')]));
         // Populate the cache via a live fetch.
         await repository.getDrinks(festival);
         await pumpEventQueue();
@@ -327,7 +341,9 @@ class _FailingDrinkCacheService extends DrinkCacheService {
 
   @override
   DrinkCacheUpdate merge(
-      String festivalId, Map<String, List<Drink>> freshByType) {
+    String festivalId,
+    Map<String, List<Drink>> freshByType,
+  ) {
     final drinks = [for (final list in freshByType.values) ...list];
     return DrinkCacheUpdate(
       drinks,

--- a/test/domain/repositories/api_drink_repository_test.mocks.dart
+++ b/test/domain/repositories/api_drink_repository_test.mocks.dart
@@ -28,46 +28,26 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeDuration_0 extends _i1.SmartFake implements Duration {
-  _FakeDuration_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeDuration_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFestivalDrinksResult_1 extends _i1.SmartFake
     implements _i2.FestivalDrinksResult {
-  _FakeFestivalDrinksResult_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFestivalDrinksResult_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFirebaseAnalytics_2 extends _i1.SmartFake
     implements _i3.FirebaseAnalytics {
-  _FakeFirebaseAnalytics_2(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFirebaseAnalytics_2(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFirebaseCrashlytics_3 extends _i1.SmartFake
     implements _i4.FirebaseCrashlytics {
-  _FakeFirebaseCrashlytics_3(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFirebaseCrashlytics_3(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [BeerApiService].
@@ -75,17 +55,16 @@ class _FakeFirebaseCrashlytics_3 extends _i1.SmartFake
 /// See the documentation for Mockito's code generation for more information.
 class MockBeerApiService extends _i1.Mock implements _i2.BeerApiService {
   @override
-  Duration get timeout => (super.noSuchMethod(
-        Invocation.getter(#timeout),
-        returnValue: _FakeDuration_0(
-          this,
-          Invocation.getter(#timeout),
-        ),
-        returnValueForMissingStub: _FakeDuration_0(
-          this,
-          Invocation.getter(#timeout),
-        ),
-      ) as Duration);
+  Duration get timeout =>
+      (super.noSuchMethod(
+            Invocation.getter(#timeout),
+            returnValue: _FakeDuration_0(this, Invocation.getter(#timeout)),
+            returnValueForMissingStub: _FakeDuration_0(
+              this,
+              Invocation.getter(#timeout),
+            ),
+          )
+          as Duration);
 
   @override
   _i5.Future<List<_i6.Drink>> fetchDrinks(
@@ -93,64 +72,52 @@ class MockBeerApiService extends _i1.Mock implements _i2.BeerApiService {
     String? beverageType,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #fetchDrinks,
-          [
-            festival,
-            beverageType,
-          ],
-        ),
-        returnValue: _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
-        returnValueForMissingStub:
-            _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
-      ) as _i5.Future<List<_i6.Drink>>);
+            Invocation.method(#fetchDrinks, [festival, beverageType]),
+            returnValue: _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
+            returnValueForMissingStub: _i5.Future<List<_i6.Drink>>.value(
+              <_i6.Drink>[],
+            ),
+          )
+          as _i5.Future<List<_i6.Drink>>);
 
   @override
   _i5.Future<_i2.FestivalDrinksResult> fetchDrinksByType(
-          _i6.Festival? festival) =>
+    _i6.Festival? festival,
+  ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #fetchDrinksByType,
-          [festival],
-        ),
-        returnValue: _i5.Future<_i2.FestivalDrinksResult>.value(
-            _FakeFestivalDrinksResult_1(
-          this,
-          Invocation.method(
-            #fetchDrinksByType,
-            [festival],
-          ),
-        )),
-        returnValueForMissingStub: _i5.Future<_i2.FestivalDrinksResult>.value(
-            _FakeFestivalDrinksResult_1(
-          this,
-          Invocation.method(
-            #fetchDrinksByType,
-            [festival],
-          ),
-        )),
-      ) as _i5.Future<_i2.FestivalDrinksResult>);
+            Invocation.method(#fetchDrinksByType, [festival]),
+            returnValue: _i5.Future<_i2.FestivalDrinksResult>.value(
+              _FakeFestivalDrinksResult_1(
+                this,
+                Invocation.method(#fetchDrinksByType, [festival]),
+              ),
+            ),
+            returnValueForMissingStub:
+                _i5.Future<_i2.FestivalDrinksResult>.value(
+                  _FakeFestivalDrinksResult_1(
+                    this,
+                    Invocation.method(#fetchDrinksByType, [festival]),
+                  ),
+                ),
+          )
+          as _i5.Future<_i2.FestivalDrinksResult>);
 
   @override
   _i5.Future<List<_i6.Drink>> fetchAllDrinks(_i6.Festival? festival) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #fetchAllDrinks,
-          [festival],
-        ),
-        returnValue: _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
-        returnValueForMissingStub:
-            _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
-      ) as _i5.Future<List<_i6.Drink>>);
+            Invocation.method(#fetchAllDrinks, [festival]),
+            returnValue: _i5.Future<List<_i6.Drink>>.value(<_i6.Drink>[]),
+            returnValueForMissingStub: _i5.Future<List<_i6.Drink>>.value(
+              <_i6.Drink>[],
+            ),
+          )
+          as _i5.Future<List<_i6.Drink>>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#dispose, []),
+    returnValueForMissingStub: null,
+  );
 }
 
 /// A class which mocks [AnalyticsService].
@@ -158,188 +125,169 @@ class MockBeerApiService extends _i1.Mock implements _i2.BeerApiService {
 /// See the documentation for Mockito's code generation for more information.
 class MockAnalyticsService extends _i1.Mock implements _i7.AnalyticsService {
   @override
-  _i3.FirebaseAnalytics get analytics => (super.noSuchMethod(
-        Invocation.getter(#analytics),
-        returnValue: _FakeFirebaseAnalytics_2(
-          this,
-          Invocation.getter(#analytics),
-        ),
-        returnValueForMissingStub: _FakeFirebaseAnalytics_2(
-          this,
-          Invocation.getter(#analytics),
-        ),
-      ) as _i3.FirebaseAnalytics);
+  _i3.FirebaseAnalytics get analytics =>
+      (super.noSuchMethod(
+            Invocation.getter(#analytics),
+            returnValue: _FakeFirebaseAnalytics_2(
+              this,
+              Invocation.getter(#analytics),
+            ),
+            returnValueForMissingStub: _FakeFirebaseAnalytics_2(
+              this,
+              Invocation.getter(#analytics),
+            ),
+          )
+          as _i3.FirebaseAnalytics);
 
   @override
-  _i4.FirebaseCrashlytics get crashlytics => (super.noSuchMethod(
-        Invocation.getter(#crashlytics),
-        returnValue: _FakeFirebaseCrashlytics_3(
-          this,
-          Invocation.getter(#crashlytics),
-        ),
-        returnValueForMissingStub: _FakeFirebaseCrashlytics_3(
-          this,
-          Invocation.getter(#crashlytics),
-        ),
-      ) as _i4.FirebaseCrashlytics);
+  _i4.FirebaseCrashlytics get crashlytics =>
+      (super.noSuchMethod(
+            Invocation.getter(#crashlytics),
+            returnValue: _FakeFirebaseCrashlytics_3(
+              this,
+              Invocation.getter(#crashlytics),
+            ),
+            returnValueForMissingStub: _FakeFirebaseCrashlytics_3(
+              this,
+              Invocation.getter(#crashlytics),
+            ),
+          )
+          as _i4.FirebaseCrashlytics);
 
   @override
-  _i5.Future<void> logAppLaunch() => (super.noSuchMethod(
-        Invocation.method(
-          #logAppLaunch,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> logAppLaunch() =>
+      (super.noSuchMethod(
+            Invocation.method(#logAppLaunch, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
   _i5.Future<void> logFestivalSelected(_i6.Festival? festival) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logFestivalSelected,
-          [festival],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+            Invocation.method(#logFestivalSelected, [festival]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> logSearch(String? query) => (super.noSuchMethod(
-        Invocation.method(
-          #logSearch,
-          [query],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logCategoryFilter(String? category) => (super.noSuchMethod(
-        Invocation.method(
-          #logCategoryFilter,
-          [category],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logStyleFilter(Set<String>? styles) => (super.noSuchMethod(
-        Invocation.method(
-          #logStyleFilter,
-          [styles],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logSortChange(String? sortType) => (super.noSuchMethod(
-        Invocation.method(
-          #logSortChange,
-          [sortType],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logFavoriteAdded(_i6.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logFavoriteAdded,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logFavoriteRemoved(_i6.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logFavoriteRemoved,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logTastedAdded(_i6.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logTastedAdded,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logTastedRemoved(_i6.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logTastedRemoved,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logDrinkViewed(_i6.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logDrinkViewed,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logBreweryViewed(String? breweryName) => (super.noSuchMethod(
-        Invocation.method(
-          #logBreweryViewed,
-          [breweryName],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logStyleViewed(String? style) => (super.noSuchMethod(
-        Invocation.method(
-          #logStyleViewed,
-          [style],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logRatingGiven(
-    _i6.Drink? drink,
-    int? rating,
-  ) =>
+  _i5.Future<void> logSearch(String? query) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logRatingGiven,
-          [
-            drink,
-            rating,
-          ],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+            Invocation.method(#logSearch, [query]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> logDrinkShared(_i6.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logDrinkShared,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> logCategoryFilter(String? category) =>
+      (super.noSuchMethod(
+            Invocation.method(#logCategoryFilter, [category]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logStyleFilter(Set<String>? styles) =>
+      (super.noSuchMethod(
+            Invocation.method(#logStyleFilter, [styles]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logSortChange(String? sortType) =>
+      (super.noSuchMethod(
+            Invocation.method(#logSortChange, [sortType]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFavoriteAdded(_i6.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFavoriteAdded, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFavoriteRemoved(_i6.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFavoriteRemoved, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logTastedAdded(_i6.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logTastedAdded, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logTastedRemoved(_i6.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logTastedRemoved, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logDrinkViewed(_i6.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logDrinkViewed, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logBreweryViewed(String? breweryName) =>
+      (super.noSuchMethod(
+            Invocation.method(#logBreweryViewed, [breweryName]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logStyleViewed(String? style) =>
+      (super.noSuchMethod(
+            Invocation.method(#logStyleViewed, [style]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logRatingGiven(_i6.Drink? drink, int? rating) =>
+      (super.noSuchMethod(
+            Invocation.method(#logRatingGiven, [drink, rating]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logDrinkShared(_i6.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logDrinkShared, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
   _i5.Future<void> logError(
@@ -348,42 +296,31 @@ class MockAnalyticsService extends _i1.Mock implements _i7.AnalyticsService {
     String? reason,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logError,
-          [
-            error,
-            stackTrace,
-          ],
-          {#reason: reason},
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+            Invocation.method(
+              #logError,
+              [error, stackTrace],
+              {#reason: reason},
+            ),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setUserProperty(
-    String? name,
-    String? value,
-  ) =>
+  _i5.Future<void> setUserProperty(String? name, String? value) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setUserProperty,
-          [
-            name,
-            value,
-          ],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+            Invocation.method(#setUserProperty, [name, value]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setUserId(String? userId) => (super.noSuchMethod(
-        Invocation.method(
-          #setUserId,
-          [userId],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> setUserId(String? userId) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserId, [userId]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 }

--- a/test/domain/repositories/api_festival_repository_test.dart
+++ b/test/domain/repositories/api_festival_repository_test.dart
@@ -7,10 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'api_festival_repository_test.mocks.dart';
 
-@GenerateNiceMocks([
-  MockSpec<FestivalService>(),
-  MockSpec<AnalyticsService>(),
-])
+@GenerateNiceMocks([MockSpec<FestivalService>(), MockSpec<AnalyticsService>()])
 void main() {
   group('ApiFestivalRepository', () {
     late MockFestivalService festivalService;
@@ -35,19 +32,16 @@ void main() {
     });
 
     test('getFestivals delegates to the festival service', () async {
-      final response = FestivalsResponse.fromJson(
-        {
-          'festivals': [
-            {
-              'id': 'cbf2025',
-              'name': 'Cambridge Beer Festival 2025',
-              'data_base_url': 'https://example.com/cbf2025',
-            },
-          ],
-          'default_festival_id': 'cbf2025',
-        },
-        'https://example.com',
-      );
+      final response = FestivalsResponse.fromJson({
+        'festivals': [
+          {
+            'id': 'cbf2025',
+            'name': 'Cambridge Beer Festival 2025',
+            'data_base_url': 'https://example.com/cbf2025',
+          },
+        ],
+        'default_festival_id': 'cbf2025',
+      }, 'https://example.com');
       when(festivalService.fetchFestivals()).thenAnswer((_) async => response);
 
       final result = await repository.getFestivals();
@@ -57,8 +51,9 @@ void main() {
     });
 
     test('getFestivals propagates festival service failures', () async {
-      when(festivalService.fetchFestivals())
-          .thenThrow(FestivalServiceException('boom', 500));
+      when(
+        festivalService.fetchFestivals(),
+      ).thenThrow(FestivalServiceException('boom', 500));
 
       expect(
         () => repository.getFestivals(),
@@ -67,19 +62,16 @@ void main() {
     });
 
     test('getFestivals caches the fetched response', () async {
-      final response = FestivalsResponse.fromJson(
-        {
-          'festivals': [
-            {
-              'id': 'cbf2025',
-              'name': 'Cambridge Beer Festival 2025',
-              'data_base_url': 'https://example.com/cbf2025',
-            },
-          ],
-          'default_festival_id': 'cbf2025',
-        },
-        'https://example.com',
-      );
+      final response = FestivalsResponse.fromJson({
+        'festivals': [
+          {
+            'id': 'cbf2025',
+            'name': 'Cambridge Beer Festival 2025',
+            'data_base_url': 'https://example.com/cbf2025',
+          },
+        ],
+        'default_festival_id': 'cbf2025',
+      }, 'https://example.com');
       when(festivalService.fetchFestivals()).thenAnswer((_) async => response);
 
       await repository.getFestivals();
@@ -99,13 +91,15 @@ void main() {
       expect(await repository.getSelectedFestivalId(), isNull);
     });
 
-    test('setSelectedFestivalId then getSelectedFestivalId round-trips',
-        () async {
-      await repository.setSelectedFestivalId('cbf2025');
+    test(
+      'setSelectedFestivalId then getSelectedFestivalId round-trips',
+      () async {
+        await repository.setSelectedFestivalId('cbf2025');
 
-      expect(await repository.getSelectedFestivalId(), 'cbf2025');
-      expect(storageService.getSelectedFestivalId(), 'cbf2025');
-    });
+        expect(await repository.getSelectedFestivalId(), 'cbf2025');
+        expect(storageService.getSelectedFestivalId(), 'cbf2025');
+      },
+    );
 
     test('setSelectedFestivalId overwrites a previous selection', () async {
       await repository.setSelectedFestivalId('cbf2024');

--- a/test/domain/repositories/api_festival_repository_test.mocks.dart
+++ b/test/domain/repositories/api_festival_repository_test.mocks.dart
@@ -28,46 +28,26 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeDuration_0 extends _i1.SmartFake implements Duration {
-  _FakeDuration_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeDuration_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFestivalsResponse_1 extends _i1.SmartFake
     implements _i2.FestivalsResponse {
-  _FakeFestivalsResponse_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFestivalsResponse_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFirebaseAnalytics_2 extends _i1.SmartFake
     implements _i3.FirebaseAnalytics {
-  _FakeFirebaseAnalytics_2(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFirebaseAnalytics_2(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFirebaseCrashlytics_3 extends _i1.SmartFake
     implements _i4.FirebaseCrashlytics {
-  _FakeFirebaseCrashlytics_3(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFirebaseCrashlytics_3(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [FestivalService].
@@ -75,50 +55,41 @@ class _FakeFirebaseCrashlytics_3 extends _i1.SmartFake
 /// See the documentation for Mockito's code generation for more information.
 class MockFestivalService extends _i1.Mock implements _i2.FestivalService {
   @override
-  Duration get timeout => (super.noSuchMethod(
-        Invocation.getter(#timeout),
-        returnValue: _FakeDuration_0(
-          this,
-          Invocation.getter(#timeout),
-        ),
-        returnValueForMissingStub: _FakeDuration_0(
-          this,
-          Invocation.getter(#timeout),
-        ),
-      ) as Duration);
+  Duration get timeout =>
+      (super.noSuchMethod(
+            Invocation.getter(#timeout),
+            returnValue: _FakeDuration_0(this, Invocation.getter(#timeout)),
+            returnValueForMissingStub: _FakeDuration_0(
+              this,
+              Invocation.getter(#timeout),
+            ),
+          )
+          as Duration);
 
   @override
-  _i5.Future<_i2.FestivalsResponse> fetchFestivals() => (super.noSuchMethod(
-        Invocation.method(
-          #fetchFestivals,
-          [],
-        ),
-        returnValue:
-            _i5.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_1(
-          this,
-          Invocation.method(
-            #fetchFestivals,
-            [],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i5.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_1(
-          this,
-          Invocation.method(
-            #fetchFestivals,
-            [],
-          ),
-        )),
-      ) as _i5.Future<_i2.FestivalsResponse>);
+  _i5.Future<_i2.FestivalsResponse> fetchFestivals() =>
+      (super.noSuchMethod(
+            Invocation.method(#fetchFestivals, []),
+            returnValue: _i5.Future<_i2.FestivalsResponse>.value(
+              _FakeFestivalsResponse_1(
+                this,
+                Invocation.method(#fetchFestivals, []),
+              ),
+            ),
+            returnValueForMissingStub: _i5.Future<_i2.FestivalsResponse>.value(
+              _FakeFestivalsResponse_1(
+                this,
+                Invocation.method(#fetchFestivals, []),
+              ),
+            ),
+          )
+          as _i5.Future<_i2.FestivalsResponse>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#dispose, []),
+    returnValueForMissingStub: null,
+  );
 }
 
 /// A class which mocks [AnalyticsService].
@@ -126,188 +97,169 @@ class MockFestivalService extends _i1.Mock implements _i2.FestivalService {
 /// See the documentation for Mockito's code generation for more information.
 class MockAnalyticsService extends _i1.Mock implements _i6.AnalyticsService {
   @override
-  _i3.FirebaseAnalytics get analytics => (super.noSuchMethod(
-        Invocation.getter(#analytics),
-        returnValue: _FakeFirebaseAnalytics_2(
-          this,
-          Invocation.getter(#analytics),
-        ),
-        returnValueForMissingStub: _FakeFirebaseAnalytics_2(
-          this,
-          Invocation.getter(#analytics),
-        ),
-      ) as _i3.FirebaseAnalytics);
+  _i3.FirebaseAnalytics get analytics =>
+      (super.noSuchMethod(
+            Invocation.getter(#analytics),
+            returnValue: _FakeFirebaseAnalytics_2(
+              this,
+              Invocation.getter(#analytics),
+            ),
+            returnValueForMissingStub: _FakeFirebaseAnalytics_2(
+              this,
+              Invocation.getter(#analytics),
+            ),
+          )
+          as _i3.FirebaseAnalytics);
 
   @override
-  _i4.FirebaseCrashlytics get crashlytics => (super.noSuchMethod(
-        Invocation.getter(#crashlytics),
-        returnValue: _FakeFirebaseCrashlytics_3(
-          this,
-          Invocation.getter(#crashlytics),
-        ),
-        returnValueForMissingStub: _FakeFirebaseCrashlytics_3(
-          this,
-          Invocation.getter(#crashlytics),
-        ),
-      ) as _i4.FirebaseCrashlytics);
+  _i4.FirebaseCrashlytics get crashlytics =>
+      (super.noSuchMethod(
+            Invocation.getter(#crashlytics),
+            returnValue: _FakeFirebaseCrashlytics_3(
+              this,
+              Invocation.getter(#crashlytics),
+            ),
+            returnValueForMissingStub: _FakeFirebaseCrashlytics_3(
+              this,
+              Invocation.getter(#crashlytics),
+            ),
+          )
+          as _i4.FirebaseCrashlytics);
 
   @override
-  _i5.Future<void> logAppLaunch() => (super.noSuchMethod(
-        Invocation.method(
-          #logAppLaunch,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> logAppLaunch() =>
+      (super.noSuchMethod(
+            Invocation.method(#logAppLaunch, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
   _i5.Future<void> logFestivalSelected(_i7.Festival? festival) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logFestivalSelected,
-          [festival],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+            Invocation.method(#logFestivalSelected, [festival]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> logSearch(String? query) => (super.noSuchMethod(
-        Invocation.method(
-          #logSearch,
-          [query],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logCategoryFilter(String? category) => (super.noSuchMethod(
-        Invocation.method(
-          #logCategoryFilter,
-          [category],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logStyleFilter(Set<String>? styles) => (super.noSuchMethod(
-        Invocation.method(
-          #logStyleFilter,
-          [styles],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logSortChange(String? sortType) => (super.noSuchMethod(
-        Invocation.method(
-          #logSortChange,
-          [sortType],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logFavoriteAdded(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logFavoriteAdded,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logFavoriteRemoved(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logFavoriteRemoved,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logTastedAdded(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logTastedAdded,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logTastedRemoved(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logTastedRemoved,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logDrinkViewed(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logDrinkViewed,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logBreweryViewed(String? breweryName) => (super.noSuchMethod(
-        Invocation.method(
-          #logBreweryViewed,
-          [breweryName],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logStyleViewed(String? style) => (super.noSuchMethod(
-        Invocation.method(
-          #logStyleViewed,
-          [style],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logRatingGiven(
-    _i7.Drink? drink,
-    int? rating,
-  ) =>
+  _i5.Future<void> logSearch(String? query) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logRatingGiven,
-          [
-            drink,
-            rating,
-          ],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+            Invocation.method(#logSearch, [query]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> logDrinkShared(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logDrinkShared,
-          [drink],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> logCategoryFilter(String? category) =>
+      (super.noSuchMethod(
+            Invocation.method(#logCategoryFilter, [category]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logStyleFilter(Set<String>? styles) =>
+      (super.noSuchMethod(
+            Invocation.method(#logStyleFilter, [styles]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logSortChange(String? sortType) =>
+      (super.noSuchMethod(
+            Invocation.method(#logSortChange, [sortType]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFavoriteAdded(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFavoriteAdded, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFavoriteRemoved(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFavoriteRemoved, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logTastedAdded(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logTastedAdded, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logTastedRemoved(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logTastedRemoved, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logDrinkViewed(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logDrinkViewed, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logBreweryViewed(String? breweryName) =>
+      (super.noSuchMethod(
+            Invocation.method(#logBreweryViewed, [breweryName]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logStyleViewed(String? style) =>
+      (super.noSuchMethod(
+            Invocation.method(#logStyleViewed, [style]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logRatingGiven(_i7.Drink? drink, int? rating) =>
+      (super.noSuchMethod(
+            Invocation.method(#logRatingGiven, [drink, rating]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logDrinkShared(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logDrinkShared, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
   _i5.Future<void> logError(
@@ -316,42 +268,31 @@ class MockAnalyticsService extends _i1.Mock implements _i6.AnalyticsService {
     String? reason,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logError,
-          [
-            error,
-            stackTrace,
-          ],
-          {#reason: reason},
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+            Invocation.method(
+              #logError,
+              [error, stackTrace],
+              {#reason: reason},
+            ),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setUserProperty(
-    String? name,
-    String? value,
-  ) =>
+  _i5.Future<void> setUserProperty(String? name, String? value) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setUserProperty,
-          [
-            name,
-            value,
-          ],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+            Invocation.method(#setUserProperty, [name, value]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setUserId(String? userId) => (super.noSuchMethod(
-        Invocation.method(
-          #setUserId,
-          [userId],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+  _i5.Future<void> setUserId(String? userId) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserId, [userId]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
 }

--- a/test/domain/services/drink_filter_service_test.dart
+++ b/test/domain/services/drink_filter_service_test.dart
@@ -113,8 +113,10 @@ void main() {
       });
 
       test('filters drinks by multiple styles (OR logic)', () {
-        final result =
-            service.filterByStyles(testDrinks, {'IPA', 'Bitter'}).toList();
+        final result = service.filterByStyles(testDrinks, {
+          'IPA',
+          'Bitter',
+        }).toList();
         expect(result, hasLength(3));
         expect(
           result.every((d) => d.style == 'IPA' || d.style == 'Bitter'),
@@ -170,8 +172,9 @@ void main() {
         final result = service.filterByAvailability(testDrinks, true).toList();
         expect(result, hasLength(3));
         expect(
-          result.every((d) =>
-              d.availabilityStatus != AvailabilityStatus.notYetAvailable),
+          result.every(
+            (d) => d.availabilityStatus != AvailabilityStatus.notYetAvailable,
+          ),
           isTrue,
         );
       });
@@ -273,8 +276,9 @@ void main() {
       });
 
       test('excludes drinks that contain a selected allergen', () {
-        final result = service.filterByExcludedAllergens(
-            [glutenDrink, cleanDrink], {'gluten'}).toList();
+        final result = service
+            .filterByExcludedAllergens([glutenDrink, cleanDrink], {'gluten'})
+            .toList();
         expect(result, hasLength(1));
         expect(result[0].name, equals('Clean'));
       });
@@ -292,8 +296,9 @@ void main() {
           producer: testDrinks[0].producer,
           festivalId: 'test',
         );
-        final result = service.filterByExcludedAllergens(
-            [zeroDrink, glutenDrink], {'gluten'}).toList();
+        final result = service
+            .filterByExcludedAllergens([zeroDrink, glutenDrink], {'gluten'})
+            .toList();
         expect(result, hasLength(1));
         expect(result[0].name, equals('Zero'));
       });
@@ -310,16 +315,19 @@ void main() {
           producer: testDrinks[0].producer,
           festivalId: 'test',
         );
-        final result = service.filterByExcludedAllergens(
-            [noDrink, glutenDrink], {'gluten'}).toList();
+        final result = service
+            .filterByExcludedAllergens([noDrink, glutenDrink], {'gluten'})
+            .toList();
         expect(result, hasLength(1));
         expect(result[0].name, equals('NoKey'));
       });
 
       test('multiple excluded allergens are ANDed', () {
         final drinks = [glutenDrink, sulphiteDrink, bothDrink, cleanDrink];
-        final result = service.filterByExcludedAllergens(
-            drinks, {'gluten', 'sulphites'}).toList();
+        final result = service.filterByExcludedAllergens(drinks, {
+          'gluten',
+          'sulphites',
+        }).toList();
         expect(result, hasLength(1));
         expect(result[0].name, equals('Clean'));
       });
@@ -362,15 +370,18 @@ void main() {
       });
 
       test('returns empty list when no matches found', () {
-        final result =
-            service.filterBySearch(testDrinks, 'nonexistent').toList();
+        final result = service
+            .filterBySearch(testDrinks, 'nonexistent')
+            .toList();
         expect(result, isEmpty);
       });
 
       test('searches across multiple fields', () {
         final result = service.filterBySearch(testDrinks, 'sweet').toList();
         expect(
-            result, hasLength(1)); // "Sweet Cider" has sweet in name and notes
+          result,
+          hasLength(1),
+        ); // "Sweet Cider" has sweet in name and notes
       });
     });
 
@@ -397,10 +408,7 @@ void main() {
       });
 
       test('applies only category filter', () {
-        final result = service.filterDrinks(
-          testDrinks,
-          category: 'cider',
-        );
+        final result = service.filterDrinks(testDrinks, category: 'cider');
         expect(result, hasLength(2));
         expect(result.every((d) => d.category == 'cider'), isTrue);
       });

--- a/test/domain/services/drink_sort_service_test.dart
+++ b/test/domain/services/drink_sort_service_test.dart
@@ -82,8 +82,10 @@ void main() {
 
     group('sortByNameAsc', () {
       test('sorts drinks by name A-Z', () {
-        final result =
-            service.sortDrinks(List.from(testDrinks), DrinkSort.nameAsc);
+        final result = service.sortDrinks(
+          List.from(testDrinks),
+          DrinkSort.nameAsc,
+        );
         expect(result[0].name, equals('Alpha Ale'));
         expect(result[1].name, equals('Bravo Bitter'));
         expect(result[2].name, equals('Charlie Beer'));
@@ -109,8 +111,10 @@ void main() {
 
     group('sortByNameDesc', () {
       test('sorts drinks by name Z-A', () {
-        final result =
-            service.sortDrinks(List.from(testDrinks), DrinkSort.nameDesc);
+        final result = service.sortDrinks(
+          List.from(testDrinks),
+          DrinkSort.nameDesc,
+        );
         expect(result[0].name, equals('Echo Lager'));
         expect(result[1].name, equals('Delta Strong'));
         expect(result[2].name, equals('Charlie Beer'));
@@ -121,8 +125,10 @@ void main() {
 
     group('sortByAbvHigh', () {
       test('sorts drinks by ABV highest to lowest', () {
-        final result =
-            service.sortDrinks(List.from(testDrinks), DrinkSort.abvHigh);
+        final result = service.sortDrinks(
+          List.from(testDrinks),
+          DrinkSort.abvHigh,
+        );
         expect(result[0].abv, equals(7.2)); // Delta Strong
         expect(result[1].abv, equals(5.5)); // Charlie Beer
         expect(result[2].abv, equals(4.5)); // Echo Lager
@@ -133,8 +139,10 @@ void main() {
 
     group('sortByAbvLow', () {
       test('sorts drinks by ABV lowest to highest', () {
-        final result =
-            service.sortDrinks(List.from(testDrinks), DrinkSort.abvLow);
+        final result = service.sortDrinks(
+          List.from(testDrinks),
+          DrinkSort.abvLow,
+        );
         expect(result[0].abv, equals(3.8)); // Bravo Bitter
         expect(result[1].abv, equals(4.2)); // Alpha Ale
         expect(result[2].abv, equals(4.5)); // Echo Lager
@@ -145,8 +153,10 @@ void main() {
 
     group('sortByBrewery', () {
       test('sorts drinks by brewery name alphabetically', () {
-        final result =
-            service.sortDrinks(List.from(testDrinks), DrinkSort.brewery);
+        final result = service.sortDrinks(
+          List.from(testDrinks),
+          DrinkSort.brewery,
+        );
         // Alpha Brewery comes before Zeta Brewery
         expect(result[0].breweryName, equals('Alpha Brewery'));
         expect(result[1].breweryName, equals('Alpha Brewery'));
@@ -158,8 +168,10 @@ void main() {
 
     group('sortByStyle', () {
       test('sorts drinks by style alphabetically', () {
-        final result =
-            service.sortDrinks(List.from(testDrinks), DrinkSort.style);
+        final result = service.sortDrinks(
+          List.from(testDrinks),
+          DrinkSort.style,
+        );
         // Empty string (no style) comes first, then Bitter, IPA, Stout
         expect(result[0].style, isNull); // Echo Lager
         expect(result[1].style, equals('Bitter'));
@@ -169,8 +181,10 @@ void main() {
       });
 
       test('handles drinks without style', () {
-        final result =
-            service.sortDrinks(List.from(testDrinks), DrinkSort.style);
+        final result = service.sortDrinks(
+          List.from(testDrinks),
+          DrinkSort.style,
+        );
         // Drinks without style should be sorted to the beginning
         expect(result[0].name, equals('Echo Lager'));
       });

--- a/test/drink_card_test.dart
+++ b/test/drink_card_test.dart
@@ -56,15 +56,17 @@ void main() {
       expect(find.text('Test IPA'), findsOneWidget);
     });
 
-    testWidgets('displays brewery name and location',
-        (WidgetTester tester) async {
+    testWidgets('displays brewery name and location', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget(drink: testDrink));
 
       expect(find.text('Test Brewery • Cambridge'), findsOneWidget);
     });
 
-    testWidgets('displays brewery name only when location is empty',
-        (WidgetTester tester) async {
+    testWidgets('displays brewery name only when location is empty', (
+      WidgetTester tester,
+    ) async {
       final producerNoLocation = Producer.fromJson({
         'id': 'brewery-2',
         'name': 'Another Brewery',
@@ -102,15 +104,17 @@ void main() {
       expect(find.text('Cask'), findsOneWidget);
     });
 
-    testWidgets('displays availability status when present',
-        (WidgetTester tester) async {
+    testWidgets('displays availability status when present', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget(drink: testDrink));
 
       expect(find.text('Available'), findsOneWidget);
     });
 
-    testWidgets('shows favorite icon as outlined when not favorite',
-        (WidgetTester tester) async {
+    testWidgets('shows favorite icon as outlined when not favorite', (
+      WidgetTester tester,
+    ) async {
       testDrink.isFavorite = false;
       await tester.pumpWidget(createTestWidget(drink: testDrink));
 
@@ -118,8 +122,9 @@ void main() {
       expect(find.byIcon(Icons.favorite), findsNothing);
     });
 
-    testWidgets('shows favorite icon as filled when favorite',
-        (WidgetTester tester) async {
+    testWidgets('shows favorite icon as filled when favorite', (
+      WidgetTester tester,
+    ) async {
       testDrink.isFavorite = true;
       await tester.pumpWidget(createTestWidget(drink: testDrink));
 
@@ -128,10 +133,9 @@ void main() {
 
     testWidgets('calls onTap when card is tapped', (WidgetTester tester) async {
       bool tapped = false;
-      await tester.pumpWidget(createTestWidget(
-        drink: testDrink,
-        onTap: () => tapped = true,
-      ));
+      await tester.pumpWidget(
+        createTestWidget(drink: testDrink, onTap: () => tapped = true),
+      );
 
       await tester.tap(find.byType(Card));
       await tester.pumpAndSettle();
@@ -139,13 +143,16 @@ void main() {
       expect(tapped, isTrue);
     });
 
-    testWidgets('calls onFavoriteTap when favorite icon is tapped',
-        (WidgetTester tester) async {
+    testWidgets('calls onFavoriteTap when favorite icon is tapped', (
+      WidgetTester tester,
+    ) async {
       bool favoriteTapped = false;
-      await tester.pumpWidget(createTestWidget(
-        drink: testDrink,
-        onFavoriteTap: () => favoriteTapped = true,
-      ));
+      await tester.pumpWidget(
+        createTestWidget(
+          drink: testDrink,
+          onFavoriteTap: () => favoriteTapped = true,
+        ),
+      );
 
       await tester.tap(find.byIcon(Icons.favorite_border));
       await tester.pumpAndSettle();
@@ -153,8 +160,9 @@ void main() {
       expect(favoriteTapped, isTrue);
     });
 
-    testWidgets('does not show style chip when style is null',
-        (WidgetTester tester) async {
+    testWidgets('does not show style chip when style is null', (
+      WidgetTester tester,
+    ) async {
       final productNoStyle = Product.fromJson({
         'id': 'drink-2',
         'name': 'Basic Beer',
@@ -176,8 +184,9 @@ void main() {
       expect(find.text('Cask'), findsOneWidget);
     });
 
-    testWidgets('shows low availability chip correctly',
-        (WidgetTester tester) async {
+    testWidgets('shows low availability chip correctly', (
+      WidgetTester tester,
+    ) async {
       final productLow = Product.fromJson({
         'id': 'drink-3',
         'name': 'Low Stock Beer',
@@ -219,8 +228,9 @@ void main() {
       expect(find.text('Sold Out'), findsOneWidget);
     });
 
-    testWidgets('handles drink without availability status',
-        (WidgetTester tester) async {
+    testWidgets('handles drink without availability status', (
+      WidgetTester tester,
+    ) async {
       final productNoStatus = Product.fromJson({
         'id': 'drink-5',
         'name': 'No Status Beer',
@@ -243,8 +253,9 @@ void main() {
       expect(find.text('Sold Out'), findsNothing);
     });
 
-    testWidgets('formats dispense method with capital first letter',
-        (WidgetTester tester) async {
+    testWidgets('formats dispense method with capital first letter', (
+      WidgetTester tester,
+    ) async {
       final productKeg = Product.fromJson({
         'id': 'drink-6',
         'name': 'Keg Beer',
@@ -276,7 +287,10 @@ void main() {
         'abv': '4.0',
       });
       return Drink(
-          product: product, producer: testProducer, festivalId: 'cbf2025');
+        product: product,
+        producer: testProducer,
+        festivalId: 'cbf2025',
+      );
     }
 
     Color? accentBorderColor(WidgetTester tester) {
@@ -294,53 +308,64 @@ void main() {
     }
 
     testWidgets('cider uses green accent', (WidgetTester tester) async {
-      await tester
-          .pumpWidget(createTestWidget(drink: drinkWithCategory('cider')));
+      await tester.pumpWidget(
+        createTestWidget(drink: drinkWithCategory('cider')),
+      );
       expect(accentBorderColor(tester), equals(const Color(0xFF22C55E)));
     });
 
     testWidgets('perry uses lime accent', (WidgetTester tester) async {
-      await tester
-          .pumpWidget(createTestWidget(drink: drinkWithCategory('perry')));
+      await tester.pumpWidget(
+        createTestWidget(drink: drinkWithCategory('perry')),
+      );
       expect(accentBorderColor(tester), equals(const Color(0xFF84CC16)));
     });
 
     testWidgets('mead uses gold accent', (WidgetTester tester) async {
-      await tester
-          .pumpWidget(createTestWidget(drink: drinkWithCategory('mead')));
+      await tester.pumpWidget(
+        createTestWidget(drink: drinkWithCategory('mead')),
+      );
       expect(accentBorderColor(tester), equals(const Color(0xFFD97706)));
     });
 
     testWidgets('wine uses purple accent', (WidgetTester tester) async {
-      await tester
-          .pumpWidget(createTestWidget(drink: drinkWithCategory('wine')));
+      await tester.pumpWidget(
+        createTestWidget(drink: drinkWithCategory('wine')),
+      );
       expect(accentBorderColor(tester), equals(const Color(0xFF9333EA)));
     });
 
-    testWidgets('international-beer uses red accent',
-        (WidgetTester tester) async {
+    testWidgets('international-beer uses red accent', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
-          createTestWidget(drink: drinkWithCategory('international-beer')));
+        createTestWidget(drink: drinkWithCategory('international-beer')),
+      );
       expect(accentBorderColor(tester), equals(const Color(0xFFEF4444)));
     });
 
     testWidgets('low-no uses cyan accent', (WidgetTester tester) async {
-      await tester
-          .pumpWidget(createTestWidget(drink: drinkWithCategory('low-no')));
+      await tester.pumpWidget(
+        createTestWidget(drink: drinkWithCategory('low-no')),
+      );
       expect(accentBorderColor(tester), equals(const Color(0xFF06B6D4)));
     });
 
-    testWidgets('apple-juice uses apple-green accent',
-        (WidgetTester tester) async {
+    testWidgets('apple-juice uses apple-green accent', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
-          createTestWidget(drink: drinkWithCategory('apple-juice')));
+        createTestWidget(drink: drinkWithCategory('apple-juice')),
+      );
       expect(accentBorderColor(tester), equals(const Color(0xFF65A30D)));
     });
 
-    testWidgets('unknown category uses navy fallback accent',
-        (WidgetTester tester) async {
+    testWidgets('unknown category uses navy fallback accent', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
-          createTestWidget(drink: drinkWithCategory('unknown-type')));
+        createTestWidget(drink: drinkWithCategory('unknown-type')),
+      );
       expect(accentBorderColor(tester), equals(const Color(0xFF2B3170)));
     });
   });

--- a/test/drink_detail_screen_screenshot_test.dart
+++ b/test/drink_detail_screen_screenshot_test.dart
@@ -47,8 +47,9 @@ void main() {
           baseUrl: 'https://data.cambeerfestival.app',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
       provider = BeerProvider(
         drinkRepository: mockDrinkRepository,
         festivalRepository: mockFestivalRepository,
@@ -78,8 +79,9 @@ void main() {
       );
     }
 
-    testWidgets('DrinkDetailScreen with long drink name - light theme',
-        (WidgetTester tester) async {
+    testWidgets('DrinkDetailScreen with long drink name - light theme', (
+      WidgetTester tester,
+    ) async {
       // Create a drink with a very long name to demonstrate the issue
       const productLongName = Product(
         id: 'drink1',
@@ -93,10 +95,14 @@ void main() {
       );
 
       final drinkLongName = Drink(
-          product: productLongName, producer: producer, festivalId: 'cbf2025');
+        product: productLongName,
+        producer: producer,
+        festivalId: 'cbf2025',
+      );
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drinkLongName]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drinkLongName]);
       await provider.loadDrinks();
 
       // Set a typical mobile screen size
@@ -112,8 +118,9 @@ void main() {
       );
     });
 
-    testWidgets('DrinkDetailScreen with medium drink name - light theme',
-        (WidgetTester tester) async {
+    testWidgets('DrinkDetailScreen with medium drink name - light theme', (
+      WidgetTester tester,
+    ) async {
       const productMediumName = Product(
         id: 'drink2',
         name: 'Golden Crown IPA',
@@ -125,12 +132,14 @@ void main() {
       );
 
       final drinkMediumName = Drink(
-          product: productMediumName,
-          producer: producer,
-          festivalId: 'cbf2025');
+        product: productMediumName,
+        producer: producer,
+        festivalId: 'cbf2025',
+      );
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drinkMediumName]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drinkMediumName]);
       await provider.loadDrinks();
 
       // Set a typical mobile screen size

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -46,8 +46,11 @@ void main() {
       allergens: {'gluten': 1, 'sulphites': 1},
     );
 
-    final drink =
-        Drink(product: product, producer: producer, festivalId: 'cbf2025');
+    final drink = Drink(
+      product: product,
+      producer: producer,
+      festivalId: 'cbf2025',
+    );
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -63,8 +66,9 @@ void main() {
           baseUrl: 'https://data.cambeerfestival.app',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
 
       provider = BeerProvider(
@@ -97,11 +101,12 @@ void main() {
             path: '/cbf2025/drink/:category/:drinkId',
             builder: (context, state) =>
                 ChangeNotifierProvider<BeerProvider>.value(
-              value: provider,
-              child: DrinkDetailScreen(
-                  festivalId: 'cbf2025',
-                  drinkId: state.pathParameters['drinkId']!),
-            ),
+                  value: provider,
+                  child: DrinkDetailScreen(
+                    festivalId: 'cbf2025',
+                    drinkId: state.pathParameters['drinkId']!,
+                  ),
+                ),
           ),
           GoRoute(
             path: '/cbf2025/brewery/:breweryId',
@@ -118,8 +123,9 @@ void main() {
       return MaterialApp.router(routerConfig: router);
     }
 
-    testWidgets('displays drink not found when drink does not exist',
-        (WidgetTester tester) async {
+    testWidgets('displays drink not found when drink does not exist', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget('nonexistent'));
       await tester.pumpAndSettle();
 
@@ -127,8 +133,9 @@ void main() {
       expect(find.text('This drink could not be found.'), findsOneWidget);
     });
 
-    testWidgets('displays drink information when drink exists',
-        (WidgetTester tester) async {
+    testWidgets('displays drink information when drink exists', (
+      WidgetTester tester,
+    ) async {
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -145,8 +152,9 @@ void main() {
     testWidgets('displays drink details chips', (WidgetTester tester) async {
       final semanticsHandle = tester.ensureSemantics();
       try {
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [drink]);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [drink]);
         await provider.loadDrinks();
 
         await tester.pumpWidget(createTestWidget('drink1'));
@@ -154,8 +162,10 @@ void main() {
 
         // New layout shows combined information in HeroInfoCard
         expect(find.textContaining('5.0%'), findsOneWidget);
-        expect(find.textContaining('IPA'),
-            findsWidgets); // Appears in HeroInfoCard and style chip
+        expect(
+          find.textContaining('IPA'),
+          findsWidgets,
+        ); // Appears in HeroInfoCard and style chip
         expect(find.textContaining('Cask'), findsOneWidget);
         expect(find.textContaining('Available at Main Bar'), findsOneWidget);
         expect(find.text('Vegan'), findsOneWidget);
@@ -165,8 +175,9 @@ void main() {
       }
     });
 
-    testWidgets('displays status text in chips when available',
-        (WidgetTester tester) async {
+    testWidgets('displays status text in chips when available', (
+      WidgetTester tester,
+    ) async {
       const productWithStatus = Product(
         id: 'drink3',
         name: 'Status Beer',
@@ -177,11 +188,13 @@ void main() {
         statusText: 'Plenty remaining',
       );
       final drinkWithStatus = Drink(
-          product: productWithStatus,
-          producer: producer,
-          festivalId: 'cbf2025');
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drinkWithStatus]);
+        product: productWithStatus,
+        producer: producer,
+        festivalId: 'cbf2025',
+      );
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drinkWithStatus]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('drink3'));
@@ -191,8 +204,9 @@ void main() {
       expect(find.textContaining('Available at Main Bar'), findsOneWidget);
     });
 
-    testWidgets('does not display status chip when status text is null',
-        (WidgetTester tester) async {
+    testWidgets('does not display status chip when status text is null', (
+      WidgetTester tester,
+    ) async {
       const productNoStatus = Product(
         id: 'drink4',
         name: 'No Status Beer',
@@ -202,9 +216,13 @@ void main() {
         statusText: null,
       );
       final drinkNoStatus = Drink(
-          product: productNoStatus, producer: producer, festivalId: 'cbf2025');
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drinkNoStatus]);
+        product: productNoStatus,
+        producer: producer,
+        festivalId: 'cbf2025',
+      );
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drinkNoStatus]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('drink4'));
@@ -216,8 +234,9 @@ void main() {
       expect(find.text('Not yet available'), findsNothing);
     });
 
-    testWidgets('displays description when notes exist',
-        (WidgetTester tester) async {
+    testWidgets('displays description when notes exist', (
+      WidgetTester tester,
+    ) async {
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -258,8 +277,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Brewery'), findsOneWidget);
-      expect(find.byIcon(Icons.chevron_right),
-          findsNWidgets(2)); // Style chip + brewery card
+      expect(
+        find.byIcon(Icons.chevron_right),
+        findsNWidgets(2),
+      ); // Style chip + brewery card
     });
 
     testWidgets('has share button in app bar', (WidgetTester tester) async {
@@ -282,8 +303,9 @@ void main() {
       expect(find.byIcon(Icons.favorite_border), findsOneWidget);
     });
 
-    testWidgets('toggles favorite when favorite button is tapped',
-        (WidgetTester tester) async {
+    testWidgets('toggles favorite when favorite button is tapped', (
+      WidgetTester tester,
+    ) async {
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -295,8 +317,9 @@ void main() {
 
       // Mock toggleFavorite to properly toggle state
       final favorites = <String>{};
-      when(mockDrinkRepository.toggleFavorite(any, any))
-          .thenAnswer((invocation) async {
+      when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer((
+        invocation,
+      ) async {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
@@ -315,8 +338,9 @@ void main() {
       expect(find.byIcon(Icons.favorite), findsOneWidget);
     });
 
-    testWidgets('navigates to brewery screen when brewery card is tapped',
-        (WidgetTester tester) async {
+    testWidgets('navigates to brewery screen when brewery card is tapped', (
+      WidgetTester tester,
+    ) async {
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -336,8 +360,9 @@ void main() {
       expect(find.text('Brewery Screen'), findsOneWidget);
     });
 
-    testWidgets('navigates to style screen when style chip is tapped',
-        (WidgetTester tester) async {
+    testWidgets('navigates to style screen when style chip is tapped', (
+      WidgetTester tester,
+    ) async {
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -354,8 +379,9 @@ void main() {
       expect(find.text('Style Screen'), findsOneWidget);
     });
 
-    testWidgets('does not display description section when notes are null',
-        (WidgetTester tester) async {
+    testWidgets('does not display description section when notes are null', (
+      WidgetTester tester,
+    ) async {
       const productNoNotes = Product(
         id: 'drink2',
         name: 'Simple Beer',
@@ -365,9 +391,13 @@ void main() {
         notes: null,
       );
       final drinkNoNotes = Drink(
-          product: productNoNotes, producer: producer, festivalId: 'cbf2025');
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drinkNoNotes]);
+        product: productNoNotes,
+        producer: producer,
+        festivalId: 'cbf2025',
+      );
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drinkNoNotes]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('drink2'));
@@ -377,8 +407,9 @@ void main() {
       expect(find.text('Simple Beer'), findsWidgets);
     });
 
-    testWidgets('displays rating value when drink has rating',
-        (WidgetTester tester) async {
+    testWidgets('displays rating value when drink has rating', (
+      WidgetTester tester,
+    ) async {
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -390,8 +421,9 @@ void main() {
       expect(find.text('4/5'), findsOneWidget);
     });
 
-    testWidgets('does not display rating value when drink has no rating',
-        (WidgetTester tester) async {
+    testWidgets('does not display rating value when drink has no rating', (
+      WidgetTester tester,
+    ) async {
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -403,8 +435,9 @@ void main() {
       expect(find.textContaining('/5'), findsNothing);
     });
 
-    testWidgets('updates rating when set through provider',
-        (WidgetTester tester) async {
+    testWidgets('updates rating when set through provider', (
+      WidgetTester tester,
+    ) async {
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
 
@@ -422,8 +455,9 @@ void main() {
     });
 
     group('Similar Drinks Section', () {
-      testWidgets('displays similar drinks section when similar drinks exist',
-          (WidgetTester tester) async {
+      testWidgets('displays similar drinks section when similar drinks exist', (
+        WidgetTester tester,
+      ) async {
         // Create multiple drinks with similar characteristics
         const producer1 = Producer(
           id: 'brewery1',
@@ -467,16 +501,24 @@ void main() {
         );
 
         final drink1 = Drink(
-            product: product1, producer: producer1, festivalId: 'cbf2025');
+          product: product1,
+          producer: producer1,
+          festivalId: 'cbf2025',
+        );
         final drink2 = Drink(
-            product: product2, producer: producer2, festivalId: 'cbf2025');
+          product: product2,
+          producer: producer2,
+          festivalId: 'cbf2025',
+        );
         final drink3 = Drink(
-            product: product3,
-            producer: producer1,
-            festivalId: 'cbf2025'); // Same brewery
+          product: product3,
+          producer: producer1,
+          festivalId: 'cbf2025',
+        ); // Same brewery
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [drink1, drink2, drink3]);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [drink1, drink2, drink3]);
         await provider.loadDrinks();
 
         await tester.pumpWidget(createTestWidget('drink1'));
@@ -499,40 +541,46 @@ void main() {
       });
 
       testWidgets(
-          'does not display similar drinks section when no similar drinks exist',
-          (WidgetTester tester) async {
-        const producer1 = Producer(
-          id: 'brewery1',
-          name: 'Test Brewery',
-          location: 'Cambridge, UK',
-          products: [],
-        );
+        'does not display similar drinks section when no similar drinks exist',
+        (WidgetTester tester) async {
+          const producer1 = Producer(
+            id: 'brewery1',
+            name: 'Test Brewery',
+            location: 'Cambridge, UK',
+            products: [],
+          );
 
-        const product1 = Product(
-          id: 'drink1',
-          name: 'Unique Beer',
-          abv: 5.0,
-          category: 'beer',
-          dispense: 'cask',
-          style: 'Unique Style',
-        );
+          const product1 = Product(
+            id: 'drink1',
+            name: 'Unique Beer',
+            abv: 5.0,
+            category: 'beer',
+            dispense: 'cask',
+            style: 'Unique Style',
+          );
 
-        final drink1 = Drink(
-            product: product1, producer: producer1, festivalId: 'cbf2025');
+          final drink1 = Drink(
+            product: product1,
+            producer: producer1,
+            festivalId: 'cbf2025',
+          );
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [drink1]);
-        await provider.loadDrinks();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => [drink1]);
+          await provider.loadDrinks();
 
-        await tester.pumpWidget(createTestWidget('drink1'));
-        await tester.pumpAndSettle();
+          await tester.pumpWidget(createTestWidget('drink1'));
+          await tester.pumpAndSettle();
 
-        // Should not show Similar Drinks section when no similar drinks
-        expect(find.text('Similar Drinks'), findsNothing);
-      });
+          // Should not show Similar Drinks section when no similar drinks
+          expect(find.text('Similar Drinks'), findsNothing);
+        },
+      );
 
-      testWidgets('similar drinks are tappable and navigate correctly',
-          (WidgetTester tester) async {
+      testWidgets('similar drinks are tappable and navigate correctly', (
+        WidgetTester tester,
+      ) async {
         const producer1 = Producer(
           id: 'brewery1',
           name: 'Test Brewery',
@@ -559,12 +607,19 @@ void main() {
         );
 
         final drink1 = Drink(
-            product: product1, producer: producer1, festivalId: 'cbf2025');
+          product: product1,
+          producer: producer1,
+          festivalId: 'cbf2025',
+        );
         final drink2 = Drink(
-            product: product2, producer: producer1, festivalId: 'cbf2025');
+          product: product2,
+          producer: producer1,
+          festivalId: 'cbf2025',
+        );
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [drink1, drink2]);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [drink1, drink2]);
         await provider.loadDrinks();
 
         await tester.pumpWidget(createTestWidget('drink1'));
@@ -581,8 +636,9 @@ void main() {
         // in the widget tree. This is tested in E2E tests instead of unit tests.
       });
 
-      testWidgets('similar drinks based on same style and close ABV',
-          (WidgetTester tester) async {
+      testWidgets('similar drinks based on same style and close ABV', (
+        WidgetTester tester,
+      ) async {
         const producer1 = Producer(
           id: 'brewery1',
           name: 'Test Brewery',
@@ -634,16 +690,29 @@ void main() {
         );
 
         final drink1 = Drink(
-            product: product1, producer: producer1, festivalId: 'cbf2025');
+          product: product1,
+          producer: producer1,
+          festivalId: 'cbf2025',
+        );
         final drink2 = Drink(
-            product: product2, producer: producer2, festivalId: 'cbf2025');
+          product: product2,
+          producer: producer2,
+          festivalId: 'cbf2025',
+        );
         final drink3 = Drink(
-            product: product3, producer: producer2, festivalId: 'cbf2025');
+          product: product3,
+          producer: producer2,
+          festivalId: 'cbf2025',
+        );
         final drink4 = Drink(
-            product: product4, producer: producer2, festivalId: 'cbf2025');
+          product: product4,
+          producer: producer2,
+          festivalId: 'cbf2025',
+        );
 
-        when(mockDrinkRepository.getDrinks(any))
-            .thenAnswer((_) async => [drink1, drink2, drink3, drink4]);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [drink1, drink2, drink3, drink4]);
         await provider.loadDrinks();
 
         await tester.pumpWidget(createTestWidget('drink1'));

--- a/test/drinks_screen_debounce_test.dart
+++ b/test/drinks_screen_debounce_test.dart
@@ -88,12 +88,15 @@ void main() {
         baseUrl: 'https://example.com',
         version: '1.0.0',
       );
-      when(mockFestivalRepository.getFestivals())
-          .thenAnswer((_) async => festivalsResponse);
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => testDrinks);
+      when(
+        mockFestivalRepository.getFestivals(),
+      ).thenAnswer((_) async => festivalsResponse);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => testDrinks);
 
       provider = BeerProvider(
         drinkRepository: mockDrinkRepository,
@@ -111,9 +114,7 @@ void main() {
     Widget createTestWidget() {
       return ChangeNotifierProvider<BeerProvider>.value(
         value: provider,
-        child: const MaterialApp(
-          home: DrinksScreen(festivalId: 'cbf2025'),
-        ),
+        child: const MaterialApp(home: DrinksScreen(festivalId: 'cbf2025')),
       );
     }
 
@@ -124,8 +125,9 @@ void main() {
       semantics.dispose();
     }
 
-    testWidgets('does not log analytics before debounce window elapses',
-        (WidgetTester tester) async {
+    testWidgets('does not log analytics before debounce window elapses', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
       await openSearchBar(tester);
@@ -137,8 +139,9 @@ void main() {
       verifyNever(mockAnalyticsService.logSearch(any));
     });
 
-    testWidgets('logs analytics once after debounce window elapses',
-        (WidgetTester tester) async {
+    testWidgets('logs analytics once after debounce window elapses', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
       await openSearchBar(tester);
@@ -150,8 +153,9 @@ void main() {
       verify(mockAnalyticsService.logSearch('IPA')).called(1);
     });
 
-    testWidgets('each keystroke resets the debounce window',
-        (WidgetTester tester) async {
+    testWidgets('each keystroke resets the debounce window', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
       await openSearchBar(tester);

--- a/test/drinks_screen_refresh_status_test.dart
+++ b/test/drinks_screen_refresh_status_test.dart
@@ -57,10 +57,12 @@ void main() {
           version: '1.0.0',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => testDrinks);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => testDrinks);
 
       provider = BeerProvider(
         drinkRepository: mockDrinkRepository,
@@ -76,21 +78,21 @@ void main() {
     Widget createTestWidget() {
       return ChangeNotifierProvider<BeerProvider>.value(
         value: provider,
-        child: const MaterialApp(
-          home: DrinksScreen(festivalId: 'cbf2025'),
-        ),
+        child: const MaterialApp(home: DrinksScreen(festivalId: 'cbf2025')),
       );
     }
 
-    testWidgets('shows a dismissible notice when a refresh fails with cache',
-        (tester) async {
+    testWidgets('shows a dismissible notice when a refresh fails with cache', (
+      tester,
+    ) async {
       // bySemanticsLabel requires an active semantics tree; dispose explicitly
       // before the test ends so Flutter's end-of-test verifier is happy.
       final semantics = tester.ensureSemantics();
       try {
         // A refresh fails while cached drinks remain on screen.
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(TimeoutException('offline'));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(TimeoutException('offline'));
         await provider.loadDrinks();
 
         await tester.pumpWidget(createTestWidget());
@@ -114,12 +116,14 @@ void main() {
       }
     });
 
-    testWidgets('shows a progress bar while refreshing with data on screen',
-        (tester) async {
+    testWidgets('shows a progress bar while refreshing with data on screen', (
+      tester,
+    ) async {
       // Hold the network refresh open so isRefreshing stays true.
       final pending = Completer<List<Drink>>();
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) => pending.future);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) => pending.future);
 
       final future = provider.loadDrinks();
 

--- a/test/drinks_screen_style_filter_test.dart
+++ b/test/drinks_screen_style_filter_test.dart
@@ -92,13 +92,16 @@ void main() {
         baseUrl: 'https://example.com',
         version: '1.0.0',
       );
-      when(mockFestivalRepository.getFestivals())
-          .thenAnswer((_) async => festivalsResponse);
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getFestivals(),
+      ).thenAnswer((_) async => festivalsResponse);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => testDrinks);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => testDrinks);
 
       provider = BeerProvider(
         drinkRepository: mockDrinkRepository,
@@ -116,9 +119,7 @@ void main() {
     Widget createTestWidget() {
       return ChangeNotifierProvider<BeerProvider>.value(
         value: provider,
-        child: const MaterialApp(
-          home: DrinksScreen(festivalId: 'cbf2025'),
-        ),
+        child: const MaterialApp(home: DrinksScreen(festivalId: 'cbf2025')),
       );
     }
 
@@ -130,9 +131,9 @@ void main() {
             path: '/cbf2025/drinks',
             builder: (context, state) =>
                 ChangeNotifierProvider<BeerProvider>.value(
-              value: provider,
-              child: const DrinksScreen(festivalId: 'cbf2025'),
-            ),
+                  value: provider,
+                  child: const DrinksScreen(festivalId: 'cbf2025'),
+                ),
           ),
           GoRoute(
             path: '/cbf2025/drink/:category/:drinkId',
@@ -144,8 +145,9 @@ void main() {
       return MaterialApp.router(routerConfig: router);
     }
 
-    testWidgets('navigates to drink detail when drink card is tapped',
-        (WidgetTester tester) async {
+    testWidgets('navigates to drink detail when drink card is tapped', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidgetWithRouter());
       await tester.pumpAndSettle();
 
@@ -159,8 +161,9 @@ void main() {
       expect(find.text('Drink Detail'), findsOneWidget);
     });
 
-    testWidgets('style filter button shows when styles are available',
-        (WidgetTester tester) async {
+    testWidgets('style filter button shows when styles are available', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
@@ -168,8 +171,9 @@ void main() {
       expect(find.text('Style'), findsOneWidget);
     });
 
-    testWidgets('style filter sheet opens when style button is tapped',
-        (WidgetTester tester) async {
+    testWidgets('style filter sheet opens when style button is tapped', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
@@ -184,8 +188,9 @@ void main() {
       expect(find.text('Stout (1)'), findsOneWidget);
     });
 
-    testWidgets('checkbox updates immediately when style is toggled',
-        (WidgetTester tester) async {
+    testWidgets('checkbox updates immediately when style is toggled', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
@@ -212,8 +217,9 @@ void main() {
       expect(provider.selectedStyles.contains('IPA'), true);
     });
 
-    testWidgets('multiple styles can be selected with checkboxes updating',
-        (WidgetTester tester) async {
+    testWidgets('multiple styles can be selected with checkboxes updating', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
@@ -251,8 +257,9 @@ void main() {
       expect(provider.selectedStyles.length, 2);
     });
 
-    testWidgets('unchecking a style updates checkbox immediately',
-        (WidgetTester tester) async {
+    testWidgets('unchecking a style updates checkbox immediately', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
@@ -281,8 +288,9 @@ void main() {
       expect(provider.selectedStyles.contains('IPA'), false);
     });
 
-    testWidgets('filter button shows selected style count',
-        (WidgetTester tester) async {
+    testWidgets('filter button shows selected style count', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
@@ -321,42 +329,44 @@ void main() {
     });
 
     testWidgets(
-        'clear button clears all selected styles and updates checkboxes',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget());
-      await tester.pumpAndSettle();
+      'clear button clears all selected styles and updates checkboxes',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
 
-      // Open style filter and select multiple styles
-      await tester.tap(find.text('Style'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(CheckboxListTile, 'IPA (1)'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(CheckboxListTile, 'Bitter (1)'));
-      await tester.pumpAndSettle();
+        // Open style filter and select multiple styles
+        await tester.tap(find.text('Style'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.widgetWithText(CheckboxListTile, 'IPA (1)'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.widgetWithText(CheckboxListTile, 'Bitter (1)'));
+        await tester.pumpAndSettle();
 
-      // Verify both are checked
-      expect(provider.selectedStyles.length, 2);
+        // Verify both are checked
+        expect(provider.selectedStyles.length, 2);
 
-      // Tap clear button
-      await tester.tap(find.text('Clear'));
-      await tester.pumpAndSettle();
+        // Tap clear button
+        await tester.tap(find.text('Clear'));
+        await tester.pumpAndSettle();
 
-      // Verify all checkboxes are unchecked
-      final ipaCheckbox = tester.widget<CheckboxListTile>(
-        find.widgetWithText(CheckboxListTile, 'IPA (1)'),
-      );
-      final bitterCheckbox = tester.widget<CheckboxListTile>(
-        find.widgetWithText(CheckboxListTile, 'Bitter (1)'),
-      );
-      expect(ipaCheckbox.value, false);
-      expect(bitterCheckbox.value, false);
+        // Verify all checkboxes are unchecked
+        final ipaCheckbox = tester.widget<CheckboxListTile>(
+          find.widgetWithText(CheckboxListTile, 'IPA (1)'),
+        );
+        final bitterCheckbox = tester.widget<CheckboxListTile>(
+          find.widgetWithText(CheckboxListTile, 'Bitter (1)'),
+        );
+        expect(ipaCheckbox.value, false);
+        expect(bitterCheckbox.value, false);
 
-      // Verify provider state
-      expect(provider.selectedStyles.isEmpty, true);
-    });
+        // Verify provider state
+        expect(provider.selectedStyles.isEmpty, true);
+      },
+    );
 
-    testWidgets('styles remain in alphabetical order when selected',
-        (WidgetTester tester) async {
+    testWidgets('styles remain in alphabetical order when selected', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
@@ -385,8 +395,9 @@ void main() {
       expect(thirdCheckbox.value, true);
     });
 
-    testWidgets('styles with non-ASCII characters sort correctly',
-        (WidgetTester tester) async {
+    testWidgets('styles with non-ASCII characters sort correctly', (
+      WidgetTester tester,
+    ) async {
       // Override the test drinks to include non-ASCII characters
       final drinksWithAccents = [
         Drink(
@@ -466,8 +477,9 @@ void main() {
         analyticsService: mockAnalyticsService,
       );
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => drinksWithAccents);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => drinksWithAccents);
 
       await accentProvider.initialize();
       await accentProvider.loadDrinks();
@@ -475,9 +487,7 @@ void main() {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: accentProvider,
-          child: const MaterialApp(
-            home: DrinksScreen(festivalId: 'cbf2025'),
-          ),
+          child: const MaterialApp(home: DrinksScreen(festivalId: 'cbf2025')),
         ),
       );
       await tester.pumpAndSettle();
@@ -503,10 +513,16 @@ void main() {
       expect((fourthCheckbox.title as Text).data, 'Rosé (1)');
 
       // Verify the accented characters display correctly (not garbled)
-      expect((secondCheckbox.title as Text).data?.contains('é'), true,
-          reason: 'Café should display the é character correctly');
-      expect((fourthCheckbox.title as Text).data?.contains('é'), true,
-          reason: 'Rosé should display the é character correctly');
+      expect(
+        (secondCheckbox.title as Text).data?.contains('é'),
+        true,
+        reason: 'Café should display the é character correctly',
+      );
+      expect(
+        (fourthCheckbox.title as Text).data?.contains('é'),
+        true,
+        reason: 'Rosé should display the é character correctly',
+      );
 
       accentProvider.dispose();
     });
@@ -537,15 +553,18 @@ void main() {
           version: '1.0.0',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
     });
 
-    testWidgets('loading state shows barrel mascot image',
-        (WidgetTester tester) async {
+    testWidgets('loading state shows barrel mascot image', (
+      WidgetTester tester,
+    ) async {
       final completer = Completer<List<Drink>>();
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) => completer.future);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) => completer.future);
 
       final provider = BeerProvider(
         drinkRepository: mockDrinkRepository,
@@ -558,9 +577,7 @@ void main() {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: const MaterialApp(
-            home: DrinksScreen(festivalId: 'cbf2025'),
-          ),
+          child: const MaterialApp(home: DrinksScreen(festivalId: 'cbf2025')),
         ),
       );
       await tester.pump();
@@ -570,18 +587,23 @@ void main() {
         final asset = img.image;
         return asset is AssetImage && asset.assetName == 'assets/app_icon.png';
       });
-      expect(hasBarrelMascot, isTrue,
-          reason: 'Loading state should show barrel mascot');
+      expect(
+        hasBarrelMascot,
+        isTrue,
+        reason: 'Loading state should show barrel mascot',
+      );
 
       completer.complete([]);
       await tester.pumpAndSettle();
       provider.dispose();
     });
 
-    testWidgets('empty state shows barrel mascot image',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => <Drink>[]);
+    testWidgets('empty state shows barrel mascot image', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => <Drink>[]);
 
       final provider = BeerProvider(
         drinkRepository: mockDrinkRepository,
@@ -594,9 +616,7 @@ void main() {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: const MaterialApp(
-            home: DrinksScreen(festivalId: 'cbf2025'),
-          ),
+          child: const MaterialApp(home: DrinksScreen(festivalId: 'cbf2025')),
         ),
       );
       await tester.pumpAndSettle();
@@ -608,8 +628,11 @@ void main() {
         final asset = img.image;
         return asset is AssetImage && asset.assetName == 'assets/app_icon.png';
       });
-      expect(hasBarrelMascot, isTrue,
-          reason: 'Empty state should show barrel mascot');
+      expect(
+        hasBarrelMascot,
+        isTrue,
+        reason: 'Empty state should show barrel mascot',
+      );
 
       provider.dispose();
     });

--- a/test/environment_badge_test.dart
+++ b/test/environment_badge_test.dart
@@ -22,15 +22,14 @@ void main() {
       expect(find.text('Content'), findsOneWidget);
     });
 
-    testWidgets('badge shows environment name when provided',
-        (WidgetTester tester) async {
+    testWidgets('badge shows environment name when provided', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
             body: Stack(
-              children: [
-                EnvironmentBadge(environmentName: 'Staging'),
-              ],
+              children: [EnvironmentBadge(environmentName: 'Staging')],
             ),
           ),
         ),
@@ -41,17 +40,12 @@ void main() {
       expect(find.byIcon(Icons.science_outlined), findsOneWidget);
     });
 
-    testWidgets('badge is hidden in production (no environment name)',
-        (WidgetTester tester) async {
+    testWidgets('badge is hidden in production (no environment name)', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: Scaffold(
-            body: Stack(
-              children: [
-                EnvironmentBadge(),
-              ],
-            ),
-          ),
+          home: Scaffold(body: Stack(children: [EnvironmentBadge()])),
         ),
       );
 

--- a/test/environment_service_test.dart
+++ b/test/environment_service_test.dart
@@ -18,18 +18,23 @@ void main() {
   group('isProductionHost()', () {
     test('production custom domain → true', () {
       expect(
-          EnvironmentService.isProductionHost('cambeerfestival.app'), isTrue);
+        EnvironmentService.isProductionHost('cambeerfestival.app'),
+        isTrue,
+      );
     });
 
     test('staging custom domain → false', () {
-      expect(EnvironmentService.isProductionHost('staging.cambeerfestival.app'),
-          isFalse);
+      expect(
+        EnvironmentService.isProductionHost('staging.cambeerfestival.app'),
+        isFalse,
+      );
     });
 
     test('staging Cloudflare Pages subdomain → false', () {
       expect(
         EnvironmentService.isProductionHost(
-            'abc123.staging-cambeerfestival.pages.dev'),
+          'abc123.staging-cambeerfestival.pages.dev',
+        ),
         isFalse,
       );
     });
@@ -60,14 +65,18 @@ void main() {
       // Safe default: unknown hosts should not be treated as production
       // to avoid accidentally logging staging/test traffic.
       expect(
-          EnvironmentService.isProductionHost('mystery.example.com'), isFalse);
+        EnvironmentService.isProductionHost('mystery.example.com'),
+        isFalse,
+      );
     });
   });
 
   group('classifyHostname()', () {
     test('production custom domain → "production"', () {
-      expect(EnvironmentService.classifyHostname('cambeerfestival.app'),
-          equals('production'));
+      expect(
+        EnvironmentService.classifyHostname('cambeerfestival.app'),
+        equals('production'),
+      );
     });
 
     test('staging custom domain → "staging"', () {
@@ -80,7 +89,8 @@ void main() {
     test('staging Cloudflare Pages subdomain → "preview"', () {
       expect(
         EnvironmentService.classifyHostname(
-            'abc123.staging-cambeerfestival.pages.dev'),
+          'abc123.staging-cambeerfestival.pages.dev',
+        ),
         equals('preview'),
       );
     });
@@ -93,18 +103,24 @@ void main() {
     });
 
     test('localhost → "development"', () {
-      expect(EnvironmentService.classifyHostname('localhost'),
-          equals('development'));
+      expect(
+        EnvironmentService.classifyHostname('localhost'),
+        equals('development'),
+      );
     });
 
     test('loopback IP → "development"', () {
-      expect(EnvironmentService.classifyHostname('127.0.0.1'),
-          equals('development'));
+      expect(
+        EnvironmentService.classifyHostname('127.0.0.1'),
+        equals('development'),
+      );
     });
 
     test('unknown host → "unknown"', () {
-      expect(EnvironmentService.classifyHostname('mystery.example.com'),
-          equals('unknown'));
+      expect(
+        EnvironmentService.classifyHostname('mystery.example.com'),
+        equals('unknown'),
+      );
     });
   });
 }

--- a/test/info_chip_test.dart
+++ b/test/info_chip_test.dart
@@ -8,10 +8,7 @@ void main() {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
-            body: InfoChip(
-              label: 'Test Label',
-              icon: Icons.star,
-            ),
+            body: InfoChip(label: 'Test Label', icon: Icons.star),
           ),
         ),
       );
@@ -24,10 +21,7 @@ void main() {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
-            body: InfoChip(
-              label: 'Test',
-              icon: Icons.info,
-            ),
+            body: InfoChip(label: 'Test', icon: Icons.info),
           ),
         ),
       );

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -46,11 +46,13 @@ void main() {
           baseUrl: 'https://example.com',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => <Drink>[]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => <Drink>[]);
     });
 
     tearDown(() {
@@ -71,8 +73,9 @@ void main() {
       expect(find.byType(BeerFestivalHome), findsOneWidget);
     });
 
-    testWidgets('calls refreshIfStale when app resumes',
-        (WidgetTester tester) async {
+    testWidgets('calls refreshIfStale when app resumes', (
+      WidgetTester tester,
+    ) async {
       // Track if refreshIfStale is called by checking API calls
       var refreshCallCount = 0;
 
@@ -114,8 +117,9 @@ void main() {
       expect(refreshCallCount, 0);
     });
 
-    testWidgets('removes lifecycle observer on dispose',
-        (WidgetTester tester) async {
+    testWidgets('removes lifecycle observer on dispose', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
@@ -131,9 +135,7 @@ void main() {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: const MaterialApp(
-            home: Scaffold(body: Text('Other Screen')),
-          ),
+          child: const MaterialApp(home: Scaffold(body: Text('Other Screen'))),
         ),
       );
 
@@ -144,8 +146,9 @@ void main() {
       expect(find.text('Other Screen'), findsOneWidget);
     });
 
-    testWidgets('shows confirmation snackbar on first back at root',
-        (WidgetTester tester) async {
+    testWidgets('shows confirmation snackbar on first back at root', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
@@ -163,18 +166,20 @@ void main() {
       expect(find.text('Press back again to exit'), findsOneWidget);
     });
 
-    testWidgets('requests app exit on second back within confirmation window',
-        (WidgetTester tester) async {
+    testWidgets('requests app exit on second back within confirmation window', (
+      WidgetTester tester,
+    ) async {
       var systemNavigatorPopCalled = false;
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(SystemChannels.platform,
-              (methodCall) async {
-        if (methodCall.method == 'SystemNavigator.pop') {
-          systemNavigatorPopCalled = true;
-        }
-        return null;
-      });
+          .setMockMethodCallHandler(SystemChannels.platform, (
+            methodCall,
+          ) async {
+            if (methodCall.method == 'SystemNavigator.pop') {
+              systemNavigatorPopCalled = true;
+            }
+            return null;
+          });
 
       addTearDown(() {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
@@ -200,58 +205,61 @@ void main() {
     });
 
     testWidgets(
-        'does not exit when second back happens after confirmation window expires',
-        (WidgetTester tester) async {
-      var systemNavigatorPopCalled = false;
+      'does not exit when second back happens after confirmation window expires',
+      (WidgetTester tester) async {
+        var systemNavigatorPopCalled = false;
 
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(SystemChannels.platform,
-              (methodCall) async {
-        if (methodCall.method == 'SystemNavigator.pop') {
-          systemNavigatorPopCalled = true;
-        }
-        return null;
-      });
-
-      addTearDown(() {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(SystemChannels.platform, null);
-      });
+            .setMockMethodCallHandler(SystemChannels.platform, (
+              methodCall,
+            ) async {
+              if (methodCall.method == 'SystemNavigator.pop') {
+                systemNavigatorPopCalled = true;
+              }
+              return null;
+            });
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: const MaterialApp(
-            home: BeerFestivalHome(child: Scaffold(body: Text('Test'))),
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null);
+        });
+
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: const MaterialApp(
+              home: BeerFestivalHome(child: Scaffold(body: Text('Test'))),
+            ),
           ),
-        ),
-      );
+        );
 
-      await tester.binding.handlePopRoute();
-      await tester.pump();
-      expect(find.text('Press back again to exit'), findsOneWidget);
-      expect(systemNavigatorPopCalled, isFalse);
+        await tester.binding.handlePopRoute();
+        await tester.pump();
+        expect(find.text('Press back again to exit'), findsOneWidget);
+        expect(systemNavigatorPopCalled, isFalse);
 
-      // Pump sequence: the snackbar duration timer only starts after the enter
-      // animation completes (250 ms). A single large pump won't work because
-      // the timer starts in the first frame, not during elapse(). We need a
-      // frame to complete the enter animation first, then advance past the 2 s
-      // confirmation window, then two more frames for the exit animation and
-      // the resulting setState rebuild.
-      await tester.pump(const Duration(milliseconds: 300));
-      await tester.pump(const Duration(seconds: 3));
-      await tester.pump(const Duration(milliseconds: 250));
-      await tester.pump(const Duration(milliseconds: 250));
-      expect(find.text('Press back again to exit'), findsNothing);
-      await tester.binding.handlePopRoute();
-      await tester.pump();
+        // Pump sequence: the snackbar duration timer only starts after the enter
+        // animation completes (250 ms). A single large pump won't work because
+        // the timer starts in the first frame, not during elapse(). We need a
+        // frame to complete the enter animation first, then advance past the 2 s
+        // confirmation window, then two more frames for the exit animation and
+        // the resulting setState rebuild.
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(seconds: 3));
+        await tester.pump(const Duration(milliseconds: 250));
+        await tester.pump(const Duration(milliseconds: 250));
+        expect(find.text('Press back again to exit'), findsNothing);
+        await tester.binding.handlePopRoute();
+        await tester.pump();
 
-      expect(systemNavigatorPopCalled, isFalse);
-      expect(find.text('Press back again to exit'), findsOneWidget);
-    });
+        expect(systemNavigatorPopCalled, isFalse);
+        expect(find.text('Press back again to exit'), findsOneWidget);
+      },
+    );
 
-    testWidgets('initializes provider on first load',
-        (WidgetTester tester) async {
+    testWidgets('initializes provider on first load', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
@@ -273,8 +281,9 @@ void main() {
       verify(mockDrinkRepository.getDrinks(any)).called(1);
     });
 
-    testWidgets('does not reinitialize on rebuild',
-        (WidgetTester tester) async {
+    testWidgets('does not reinitialize on rebuild', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
@@ -310,8 +319,9 @@ void main() {
       verifyNever(mockDrinkRepository.getDrinks(any));
     });
 
-    testWidgets('calls refreshIfStale when ProviderInitializer app resumes',
-        (WidgetTester tester) async {
+    testWidgets('calls refreshIfStale when ProviderInitializer app resumes', (
+      WidgetTester tester,
+    ) async {
       var getDrinksCalls = 0;
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async {
         getDrinksCalls++;
@@ -322,9 +332,7 @@ void main() {
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
           child: const MaterialApp(
-            home: ProviderInitializer(
-              child: Scaffold(body: Text('Test')),
-            ),
+            home: ProviderInitializer(child: Scaffold(body: Text('Test'))),
           ),
         ),
       );
@@ -333,10 +341,12 @@ void main() {
       // Reset counter after initial load, then force stale state so that the
       // next refreshIfStale() call actually triggers a network reload.
       getDrinksCalls = 0;
-      provider.lastDrinksRefresh =
-          DateTime.now().subtract(const Duration(hours: 2));
-      provider.lastDrinksRefreshAttempt =
-          DateTime.now().subtract(const Duration(minutes: 5));
+      provider.lastDrinksRefresh = DateTime.now().subtract(
+        const Duration(hours: 2),
+      );
+      provider.lastDrinksRefreshAttempt = DateTime.now().subtract(
+        const Duration(minutes: 5),
+      );
 
       // Simulate app resuming from background
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
@@ -391,12 +401,15 @@ void main() {
           baseUrl: 'https://example.com',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [favoriteDrink]);
-      when(mockDrinkRepository.getFavorites(any))
-          .thenAnswer((_) async => ['drink1']);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [favoriteDrink]);
+      when(
+        mockDrinkRepository.getFavorites(any),
+      ).thenAnswer((_) async => ['drink1']);
 
       provider = BeerProvider(
         drinkRepository: mockDrinkRepository,
@@ -411,39 +424,41 @@ void main() {
       provider.dispose();
     });
 
-    testWidgets('navigates to drink detail when favorite drink card is tapped',
-        (WidgetTester tester) async {
-      final router = GoRouter(
-        initialLocation: '/favorites',
-        routes: [
-          GoRoute(
-            path: '/favorites',
-            builder: (context, state) =>
-                ChangeNotifierProvider<BeerProvider>.value(
-              value: provider,
-              child: const FavoritesScreen(festivalId: 'cbf2025'),
+    testWidgets(
+      'navigates to drink detail when favorite drink card is tapped',
+      (WidgetTester tester) async {
+        final router = GoRouter(
+          initialLocation: '/favorites',
+          routes: [
+            GoRoute(
+              path: '/favorites',
+              builder: (context, state) =>
+                  ChangeNotifierProvider<BeerProvider>.value(
+                    value: provider,
+                    child: const FavoritesScreen(festivalId: 'cbf2025'),
+                  ),
             ),
-          ),
-          GoRoute(
-            path: '/cbf2025/drink/:category/:drinkId',
-            builder: (context, state) =>
-                const Scaffold(body: Text('Drink Detail')),
-          ),
-        ],
-      );
+            GoRoute(
+              path: '/cbf2025/drink/:category/:drinkId',
+              builder: (context, state) =>
+                  const Scaffold(body: Text('Drink Detail')),
+            ),
+          ],
+        );
 
-      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+        await tester.pumpAndSettle();
 
-      expect(find.text('Favourite Ale'), findsOneWidget);
+        expect(find.text('Favourite Ale'), findsOneWidget);
 
-      final drinkCard = find.byKey(const ValueKey('drink1'));
-      await tester.ensureVisible(drinkCard);
-      await tester.tap(drinkCard);
-      await tester.pumpAndSettle();
+        final drinkCard = find.byKey(const ValueKey('drink1'));
+        await tester.ensureVisible(drinkCard);
+        await tester.tap(drinkCard);
+        await tester.pumpAndSettle();
 
-      expect(find.text('Drink Detail'), findsOneWidget);
-    });
+        expect(find.text('Drink Detail'), findsOneWidget);
+      },
+    );
   });
 
   group('isTransientFontLoadError', () {

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -73,7 +73,7 @@ void main() {
           'category': 'beer',
           'dispense': 'cask',
           'abv': '4',
-          'status_text': 'Plenty left'
+          'status_text': 'Plenty left',
         }).availabilityStatus,
         AvailabilityStatus.plenty,
       );
@@ -85,7 +85,7 @@ void main() {
           'category': 'beer',
           'dispense': 'cask',
           'abv': '4',
-          'status_text': 'A little remaining'
+          'status_text': 'A little remaining',
         }).availabilityStatus,
         AvailabilityStatus.low,
       );
@@ -97,7 +97,7 @@ void main() {
           'category': 'beer',
           'dispense': 'cask',
           'abv': '4',
-          'status_text': 'Sold out'
+          'status_text': 'Sold out',
         }).availabilityStatus,
         AvailabilityStatus.out,
       );
@@ -109,7 +109,7 @@ void main() {
           'category': 'beer',
           'dispense': 'cask',
           'abv': '4',
-          'status_text': 'Not yet available'
+          'status_text': 'Not yet available',
         }).availabilityStatus,
         AvailabilityStatus.notYetAvailable,
       );
@@ -121,7 +121,7 @@ void main() {
           'category': 'beer',
           'dispense': 'cask',
           'abv': '4',
-          'status_text': 'Coming soon'
+          'status_text': 'Coming soon',
         }).availabilityStatus,
         AvailabilityStatus.notYetAvailable,
       );
@@ -643,7 +643,7 @@ void main() {
             'category': 'beer',
             'dispense': 'cask',
             'abv': '4.5',
-          }
+          },
         ],
       };
 
@@ -987,8 +987,10 @@ void main() {
 
         final message = drink.getShareMessage('#cbf2025');
 
-        expect(message,
-            'Drinking Test IPA from Test Brewery at #cbf2025 - 4 stars');
+        expect(
+          message,
+          'Drinking Test IPA from Test Brewery at #cbf2025 - 4 stars',
+        );
       });
 
       test('uses provided hashtag', () {
@@ -1063,12 +1065,18 @@ void main() {
         dataBaseUrl: 'https://example.com/cbf2025',
       );
 
-      expect(festival.getBeverageUrl('cider'),
-          'https://example.com/cbf2025/cider.json');
-      expect(festival.getBeverageUrl('mead'),
-          'https://example.com/cbf2025/mead.json');
-      expect(festival.getBeverageUrl('wine'),
-          'https://example.com/cbf2025/wine.json');
+      expect(
+        festival.getBeverageUrl('cider'),
+        'https://example.com/cbf2025/cider.json',
+      );
+      expect(
+        festival.getBeverageUrl('mead'),
+        'https://example.com/cbf2025/mead.json',
+      );
+      expect(
+        festival.getBeverageUrl('wine'),
+        'https://example.com/cbf2025/wine.json',
+      );
     });
 
     group('formattedDates', () {
@@ -1130,7 +1138,7 @@ void main() {
           'Sep',
           'Oct',
           'Nov',
-          'Dec'
+          'Dec',
         ];
 
         for (var i = 0; i < 12; i++) {
@@ -1225,7 +1233,9 @@ void main() {
 
         expect(festival.charityPartnerName, 'Test Charity');
         expect(
-            festival.charityDonationUrl, 'https://charity.example.com/donate');
+          festival.charityDonationUrl,
+          'https://charity.example.com/donate',
+        );
       });
 
       test('handles latitude and longitude as int', () {
@@ -1319,7 +1329,9 @@ void main() {
 
         expect(json['charity_partner_name'], 'Test Charity');
         expect(
-            json['charity_donation_url'], 'https://charity.example.com/donate');
+          json['charity_donation_url'],
+          'https://charity.example.com/donate',
+        );
       });
     });
 
@@ -1380,27 +1392,29 @@ void main() {
     });
 
     group('FestivalStatus', () {
-      test('isLive returns true when current date is between start and end',
-          () {
-        final festival = Festival(
-          id: 'test',
-          name: 'Test Festival',
-          startDate: DateTime(2025, 5, 19),
-          endDate: DateTime(2025, 5, 24),
-          dataBaseUrl: 'https://example.com/test',
-        );
+      test(
+        'isLive returns true when current date is between start and end',
+        () {
+          final festival = Festival(
+            id: 'test',
+            name: 'Test Festival',
+            startDate: DateTime(2025, 5, 19),
+            endDate: DateTime(2025, 5, 24),
+            dataBaseUrl: 'https://example.com/test',
+          );
 
-        // During the festival
-        expect(festival.isLive(DateTime(2025, 5, 20)), isTrue);
-        expect(festival.isLive(DateTime(2025, 5, 19)), isTrue);
-        expect(festival.isLive(DateTime(2025, 5, 24, 23, 59)), isTrue);
+          // During the festival
+          expect(festival.isLive(DateTime(2025, 5, 20)), isTrue);
+          expect(festival.isLive(DateTime(2025, 5, 19)), isTrue);
+          expect(festival.isLive(DateTime(2025, 5, 24, 23, 59)), isTrue);
 
-        // Before the festival
-        expect(festival.isLive(DateTime(2025, 5, 18)), isFalse);
+          // Before the festival
+          expect(festival.isLive(DateTime(2025, 5, 18)), isFalse);
 
-        // After the festival
-        expect(festival.isLive(DateTime(2025, 5, 25)), isFalse);
-      });
+          // After the festival
+          expect(festival.isLive(DateTime(2025, 5, 25)), isFalse);
+        },
+      );
 
       test('isUpcoming returns true when start date is in the future', () {
         final festival = Festival(
@@ -1441,12 +1455,18 @@ void main() {
           dataBaseUrl: 'https://example.com/test',
         );
 
-        expect(festival.getBasicStatus(DateTime(2025, 5, 1)),
-            FestivalStatus.upcoming);
-        expect(festival.getBasicStatus(DateTime(2025, 5, 20)),
-            FestivalStatus.live);
         expect(
-            festival.getBasicStatus(DateTime(2025, 6, 1)), FestivalStatus.past);
+          festival.getBasicStatus(DateTime(2025, 5, 1)),
+          FestivalStatus.upcoming,
+        );
+        expect(
+          festival.getBasicStatus(DateTime(2025, 5, 20)),
+          FestivalStatus.live,
+        );
+        expect(
+          festival.getBasicStatus(DateTime(2025, 6, 1)),
+          FestivalStatus.past,
+        );
       });
 
       test('sortByDate orders festivals correctly', () {
@@ -1492,8 +1512,13 @@ void main() {
 
         // Test with date during live festival
         final now = DateTime(2025, 5, 20);
-        final sorted = Festival.sortByDate(
-            [past2, upcoming2, past1, live, upcoming1], now);
+        final sorted = Festival.sortByDate([
+          past2,
+          upcoming2,
+          past1,
+          live,
+          upcoming1,
+        ], now);
 
         expect(sorted[0].id, 'live'); // Live first
         expect(sorted[1].id, 'upcoming1'); // Then upcoming (soonest first)
@@ -1522,10 +1547,14 @@ void main() {
         final now = DateTime(2025, 5, 1);
         final sorted = Festival.sortByDate([past2, past1], now);
 
-        expect(Festival.getStatusInContext(past1, sorted, now),
-            FestivalStatus.mostRecent);
-        expect(Festival.getStatusInContext(past2, sorted, now),
-            FestivalStatus.past);
+        expect(
+          Festival.getStatusInContext(past1, sorted, now),
+          FestivalStatus.mostRecent,
+        );
+        expect(
+          Festival.getStatusInContext(past2, sorted, now),
+          FestivalStatus.past,
+        );
       });
 
       test('isLive treats a festival with no end date as a single day', () {
@@ -1595,8 +1624,10 @@ void main() {
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.plenty));
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.low));
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.out));
-      expect(AvailabilityStatus.values,
-          contains(AvailabilityStatus.notYetAvailable));
+      expect(
+        AvailabilityStatus.values,
+        contains(AvailabilityStatus.notYetAvailable),
+      );
     });
   });
 }

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -38,8 +38,9 @@ void main() {
           baseUrl: 'https://data.cambeerfestival.app',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
     });
 
     group('loadDrinks error messages', () {
@@ -52,8 +53,9 @@ void main() {
         await provider.initialize();
 
         // Mock 404 BeerApiException
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(BeerApiException('Not found', 404));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(BeerApiException('Not found', 404));
 
         await provider.loadDrinks();
 
@@ -72,8 +74,9 @@ void main() {
         await provider.initialize();
 
         // Mock 500 BeerApiException
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(BeerApiException('Server error', 500));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(BeerApiException('Server error', 500));
 
         await provider.loadDrinks();
 
@@ -93,8 +96,9 @@ void main() {
         await provider.initialize();
 
         // Mock 502 BeerApiException (Bad Gateway)
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(BeerApiException('Bad Gateway', 502));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(BeerApiException('Bad Gateway', 502));
 
         await provider.loadDrinks();
 
@@ -114,8 +118,9 @@ void main() {
         await provider.initialize();
 
         // Mock 503 BeerApiException (Service Unavailable)
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(BeerApiException('Service Unavailable', 503));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(BeerApiException('Service Unavailable', 503));
 
         await provider.loadDrinks();
 
@@ -135,8 +140,9 @@ void main() {
         await provider.initialize();
 
         // Mock TimeoutException
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(TimeoutException('Connection timeout'));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(TimeoutException('Connection timeout'));
 
         await provider.loadDrinks();
 
@@ -155,8 +161,9 @@ void main() {
         await provider.initialize();
 
         // http.ClientException is thrown on network failures across all platforms
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(http.ClientException('Failed host lookup'));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(http.ClientException('Failed host lookup'));
 
         await provider.loadDrinks();
 
@@ -176,8 +183,9 @@ void main() {
         await provider.initialize();
 
         // Mock generic exception
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(Exception('Some random error'));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(Exception('Some random error'));
 
         await provider.loadDrinks();
 
@@ -197,8 +205,9 @@ void main() {
         await provider.initialize();
 
         // Mock 403 BeerApiException
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(BeerApiException('Forbidden', 403));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenThrow(BeerApiException('Forbidden', 403));
 
         await provider.loadDrinks();
 
@@ -209,26 +218,29 @@ void main() {
         expect(provider.error, isNot(contains('403')));
       });
 
-      test('shows connection message for BeerApiException without status code',
-          () async {
-        final provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'shows connection message for BeerApiException without status code',
+        () async {
+          final provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        // Mock BeerApiException without status code
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(BeerApiException('Network error'));
+          // Mock BeerApiException without status code
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenThrow(BeerApiException('Network error'));
 
-        await provider.loadDrinks();
+          await provider.loadDrinks();
 
-        expect(provider.error, isNotNull);
-        expect(provider.error, contains('Could not load drinks'));
-        expect(provider.error, contains('check your connection'));
-        expect(provider.error, isNot(contains('BeerApiException')));
-      });
+          expect(provider.error, isNotNull);
+          expect(provider.error, contains('Could not load drinks'));
+          expect(provider.error, contains('check your connection'));
+          expect(provider.error, isNot(contains('BeerApiException')));
+        },
+      );
     });
 
     group('loadFestivals error messages', () {
@@ -240,15 +252,18 @@ void main() {
         );
 
         // Mock 404 FestivalServiceException
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(FestivalServiceException('Not found', 404));
+        when(
+          mockFestivalRepository.getFestivals(),
+        ).thenThrow(FestivalServiceException('Not found', 404));
 
         await provider.loadFestivals();
 
         expect(provider.festivalsError, isNotNull);
         expect(provider.festivalsError, contains('Festival list not found'));
-        expect(provider.festivalsError,
-            isNot(contains('FestivalServiceException')));
+        expect(
+          provider.festivalsError,
+          isNot(contains('FestivalServiceException')),
+        );
         expect(provider.festivalsError, isNot(contains('404')));
       });
 
@@ -260,8 +275,9 @@ void main() {
         );
 
         // Mock 500 FestivalServiceException
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(FestivalServiceException('Server error', 500));
+        when(
+          mockFestivalRepository.getFestivals(),
+        ).thenThrow(FestivalServiceException('Server error', 500));
 
         await provider.loadFestivals();
 
@@ -279,8 +295,9 @@ void main() {
         );
 
         // Mock 502 FestivalServiceException (Bad Gateway)
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(FestivalServiceException('Bad Gateway', 502));
+        when(
+          mockFestivalRepository.getFestivals(),
+        ).thenThrow(FestivalServiceException('Bad Gateway', 502));
 
         await provider.loadFestivals();
 
@@ -298,8 +315,9 @@ void main() {
         );
 
         // Mock 503 FestivalServiceException (Service Unavailable)
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(FestivalServiceException('Service Unavailable', 503));
+        when(
+          mockFestivalRepository.getFestivals(),
+        ).thenThrow(FestivalServiceException('Service Unavailable', 503));
 
         await provider.loadFestivals();
 
@@ -317,8 +335,9 @@ void main() {
         );
 
         // http.ClientException is thrown on network failures across all platforms
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(http.ClientException('Network unreachable'));
+        when(
+          mockFestivalRepository.getFestivals(),
+        ).thenThrow(http.ClientException('Network unreachable'));
 
         await provider.loadFestivals();
 
@@ -328,52 +347,57 @@ void main() {
       });
 
       test(
-          'shows connection message for FestivalServiceException without status',
-          () async {
-        final provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
+        'shows connection message for FestivalServiceException without status',
+        () async {
+          final provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
 
-        // Mock FestivalServiceException without status code
-        when(mockFestivalRepository.getFestivals())
-            .thenThrow(FestivalServiceException('Parse error'));
+          // Mock FestivalServiceException without status code
+          when(
+            mockFestivalRepository.getFestivals(),
+          ).thenThrow(FestivalServiceException('Parse error'));
 
-        await provider.loadFestivals();
+          await provider.loadFestivals();
 
-        expect(provider.festivalsError, isNotNull);
-        expect(provider.festivalsError, contains('Could not load festivals'));
-        expect(provider.festivalsError, contains('check your connection'));
-      });
+          expect(provider.festivalsError, isNotNull);
+          expect(provider.festivalsError, contains('Could not load festivals'));
+          expect(provider.festivalsError, contains('check your connection'));
+        },
+      );
     });
 
     group('setFestival error messages', () {
-      test('shows user-friendly message when switching festivals fails',
-          () async {
-        final provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'shows user-friendly message when switching festivals fails',
+        () async {
+          final provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        const testFestival = Festival(
-          id: 'test',
-          name: 'Test Festival',
-          dataBaseUrl: 'https://example.com',
-        );
+          const testFestival = Festival(
+            id: 'test',
+            name: 'Test Festival',
+            dataBaseUrl: 'https://example.com',
+          );
 
-        // Mock 500 error when loading new festival
-        when(mockDrinkRepository.getDrinks(any))
-            .thenThrow(BeerApiException('Server error', 500));
+          // Mock 500 error when loading new festival
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenThrow(BeerApiException('Server error', 500));
 
-        await provider.setFestival(testFestival);
+          await provider.setFestival(testFestival);
 
-        expect(provider.error, isNotNull);
-        expect(provider.error, contains('Server error'));
-        expect(provider.error, isNot(contains('BeerApiException')));
-      });
+          expect(provider.error, isNotNull);
+          expect(provider.error, contains('Server error'));
+          expect(provider.error, isNot(contains('BeerApiException')));
+        },
+      );
     });
   });
 
@@ -504,14 +528,16 @@ void main() {
         festivalId: 'test-festival',
       );
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [testDrink]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [testDrink]);
       await provider.loadDrinks();
 
       // Mock toggleFavorite to properly toggle state
       final favorites = <String>{};
-      when(mockDrinkRepository.toggleFavorite(any, any))
-          .thenAnswer((invocation) async {
+      when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer((
+        invocation,
+      ) async {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
@@ -556,14 +582,16 @@ void main() {
         festivalId: 'test-festival',
       );
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [testDrink]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [testDrink]);
       await provider.loadDrinks();
 
       // Mock toggleFavorite to properly toggle state
       final favorites = <String>{};
-      when(mockDrinkRepository.toggleFavorite(any, any))
-          .thenAnswer((invocation) async {
+      when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer((
+        invocation,
+      ) async {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
@@ -610,8 +638,9 @@ void main() {
         festivalId: 'test-festival',
       );
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [testDrink]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [testDrink]);
       await provider.loadDrinks();
 
       await provider.setRating(testDrink, 5);
@@ -648,8 +677,9 @@ void main() {
         festivalId: 'test-festival',
       );
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [testDrink]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [testDrink]);
       await provider.loadDrinks();
 
       await provider.setRating(testDrink, null);

--- a/test/provider_test.mocks.dart
+++ b/test/provider_test.mocks.dart
@@ -33,35 +33,20 @@ import 'package:mockito/mockito.dart' as _i1;
 
 class _FakeFestivalsResponse_0 extends _i1.SmartFake
     implements _i2.FestivalsResponse {
-  _FakeFestivalsResponse_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFestivalsResponse_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFirebaseAnalytics_1 extends _i1.SmartFake
     implements _i3.FirebaseAnalytics {
-  _FakeFirebaseAnalytics_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFirebaseAnalytics_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFirebaseCrashlytics_2 extends _i1.SmartFake
     implements _i4.FirebaseCrashlytics {
-  _FakeFirebaseCrashlytics_2(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFirebaseCrashlytics_2(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [DrinkRepository].
@@ -71,70 +56,51 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
   @override
   _i6.Future<List<_i7.Drink>> getDrinks(_i7.Festival? festival) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getDrinks,
-          [festival],
-        ),
-        returnValue: _i6.Future<List<_i7.Drink>>.value(<_i7.Drink>[]),
-        returnValueForMissingStub:
-            _i6.Future<List<_i7.Drink>>.value(<_i7.Drink>[]),
-      ) as _i6.Future<List<_i7.Drink>>);
+            Invocation.method(#getDrinks, [festival]),
+            returnValue: _i6.Future<List<_i7.Drink>>.value(<_i7.Drink>[]),
+            returnValueForMissingStub: _i6.Future<List<_i7.Drink>>.value(
+              <_i7.Drink>[],
+            ),
+          )
+          as _i6.Future<List<_i7.Drink>>);
 
   @override
   _i6.Future<List<_i7.Drink>?> getCachedDrinks(_i7.Festival? festival) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getCachedDrinks,
-          [festival],
-        ),
-        returnValue: _i6.Future<List<_i7.Drink>?>.value(),
-        returnValueForMissingStub: _i6.Future<List<_i7.Drink>?>.value(),
-      ) as _i6.Future<List<_i7.Drink>?>);
+            Invocation.method(#getCachedDrinks, [festival]),
+            returnValue: _i6.Future<List<_i7.Drink>?>.value(),
+            returnValueForMissingStub: _i6.Future<List<_i7.Drink>?>.value(),
+          )
+          as _i6.Future<List<_i7.Drink>?>);
 
   @override
   _i6.Future<List<String>> getFavorites(String? festivalId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getFavorites,
-          [festivalId],
-        ),
-        returnValue: _i6.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i6.Future<List<String>>.value(<String>[]),
-      ) as _i6.Future<List<String>>);
+            Invocation.method(#getFavorites, [festivalId]),
+            returnValue: _i6.Future<List<String>>.value(<String>[]),
+            returnValueForMissingStub: _i6.Future<List<String>>.value(
+              <String>[],
+            ),
+          )
+          as _i6.Future<List<String>>);
 
   @override
-  _i6.Future<bool> toggleFavorite(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<bool> toggleFavorite(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #toggleFavorite,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<bool>.value(false),
-        returnValueForMissingStub: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+            Invocation.method(#toggleFavorite, [festivalId, drinkId]),
+            returnValue: _i6.Future<bool>.value(false),
+            returnValueForMissingStub: _i6.Future<bool>.value(false),
+          )
+          as _i6.Future<bool>);
 
   @override
-  _i6.Future<int?> getRating(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<int?> getRating(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getRating,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<int?>.value(),
-        returnValueForMissingStub: _i6.Future<int?>.value(),
-      ) as _i6.Future<int?>);
+            Invocation.method(#getRating, [festivalId, drinkId]),
+            returnValue: _i6.Future<int?>.value(),
+            returnValueForMissingStub: _i6.Future<int?>.value(),
+          )
+          as _i6.Future<int?>);
 
   @override
   _i6.Future<void> setRating(
@@ -143,79 +109,49 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
     int? rating,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setRating,
-          [
-            festivalId,
-            drinkId,
-            rating,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#setRating, [festivalId, drinkId, rating]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> removeRating(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<void> removeRating(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #removeRating,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#removeRating, [festivalId, drinkId]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<bool> hasTasted(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<bool> hasTasted(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #hasTasted,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<bool>.value(false),
-        returnValueForMissingStub: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+            Invocation.method(#hasTasted, [festivalId, drinkId]),
+            returnValue: _i6.Future<bool>.value(false),
+            returnValueForMissingStub: _i6.Future<bool>.value(false),
+          )
+          as _i6.Future<bool>);
 
   @override
-  _i6.Future<bool> toggleTasted(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<bool> toggleTasted(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #toggleTasted,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<bool>.value(false),
-        returnValueForMissingStub: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+            Invocation.method(#toggleTasted, [festivalId, drinkId]),
+            returnValue: _i6.Future<bool>.value(false),
+            returnValueForMissingStub: _i6.Future<bool>.value(false),
+          )
+          as _i6.Future<bool>);
 
   @override
   _i6.Future<List<String>> getTastedDrinks(String? festivalId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getTastedDrinks,
-          [festivalId],
-        ),
-        returnValue: _i6.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i6.Future<List<String>>.value(<String>[]),
-      ) as _i6.Future<List<String>>);
+            Invocation.method(#getTastedDrinks, [festivalId]),
+            returnValue: _i6.Future<List<String>>.value(<String>[]),
+            returnValueForMissingStub: _i6.Future<List<String>>.value(
+              <String>[],
+            ),
+          )
+          as _i6.Future<List<String>>);
 }
 
 /// A class which mocks [FestivalRepository].
@@ -224,60 +160,51 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
 class MockFestivalRepository extends _i1.Mock
     implements _i8.FestivalRepository {
   @override
-  _i6.Future<_i2.FestivalsResponse> getFestivals() => (super.noSuchMethod(
-        Invocation.method(
-          #getFestivals,
-          [],
-        ),
-        returnValue:
-            _i6.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_0(
-          this,
-          Invocation.method(
-            #getFestivals,
-            [],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i6.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_0(
-          this,
-          Invocation.method(
-            #getFestivals,
-            [],
-          ),
-        )),
-      ) as _i6.Future<_i2.FestivalsResponse>);
+  _i6.Future<_i2.FestivalsResponse> getFestivals() =>
+      (super.noSuchMethod(
+            Invocation.method(#getFestivals, []),
+            returnValue: _i6.Future<_i2.FestivalsResponse>.value(
+              _FakeFestivalsResponse_0(
+                this,
+                Invocation.method(#getFestivals, []),
+              ),
+            ),
+            returnValueForMissingStub: _i6.Future<_i2.FestivalsResponse>.value(
+              _FakeFestivalsResponse_0(
+                this,
+                Invocation.method(#getFestivals, []),
+              ),
+            ),
+          )
+          as _i6.Future<_i2.FestivalsResponse>);
 
   @override
   _i6.Future<_i2.FestivalsResponse?> getCachedFestivals() =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getCachedFestivals,
-          [],
-        ),
-        returnValue: _i6.Future<_i2.FestivalsResponse?>.value(),
-        returnValueForMissingStub: _i6.Future<_i2.FestivalsResponse?>.value(),
-      ) as _i6.Future<_i2.FestivalsResponse?>);
+            Invocation.method(#getCachedFestivals, []),
+            returnValue: _i6.Future<_i2.FestivalsResponse?>.value(),
+            returnValueForMissingStub:
+                _i6.Future<_i2.FestivalsResponse?>.value(),
+          )
+          as _i6.Future<_i2.FestivalsResponse?>);
 
   @override
-  _i6.Future<String?> getSelectedFestivalId() => (super.noSuchMethod(
-        Invocation.method(
-          #getSelectedFestivalId,
-          [],
-        ),
-        returnValue: _i6.Future<String?>.value(),
-        returnValueForMissingStub: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
+  _i6.Future<String?> getSelectedFestivalId() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSelectedFestivalId, []),
+            returnValue: _i6.Future<String?>.value(),
+            returnValueForMissingStub: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
 
   @override
   _i6.Future<void> setSelectedFestivalId(String? festivalId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setSelectedFestivalId,
-          [festivalId],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#setSelectedFestivalId, [festivalId]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 }
 
 /// A class which mocks [AnalyticsService].
@@ -285,188 +212,169 @@ class MockFestivalRepository extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockAnalyticsService extends _i1.Mock implements _i9.AnalyticsService {
   @override
-  _i3.FirebaseAnalytics get analytics => (super.noSuchMethod(
-        Invocation.getter(#analytics),
-        returnValue: _FakeFirebaseAnalytics_1(
-          this,
-          Invocation.getter(#analytics),
-        ),
-        returnValueForMissingStub: _FakeFirebaseAnalytics_1(
-          this,
-          Invocation.getter(#analytics),
-        ),
-      ) as _i3.FirebaseAnalytics);
+  _i3.FirebaseAnalytics get analytics =>
+      (super.noSuchMethod(
+            Invocation.getter(#analytics),
+            returnValue: _FakeFirebaseAnalytics_1(
+              this,
+              Invocation.getter(#analytics),
+            ),
+            returnValueForMissingStub: _FakeFirebaseAnalytics_1(
+              this,
+              Invocation.getter(#analytics),
+            ),
+          )
+          as _i3.FirebaseAnalytics);
 
   @override
-  _i4.FirebaseCrashlytics get crashlytics => (super.noSuchMethod(
-        Invocation.getter(#crashlytics),
-        returnValue: _FakeFirebaseCrashlytics_2(
-          this,
-          Invocation.getter(#crashlytics),
-        ),
-        returnValueForMissingStub: _FakeFirebaseCrashlytics_2(
-          this,
-          Invocation.getter(#crashlytics),
-        ),
-      ) as _i4.FirebaseCrashlytics);
+  _i4.FirebaseCrashlytics get crashlytics =>
+      (super.noSuchMethod(
+            Invocation.getter(#crashlytics),
+            returnValue: _FakeFirebaseCrashlytics_2(
+              this,
+              Invocation.getter(#crashlytics),
+            ),
+            returnValueForMissingStub: _FakeFirebaseCrashlytics_2(
+              this,
+              Invocation.getter(#crashlytics),
+            ),
+          )
+          as _i4.FirebaseCrashlytics);
 
   @override
-  _i6.Future<void> logAppLaunch() => (super.noSuchMethod(
-        Invocation.method(
-          #logAppLaunch,
-          [],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+  _i6.Future<void> logAppLaunch() =>
+      (super.noSuchMethod(
+            Invocation.method(#logAppLaunch, []),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
   _i6.Future<void> logFestivalSelected(_i7.Festival? festival) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logFestivalSelected,
-          [festival],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#logFestivalSelected, [festival]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> logSearch(String? query) => (super.noSuchMethod(
-        Invocation.method(
-          #logSearch,
-          [query],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logCategoryFilter(String? category) => (super.noSuchMethod(
-        Invocation.method(
-          #logCategoryFilter,
-          [category],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logStyleFilter(Set<String>? styles) => (super.noSuchMethod(
-        Invocation.method(
-          #logStyleFilter,
-          [styles],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logSortChange(String? sortType) => (super.noSuchMethod(
-        Invocation.method(
-          #logSortChange,
-          [sortType],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logFavoriteAdded(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logFavoriteAdded,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logFavoriteRemoved(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logFavoriteRemoved,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logTastedAdded(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logTastedAdded,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logTastedRemoved(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logTastedRemoved,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logDrinkViewed(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logDrinkViewed,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logBreweryViewed(String? breweryName) => (super.noSuchMethod(
-        Invocation.method(
-          #logBreweryViewed,
-          [breweryName],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logStyleViewed(String? style) => (super.noSuchMethod(
-        Invocation.method(
-          #logStyleViewed,
-          [style],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logRatingGiven(
-    _i7.Drink? drink,
-    int? rating,
-  ) =>
+  _i6.Future<void> logSearch(String? query) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logRatingGiven,
-          [
-            drink,
-            rating,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#logSearch, [query]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> logDrinkShared(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logDrinkShared,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+  _i6.Future<void> logCategoryFilter(String? category) =>
+      (super.noSuchMethod(
+            Invocation.method(#logCategoryFilter, [category]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logStyleFilter(Set<String>? styles) =>
+      (super.noSuchMethod(
+            Invocation.method(#logStyleFilter, [styles]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logSortChange(String? sortType) =>
+      (super.noSuchMethod(
+            Invocation.method(#logSortChange, [sortType]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFavoriteAdded(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFavoriteAdded, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFavoriteRemoved(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFavoriteRemoved, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logTastedAdded(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logTastedAdded, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logTastedRemoved(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logTastedRemoved, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logDrinkViewed(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logDrinkViewed, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logBreweryViewed(String? breweryName) =>
+      (super.noSuchMethod(
+            Invocation.method(#logBreweryViewed, [breweryName]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logStyleViewed(String? style) =>
+      (super.noSuchMethod(
+            Invocation.method(#logStyleViewed, [style]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logRatingGiven(_i7.Drink? drink, int? rating) =>
+      (super.noSuchMethod(
+            Invocation.method(#logRatingGiven, [drink, rating]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logDrinkShared(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logDrinkShared, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
   _i6.Future<void> logError(
@@ -475,42 +383,31 @@ class MockAnalyticsService extends _i1.Mock implements _i9.AnalyticsService {
     String? reason,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logError,
-          [
-            error,
-            stackTrace,
-          ],
-          {#reason: reason},
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(
+              #logError,
+              [error, stackTrace],
+              {#reason: reason},
+            ),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> setUserProperty(
-    String? name,
-    String? value,
-  ) =>
+  _i6.Future<void> setUserProperty(String? name, String? value) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setUserProperty,
-          [
-            name,
-            value,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#setUserProperty, [name, value]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> setUserId(String? userId) => (super.noSuchMethod(
-        Invocation.method(
-          #setUserId,
-          [userId],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+  _i6.Future<void> setUserId(String? userId) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserId, [userId]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 }

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -56,11 +56,13 @@ void main() {
           baseUrl: 'https://example.com',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => <Drink>[]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => <Drink>[]);
     });
 
     tearDown(() {
@@ -74,9 +76,7 @@ void main() {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
 
@@ -86,8 +86,9 @@ void main() {
       expect(find.byType(NavigationBar), findsOneWidget);
     });
 
-    testWidgets('router handles festival-scoped /favorites route',
-        (tester) async {
+    testWidgets('router handles festival-scoped /favorites route', (
+      tester,
+    ) async {
       // Initialize provider with festivals
       await provider.initialize();
       final festivalId = provider.currentFestival.id;
@@ -95,9 +96,7 @@ void main() {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
 
@@ -132,8 +131,9 @@ void main() {
           baseUrl: 'https://example.com',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
       await provider.initialize();
       expect(provider.currentFestival.id, 'cbf2025');
@@ -141,9 +141,7 @@ void main() {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
 
@@ -166,37 +164,36 @@ void main() {
     });
 
     testWidgets(
-        'router redirects root path to festival home after async initialization',
-        (tester) async {
+      'router redirects root path to festival home after async initialization',
+      (tester) async {
+        // DO NOT pre-initialize - this simulates the e2e scenario
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
+          ),
+        );
+
+        // Pump frames to allow async initialization to complete
+        await tester.pumpAndSettle();
+
+        // Should redirect from / to /cbf2025 after initialization
+        final currentUri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(currentUri.pathSegments.isNotEmpty, true);
+        expect(currentUri.pathSegments.first, 'cbf2025');
+      },
+    );
+
+    testWidgets('router redirects invalid festival after async initialization', (
+      tester,
+    ) async {
       // DO NOT pre-initialize - this simulates the e2e scenario
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
-        ),
-      );
-
-      // Pump frames to allow async initialization to complete
-      await tester.pumpAndSettle();
-
-      // Should redirect from / to /cbf2025 after initialization
-      final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(currentUri.pathSegments.isNotEmpty, true);
-      expect(currentUri.pathSegments.first, 'cbf2025');
-    });
-
-    testWidgets('router redirects invalid festival after async initialization',
-        (tester) async {
-      // DO NOT pre-initialize - this simulates the e2e scenario
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
 
@@ -209,96 +206,101 @@ void main() {
 
       // Should redirect to current festival (cbf2025) after initialization
       final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
+        appRouter.routerDelegate.currentConfiguration.uri.toString(),
+      );
       expect(currentUri.pathSegments.first, 'cbf2025');
       expect(provider.currentFestival.id, 'cbf2025');
     });
 
     testWidgets(
-        'router redirects invalid festival with query params after async initialization',
-        (tester) async {
-      // DO NOT pre-initialize - this simulates the e2e scenario
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
+      'router redirects invalid festival with query params after async initialization',
+      (tester) async {
+        // DO NOT pre-initialize - this simulates the e2e scenario
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
           ),
-        ),
-      );
+        );
 
-      // Navigate to invalid festival with query params immediately
-      appRouter.go('/invalid-fest?search=IPA&category=beer');
-      await tester.pump();
+        // Navigate to invalid festival with query params immediately
+        appRouter.go('/invalid-fest?search=IPA&category=beer');
+        await tester.pump();
 
-      // Pump frames to allow async initialization AND redirect to complete
-      await tester.pumpAndSettle();
+        // Pump frames to allow async initialization AND redirect to complete
+        await tester.pumpAndSettle();
 
-      // Should redirect to cbf2025 and preserve query parameters
-      final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(currentUri.pathSegments.first, 'cbf2025');
-      expect(currentUri.queryParameters['search'], 'IPA');
-      expect(currentUri.queryParameters['category'], 'beer');
-    });
+        // Should redirect to cbf2025 and preserve query parameters
+        final currentUri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(currentUri.pathSegments.first, 'cbf2025');
+        expect(currentUri.queryParameters['search'], 'IPA');
+        expect(currentUri.queryParameters['category'], 'beer');
+      },
+    );
 
     testWidgets(
-        'deep link to valid route does NOT redirect after async initialization',
-        (tester) async {
-      // DO NOT pre-initialize - simulates deep link before app loads
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
+      'deep link to valid route does NOT redirect after async initialization',
+      (tester) async {
+        // DO NOT pre-initialize - simulates deep link before app loads
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
           ),
-        ),
-      );
+        );
 
-      // Navigate to drink detail immediately (before init)
-      appRouter.go('/$testFestivalId/drink/beer/$testDrinkId');
-      await tester.pump();
+        // Navigate to drink detail immediately (before init)
+        appRouter.go('/$testFestivalId/drink/beer/$testDrinkId');
+        await tester.pump();
 
-      // Pump frames to allow async initialization to complete
-      await tester.pumpAndSettle();
+        // Pump frames to allow async initialization to complete
+        await tester.pumpAndSettle();
 
-      // Should stay on drink detail route (valid festival ID)
-      final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(currentUri.pathSegments.length, 4);
-      expect(currentUri.pathSegments[0], testFestivalId);
-      expect(currentUri.pathSegments[1], 'drink');
-      expect(currentUri.pathSegments[2], 'beer');
-      expect(currentUri.pathSegments[3], testDrinkId);
-    });
+        // Should stay on drink detail route (valid festival ID)
+        final currentUri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(currentUri.pathSegments.length, 4);
+        expect(currentUri.pathSegments[0], testFestivalId);
+        expect(currentUri.pathSegments[1], 'drink');
+        expect(currentUri.pathSegments[2], 'beer');
+        expect(currentUri.pathSegments[3], testDrinkId);
+      },
+    );
 
-    testWidgets('global /about route NOT redirected after async initialization',
-        (tester) async {
-      // Create a fresh router for this test to avoid state pollution
-      final testRouter = GoRouter(
-        initialLocation: '/about', // Start at /about
-        debugLogDiagnostics: kDebugMode,
-        routes: appRouter.configuration.routes,
-      );
+    testWidgets(
+      'global /about route NOT redirected after async initialization',
+      (tester) async {
+        // Create a fresh router for this test to avoid state pollution
+        final testRouter = GoRouter(
+          initialLocation: '/about', // Start at /about
+          debugLogDiagnostics: kDebugMode,
+          routes: appRouter.configuration.routes,
+        );
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(
-            routerConfig: testRouter,
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: testRouter),
           ),
-        ),
-      );
+        );
 
-      // Pump frames to allow async initialization to complete
-      await tester.pumpAndSettle();
+        // Pump frames to allow async initialization to complete
+        await tester.pumpAndSettle();
 
-      // Should STAY at /about (NOT redirect to /cbf2025)
-      final currentUri = Uri.parse(
-          testRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(currentUri.path, '/about',
-          reason: 'Global /about route should not be redirected');
-    });
+        // Should STAY at /about (NOT redirect to /cbf2025)
+        final currentUri = Uri.parse(
+          testRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(
+          currentUri.path,
+          '/about',
+          reason: 'Global /about route should not be redirected',
+        );
+      },
+    );
 
     // Note: Browser back/forward is handled by go_router's declarative API
     // and is tested in the e2e tests (test-e2e/routing.spec.ts).
@@ -307,31 +309,35 @@ void main() {
 
     testWidgets('redirect handles API failure gracefully', (tester) async {
       // Mock API failure
-      when(mockFestivalRepository.getFestivals())
-          .thenThrow(Exception('API error'));
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getFestivals(),
+      ).thenThrow(Exception('API error'));
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
       await tester.pumpAndSettle();
 
       // Should fall back to default festival despite API failure
       final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
+        appRouter.routerDelegate.currentConfiguration.uri.toString(),
+      );
       expect(currentUri.pathSegments.isNotEmpty, true);
-      expect(currentUri.pathSegments.first,
-          DefaultFestivals.all.firstWhere((f) => f.isActive).id,
-          reason: 'Should use active hardcoded festival when API fails');
+      expect(
+        currentUri.pathSegments.first,
+        DefaultFestivals.all.firstWhere((f) => f.isActive).id,
+        reason: 'Should use active hardcoded festival when API fails',
+      );
     });
 
     testWidgets('redirect handles empty festivals list', (tester) async {
@@ -345,15 +351,14 @@ void main() {
           baseUrl: 'https://example.com',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
 
@@ -361,22 +366,23 @@ void main() {
 
       // Should use hardcoded default festival
       final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
+        appRouter.routerDelegate.currentConfiguration.uri.toString(),
+      );
       expect(currentUri.pathSegments.isNotEmpty, true);
-      expect(currentUri.pathSegments.first,
-          DefaultFestivals.all.firstWhere((f) => f.isActive).id,
-          reason:
-              'Should use active hardcoded festival when registry is empty');
+      expect(
+        currentUri.pathSegments.first,
+        DefaultFestivals.all.firstWhere((f) => f.isActive).id,
+        reason: 'Should use active hardcoded festival when registry is empty',
+      );
     });
 
-    testWidgets('multiple rapid navigations before init completes',
-        (tester) async {
+    testWidgets('multiple rapid navigations before init completes', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
 
@@ -393,10 +399,14 @@ void main() {
 
       // Should end up at the final destination without errors
       final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
+        appRouter.routerDelegate.currentConfiguration.uri.toString(),
+      );
       expect(currentUri.pathSegments.first, 'cbf2025');
-      expect(tester.takeException(), isNull,
-          reason: 'Should not throw exceptions during rapid navigation');
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'Should not throw exceptions during rapid navigation',
+      );
     });
 
     testWidgets('festival switch during navigation after init', (tester) async {
@@ -420,15 +430,14 @@ void main() {
           baseUrl: 'https://example.com',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
 
@@ -440,28 +449,32 @@ void main() {
       await tester.pumpAndSettle();
 
       // Provider should switch to cbf2024 (via postFrameCallback)
-      expect(provider.currentFestival.id, 'cbf2024',
-          reason: 'Provider should switch to festival in URL');
+      expect(
+        provider.currentFestival.id,
+        'cbf2024',
+        reason: 'Provider should switch to festival in URL',
+      );
     });
 
     testWidgets('navigation during slow initialization', (tester) async {
       // Create a completer to control initialization timing
       final completer = Completer<FestivalsResponse>();
-      when(mockFestivalRepository.getFestivals())
-          .thenAnswer((_) => completer.future);
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getFestivals(),
+      ).thenAnswer((_) => completer.future);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
 
       // Start showing loading state
       await tester.pump();
@@ -471,26 +484,32 @@ void main() {
       await tester.pump();
 
       // Now complete initialization
-      completer.complete(FestivalsResponse(
-        festivals: const [
-          Festival(
-            id: 'cbf2025',
-            name: 'Cambridge 2025',
-            dataBaseUrl: 'https://example.com/cbf2025',
-          ),
-        ],
-        defaultFestivalId: 'cbf2025',
-        version: '1.0.0',
-        baseUrl: 'https://example.com',
-      ));
+      completer.complete(
+        FestivalsResponse(
+          festivals: const [
+            Festival(
+              id: 'cbf2025',
+              name: 'Cambridge 2025',
+              dataBaseUrl: 'https://example.com/cbf2025',
+            ),
+          ],
+          defaultFestivalId: 'cbf2025',
+          version: '1.0.0',
+          baseUrl: 'https://example.com',
+        ),
+      );
 
       await tester.pumpAndSettle();
 
       // Should STAY at drink detail (not redirect to /cbf2025)
       final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(currentUri.path, '/cbf2025/drink/beer/test-drink-123',
-          reason: 'Should not redirect when already on valid route');
+        appRouter.routerDelegate.currentConfiguration.uri.toString(),
+      );
+      expect(
+        currentUri.path,
+        '/cbf2025/drink/beer/test-drink-123',
+        reason: 'Should not redirect when already on valid route',
+      );
     });
 
     // KNOWN LIMITATION: Deep links with invalid festival IDs in subpaths
@@ -500,68 +519,66 @@ void main() {
     // Fix: Requires adding festival ID validation to ALL route builders
 
     testWidgets(
-        'router redirects invalid festival ID (pre-initialized provider)',
-        (tester) async {
-      await provider.initialize();
-      final currentFestival = provider.currentFestival.id;
+      'router redirects invalid festival ID (pre-initialized provider)',
+      (tester) async {
+        await provider.initialize();
+        final currentFestival = provider.currentFestival.id;
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
           ),
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
+        await tester.pumpAndSettle();
 
-      // Try to navigate to invalid festival ID
-      appRouter.go('/invalid-festival-123');
-      await tester.pumpAndSettle();
+        // Try to navigate to invalid festival ID
+        appRouter.go('/invalid-festival-123');
+        await tester.pumpAndSettle();
 
-      // Should redirect to current festival
-      expect(provider.currentFestival.id, currentFestival);
-    });
+        // Should redirect to current festival
+        expect(provider.currentFestival.id, currentFestival);
+      },
+    );
 
     testWidgets(
-        'router preserves query parameters when redirecting invalid festival ID',
-        (tester) async {
-      await provider.initialize();
-      final currentFestival = provider.currentFestival.id;
+      'router preserves query parameters when redirecting invalid festival ID',
+      (tester) async {
+        await provider.initialize();
+        final currentFestival = provider.currentFestival.id;
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
           ),
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
+        await tester.pumpAndSettle();
 
-      // Try to navigate to invalid festival with query parameters
-      appRouter.go('/invalid-festival-123?search=IPA&category=beer');
-      await tester.pumpAndSettle();
+        // Try to navigate to invalid festival with query parameters
+        appRouter.go('/invalid-festival-123?search=IPA&category=beer');
+        await tester.pumpAndSettle();
 
-      // Should redirect to current festival and preserve query params
-      final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(currentUri.pathSegments.first, currentFestival);
-      expect(currentUri.queryParameters['search'], 'IPA');
-      expect(currentUri.queryParameters['category'], 'beer');
-    });
+        // Should redirect to current festival and preserve query params
+        final currentUri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(currentUri.pathSegments.first, currentFestival);
+        expect(currentUri.queryParameters['search'], 'IPA');
+        expect(currentUri.queryParameters['category'], 'beer');
+      },
+    );
     // Edge cases and limitations
-    testWidgets('URL fragments are lost during redirect (KNOWN LIMITATION)',
-        (tester) async {
+    testWidgets('URL fragments are lost during redirect (KNOWN LIMITATION)', (
+      tester,
+    ) async {
       // This documents the current limitation mentioned in lib/main.dart
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
 
@@ -571,25 +588,31 @@ void main() {
       await tester.pumpAndSettle();
 
       final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
+        appRouter.routerDelegate.currentConfiguration.uri.toString(),
+      );
 
       // Currently fragments are lost during redirect
-      expect(currentUri.pathSegments.first, testFestivalId,
-          reason: 'Should redirect to valid festival');
-      expect(currentUri.fragment, isEmpty,
-          reason: 'Fragment is lost (KNOWN LIMITATION - see lib/main.dart)');
+      expect(
+        currentUri.pathSegments.first,
+        testFestivalId,
+        reason: 'Should redirect to valid festival',
+      );
+      expect(
+        currentUri.fragment,
+        isEmpty,
+        reason: 'Fragment is lost (KNOWN LIMITATION - see lib/main.dart)',
+      );
       // TODO: Fix this by preserving currentUri.fragment in redirect URL construction
     });
 
-    testWidgets('URL-encoded festival IDs are handled correctly',
-        (tester) async {
+    testWidgets('URL-encoded festival IDs are handled correctly', (
+      tester,
+    ) async {
       // Ensure malformed/encoded IDs don't bypass validation
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
-          child: MaterialApp.router(
-            routerConfig: appRouter,
-          ),
+          child: MaterialApp.router(routerConfig: appRouter),
         ),
       );
 
@@ -599,310 +622,359 @@ void main() {
       await tester.pumpAndSettle();
 
       final currentUri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
+        appRouter.routerDelegate.currentConfiguration.uri.toString(),
+      );
 
       // URL-encoded IDs should be treated as invalid and redirected
-      expect(currentUri.pathSegments.first, testFestivalId,
-          reason: 'Encoded festival IDs should not match valid festival IDs');
+      expect(
+        currentUri.pathSegments.first,
+        testFestivalId,
+        reason: 'Encoded festival IDs should not match valid festival IDs',
+      );
     });
 
     // Regression tests for issue #266: cold-load / browser-refresh uses wrong festival
     testWidgets(
-        'cold load of non-default festival URL syncs provider (regression #266)',
-        (tester) async {
-      when(mockFestivalRepository.getFestivals()).thenAnswer(
-        (_) async => FestivalsResponse(
-          festivals: const [
-            Festival(
-              id: 'cbf2025',
-              name: 'Cambridge 2025',
-              dataBaseUrl: 'https://example.com/cbf2025',
-            ),
-            Festival(
-              id: 'cbf2024',
-              name: 'Cambridge 2024',
-              dataBaseUrl: 'https://example.com/cbf2024',
-            ),
-          ],
-          defaultFestivalId: 'cbf2025',
-          version: '1.0.0',
-          baseUrl: 'https://example.com',
-        ),
-      );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      'cold load of non-default festival URL syncs provider (regression #266)',
+      (tester) async {
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: const [
+              Festival(
+                id: 'cbf2025',
+                name: 'Cambridge 2025',
+                dataBaseUrl: 'https://example.com/cbf2025',
+              ),
+              Festival(
+                id: 'cbf2024',
+                name: 'Cambridge 2024',
+                dataBaseUrl: 'https://example.com/cbf2024',
+              ),
+            ],
+            defaultFestivalId: 'cbf2025',
+            version: '1.0.0',
+            baseUrl: 'https://example.com',
+          ),
+        );
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
-      // True cold load: router starts at cbf2024 before any initialization
-      final testRouter = GoRouter(
-        initialLocation: '/cbf2024',
-        debugLogDiagnostics: kDebugMode,
-        routes: appRouter.configuration.routes,
-      );
+        // True cold load: router starts at cbf2024 before any initialization
+        final testRouter = GoRouter(
+          initialLocation: '/cbf2024',
+          debugLogDiagnostics: kDebugMode,
+          routes: appRouter.configuration.routes,
+        );
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(routerConfig: testRouter),
-        ),
-      );
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: testRouter),
+          ),
+        );
 
-      await tester.pumpAndSettle();
+        await tester.pumpAndSettle();
 
-      // Provider must be synced to the URL festival, not the default
-      expect(provider.currentFestival.id, 'cbf2024',
+        // Provider must be synced to the URL festival, not the default
+        expect(
+          provider.currentFestival.id,
+          'cbf2024',
           reason:
-              'Cold-loaded festival URL must sync the provider (issue #266)');
-      expect(find.text('Cambridge 2024'), findsOneWidget);
-      expect(find.text('Cambridge 2025'), findsNothing);
-    });
+              'Cold-loaded festival URL must sync the provider (issue #266)',
+        );
+        expect(find.text('Cambridge 2024'), findsOneWidget);
+        expect(find.text('Cambridge 2025'), findsNothing);
+      },
+    );
 
     testWidgets(
-        'cold load of drink deep link from non-default festival syncs provider (regression #266)',
-        (tester) async {
-      when(mockFestivalRepository.getFestivals()).thenAnswer(
-        (_) async => FestivalsResponse(
-          festivals: const [
-            Festival(
-              id: 'cbf2025',
-              name: 'Cambridge 2025',
-              dataBaseUrl: 'https://example.com/cbf2025',
-            ),
-            Festival(
-              id: 'cbf2024',
-              name: 'Cambridge 2024',
-              dataBaseUrl: 'https://example.com/cbf2024',
-            ),
-          ],
-          defaultFestivalId: 'cbf2025',
-          version: '1.0.0',
-          baseUrl: 'https://example.com',
-        ),
-      );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      'cold load of drink deep link from non-default festival syncs provider (regression #266)',
+      (tester) async {
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: const [
+              Festival(
+                id: 'cbf2025',
+                name: 'Cambridge 2025',
+                dataBaseUrl: 'https://example.com/cbf2025',
+              ),
+              Festival(
+                id: 'cbf2024',
+                name: 'Cambridge 2024',
+                dataBaseUrl: 'https://example.com/cbf2024',
+              ),
+            ],
+            defaultFestivalId: 'cbf2025',
+            version: '1.0.0',
+            baseUrl: 'https://example.com',
+          ),
+        );
+        when(
+          mockFestivalRepository.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
 
-      // True cold load: shared drink link from a non-default festival
-      final testRouter = GoRouter(
-        initialLocation: '/cbf2024/drink/beer/$testDrinkId',
-        debugLogDiagnostics: kDebugMode,
-        routes: appRouter.configuration.routes,
-      );
+        // True cold load: shared drink link from a non-default festival
+        final testRouter = GoRouter(
+          initialLocation: '/cbf2024/drink/beer/$testDrinkId',
+          debugLogDiagnostics: kDebugMode,
+          routes: appRouter.configuration.routes,
+        );
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(routerConfig: testRouter),
-        ),
-      );
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: testRouter),
+          ),
+        );
 
-      await tester.pumpAndSettle();
+        await tester.pumpAndSettle();
 
-      // Provider must switch to cbf2024 so getDrinkById searches the right festival
-      expect(provider.currentFestival.id, 'cbf2024',
+        // Provider must switch to cbf2024 so getDrinkById searches the right festival
+        expect(
+          provider.currentFestival.id,
+          'cbf2024',
           reason:
-              'Cold-loaded deep link must sync provider to the URL festival (issue #266)');
-    });
+              'Cold-loaded deep link must sync provider to the URL festival (issue #266)',
+        );
+      },
+    );
 
     testWidgets(
-        'invalid festival ID in detail routes redirects to current festival equivalent',
-        (tester) async {
-      await provider.initialize();
+      'invalid festival ID in detail routes redirects to current festival equivalent',
+      (tester) async {
+        await provider.initialize();
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(routerConfig: appRouter),
-        ),
-      );
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      // Drink route
-      appRouter.go('/$invalidFestivalId/drink/beer/$testDrinkId');
-      await tester.pumpAndSettle();
-      var uri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(uri.pathSegments[0], testFestivalId);
-      expect(uri.pathSegments[1], 'drink');
-      expect(uri.pathSegments[2], 'beer');
-      expect(uri.pathSegments[3], testDrinkId,
+        // Drink route
+        appRouter.go('/$invalidFestivalId/drink/beer/$testDrinkId');
+        await tester.pumpAndSettle();
+        var uri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(uri.pathSegments[1], 'drink');
+        expect(uri.pathSegments[2], 'beer');
+        expect(
+          uri.pathSegments[3],
+          testDrinkId,
           reason:
-              'Invalid festival in drink route should redirect, preserving category and drink ID');
+              'Invalid festival in drink route should redirect, preserving category and drink ID',
+        );
 
-      // Brewery route
-      appRouter.go('/$invalidFestivalId/brewery/$testBreweryId');
-      await tester.pumpAndSettle();
-      uri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(uri.pathSegments[0], testFestivalId);
-      expect(uri.pathSegments[1], 'brewery');
-      expect(uri.pathSegments[2], testBreweryId,
+        // Brewery route
+        appRouter.go('/$invalidFestivalId/brewery/$testBreweryId');
+        await tester.pumpAndSettle();
+        uri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(uri.pathSegments[1], 'brewery');
+        expect(
+          uri.pathSegments[2],
+          testBreweryId,
           reason:
-              'Invalid festival in brewery route should redirect, preserving brewery ID');
+              'Invalid festival in brewery route should redirect, preserving brewery ID',
+        );
 
-      // Style route
-      appRouter.go('/$invalidFestivalId/style/IPA');
-      await tester.pumpAndSettle();
-      uri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(uri.pathSegments[0], testFestivalId);
-      expect(uri.pathSegments[1], 'style');
+        // Style route
+        appRouter.go('/$invalidFestivalId/style/IPA');
+        await tester.pumpAndSettle();
+        uri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(uri.pathSegments[1], 'style');
 
-      // Info route
-      appRouter.go('/$invalidFestivalId/info');
-      await tester.pumpAndSettle();
-      uri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(uri.pathSegments[0], testFestivalId);
-      expect(uri.pathSegments[1], 'info',
-          reason: 'Invalid festival in info route should redirect');
+        // Info route
+        appRouter.go('/$invalidFestivalId/info');
+        await tester.pumpAndSettle();
+        uri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(
+          uri.pathSegments[1],
+          'info',
+          reason: 'Invalid festival in info route should redirect',
+        );
 
-      // Favorites route
-      appRouter.go('/$invalidFestivalId/favorites');
-      await tester.pumpAndSettle();
-      uri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(uri.pathSegments[0], testFestivalId);
-      expect(uri.pathSegments[1], 'favorites',
-          reason: 'Invalid festival in favorites route should redirect');
-    });
+        // Favorites route
+        appRouter.go('/$invalidFestivalId/favorites');
+        await tester.pumpAndSettle();
+        uri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(
+          uri.pathSegments[1],
+          'favorites',
+          reason: 'Invalid festival in favorites route should redirect',
+        );
+      },
+    );
 
     testWidgets(
-        'favorites route with different festival switches provider (hot navigation)',
-        (tester) async {
-      when(mockFestivalRepository.getFestivals()).thenAnswer(
-        (_) async => FestivalsResponse(
-          festivals: const [
-            Festival(
-              id: 'cbf2025',
-              name: 'Cambridge 2025',
-              dataBaseUrl: 'https://example.com/cbf2025',
-            ),
-            Festival(
-              id: 'cbf2024',
-              name: 'Cambridge 2024',
-              dataBaseUrl: 'https://example.com/cbf2024',
-            ),
-          ],
-          defaultFestivalId: 'cbf2025',
-          version: '1.0.0',
-          baseUrl: 'https://example.com',
-        ),
-      );
-      await provider.initialize();
-      expect(provider.currentFestival.id, 'cbf2025');
+      'favorites route with different festival switches provider (hot navigation)',
+      (tester) async {
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: const [
+              Festival(
+                id: 'cbf2025',
+                name: 'Cambridge 2025',
+                dataBaseUrl: 'https://example.com/cbf2025',
+              ),
+              Festival(
+                id: 'cbf2024',
+                name: 'Cambridge 2024',
+                dataBaseUrl: 'https://example.com/cbf2024',
+              ),
+            ],
+            defaultFestivalId: 'cbf2025',
+            version: '1.0.0',
+            baseUrl: 'https://example.com',
+          ),
+        );
+        await provider.initialize();
+        expect(provider.currentFestival.id, 'cbf2025');
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(routerConfig: appRouter),
-        ),
-      );
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      appRouter.go('/cbf2024/favorites');
-      await tester.pumpAndSettle();
+        appRouter.go('/cbf2024/favorites');
+        await tester.pumpAndSettle();
 
-      expect(provider.currentFestival.id, 'cbf2024',
+        expect(
+          provider.currentFestival.id,
+          'cbf2024',
           reason:
-              'Navigating to favorites of a different festival should switch provider');
-    });
+              'Navigating to favorites of a different festival should switch provider',
+        );
+      },
+    );
 
     testWidgets(
-        'brewery, style and info routes are reachable for valid festival',
-        (tester) async {
-      await provider.initialize();
+      'brewery, style and info routes are reachable for valid festival',
+      (tester) async {
+        await provider.initialize();
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(routerConfig: appRouter),
-        ),
-      );
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      // Brewery route
-      appRouter.go('/$testFestivalId/brewery/$testBreweryId');
-      await tester.pumpAndSettle();
-      var uri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(uri.pathSegments[0], testFestivalId);
-      expect(uri.pathSegments[1], 'brewery');
+        // Brewery route
+        appRouter.go('/$testFestivalId/brewery/$testBreweryId');
+        await tester.pumpAndSettle();
+        var uri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(uri.pathSegments[1], 'brewery');
 
-      // Style route
-      appRouter.go('/$testFestivalId/style/IPA');
-      await tester.pumpAndSettle();
-      uri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(uri.pathSegments[0], testFestivalId);
-      expect(uri.pathSegments[1], 'style');
+        // Style route
+        appRouter.go('/$testFestivalId/style/IPA');
+        await tester.pumpAndSettle();
+        uri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(uri.pathSegments[1], 'style');
 
-      // Info route
-      appRouter.go('/$testFestivalId/info');
-      await tester.pumpAndSettle();
-      uri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(uri.pathSegments[0], testFestivalId);
-      expect(uri.pathSegments[1], 'info');
-    });
-
-    testWidgets(
-        'style route with illegal percent encoding does not crash the build',
-        (tester) async {
-      await provider.initialize();
-
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(routerConfig: appRouter),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      // A malformed URL (e.g. an old bookmark with a stray `%`) previously
-      // crashed the build via Uri.decodeComponent throwing.
-      appRouter.go('/$testFestivalId/style/50%');
-      await tester.pumpAndSettle();
-
-      expect(tester.takeException(), isNull);
-      expect(find.byType(StyleScreen), findsOneWidget);
-    });
+        // Info route
+        appRouter.go('/$testFestivalId/info');
+        await tester.pumpAndSettle();
+        uri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(uri.pathSegments[1], 'info');
+      },
+    );
 
     testWidgets(
-        'navigating to drink detail updates URL with category and drink ID',
-        (tester) async {
-      await provider.initialize();
+      'style route with illegal percent encoding does not crash the build',
+      (tester) async {
+        await provider.initialize();
 
-      await tester.pumpWidget(
-        ChangeNotifierProvider<BeerProvider>.value(
-          value: provider,
-          child: MaterialApp.router(routerConfig: appRouter),
-        ),
-      );
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      // Start at drinks list
-      appRouter.go('/$testFestivalId');
-      await tester.pumpAndSettle();
+        // A malformed URL (e.g. an old bookmark with a stray `%`) previously
+        // crashed the build via Uri.decodeComponent throwing.
+        appRouter.go('/$testFestivalId/style/50%');
+        await tester.pumpAndSettle();
 
-      // On web, navigateToRoute() uses context.go so the URL updates.
-      // Simulate this by calling appRouter.go (equivalent on web).
-      const category = 'beer';
-      appRouter.go('/$testFestivalId/drink/$category/$testDrinkId');
-      await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull);
+        expect(find.byType(StyleScreen), findsOneWidget);
+      },
+    );
 
-      // URL must update to the full /:festivalId/drink/:category/:id deep-link format
-      final uri = Uri.parse(
-          appRouter.routerDelegate.currentConfiguration.uri.toString());
-      expect(uri.pathSegments.length, 4,
+    testWidgets(
+      'navigating to drink detail updates URL with category and drink ID',
+      (tester) async {
+        await provider.initialize();
+
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Start at drinks list
+        appRouter.go('/$testFestivalId');
+        await tester.pumpAndSettle();
+
+        // On web, navigateToRoute() uses context.go so the URL updates.
+        // Simulate this by calling appRouter.go (equivalent on web).
+        const category = 'beer';
+        appRouter.go('/$testFestivalId/drink/$category/$testDrinkId');
+        await tester.pumpAndSettle();
+
+        // URL must update to the full /:festivalId/drink/:category/:id deep-link format
+        final uri = Uri.parse(
+          appRouter.routerDelegate.currentConfiguration.uri.toString(),
+        );
+        expect(
+          uri.pathSegments.length,
+          4,
           reason:
-              'Drink detail URL must include festivalId, "drink", category, and drinkId');
-      expect(uri.pathSegments[0], testFestivalId);
-      expect(uri.pathSegments[1], 'drink');
-      expect(uri.pathSegments[2], category);
-      expect(uri.pathSegments[3], testDrinkId,
+              'Drink detail URL must include festivalId, "drink", category, and drinkId',
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(uri.pathSegments[1], 'drink');
+        expect(uri.pathSegments[2], category);
+        expect(
+          uri.pathSegments[3],
+          testDrinkId,
           reason:
-              'URL must match deep-link format so shared/bookmarked links work');
-    });
+              'URL must match deep-link format so shared/bookmarked links work',
+        );
+      },
+    );
   });
 
   group('Router Navigation Paths (Phase 1 - Festival-scoped)', () {

--- a/test/screens_test.dart
+++ b/test/screens_test.dart
@@ -125,8 +125,9 @@ void main() {
       );
     }
 
-    testWidgets('shows error SnackBar when website URL cannot be launched',
-        (WidgetTester tester) async {
+    testWidgets('shows error SnackBar when website URL cannot be launched', (
+      WidgetTester tester,
+    ) async {
       // Mock canLaunchUrl to return false
       mockUrlLauncher.canLaunchResult = false;
 
@@ -142,24 +143,27 @@ void main() {
       expect(find.text('Could not open website'), findsOneWidget);
     });
 
-    testWidgets('shows error SnackBar when website URL launch throws exception',
-        (WidgetTester tester) async {
-      // Mock launch to throw exception
-      mockUrlLauncher.shouldThrowOnLaunch = true;
+    testWidgets(
+      'shows error SnackBar when website URL launch throws exception',
+      (WidgetTester tester) async {
+        // Mock launch to throw exception
+        mockUrlLauncher.shouldThrowOnLaunch = true;
 
-      await tester.pumpWidget(createTestWidget());
+        await tester.pumpWidget(createTestWidget());
 
-      // Find and tap the website button
-      final websiteButton = find.text('Visit Festival Website');
-      await tester.tap(websiteButton);
-      await tester.pumpAndSettle();
+        // Find and tap the website button
+        final websiteButton = find.text('Visit Festival Website');
+        await tester.tap(websiteButton);
+        await tester.pumpAndSettle();
 
-      // Verify error SnackBar is shown (now unified message)
-      expect(find.text('Could not open website'), findsOneWidget);
-    });
+        // Verify error SnackBar is shown (now unified message)
+        expect(find.text('Could not open website'), findsOneWidget);
+      },
+    );
 
-    testWidgets('shows error SnackBar when maps URL cannot be launched',
-        (WidgetTester tester) async {
+    testWidgets('shows error SnackBar when maps URL cannot be launched', (
+      WidgetTester tester,
+    ) async {
       // Mock canLaunchUrl to return false
       mockUrlLauncher.canLaunchResult = false;
 
@@ -175,8 +179,9 @@ void main() {
       expect(find.text('Could not open maps'), findsOneWidget);
     });
 
-    testWidgets('shows error SnackBar when maps URL launch throws exception',
-        (WidgetTester tester) async {
+    testWidgets('shows error SnackBar when maps URL launch throws exception', (
+      WidgetTester tester,
+    ) async {
       // Mock launch to throw exception
       mockUrlLauncher.shouldThrowOnLaunch = true;
 
@@ -191,8 +196,9 @@ void main() {
       expect(find.text('Could not open maps'), findsOneWidget);
     });
 
-    testWidgets('successfully launches website URL when canLaunch returns true',
-        (WidgetTester tester) async {
+    testWidgets('successfully launches website URL when canLaunch returns true', (
+      WidgetTester tester,
+    ) async {
       // Default mock behavior allows launch
 
       await tester.pumpWidget(createTestWidget());
@@ -208,8 +214,9 @@ void main() {
       expect(find.text('Error opening website'), findsNothing);
     });
 
-    testWidgets('successfully launches maps URL when canLaunch returns true',
-        (WidgetTester tester) async {
+    testWidgets('successfully launches maps URL when canLaunch returns true', (
+      WidgetTester tester,
+    ) async {
       // Default mock behavior allows launch
 
       await tester.pumpWidget(createTestWidget());
@@ -220,8 +227,10 @@ void main() {
       await tester.pumpAndSettle();
 
       // Verify launch was called with correct URL and no error SnackBar is shown
-      expect(mockUrlLauncher.lastLaunchedUrl,
-          'https://www.google.com/maps/search/?api=1&query=52.2053,0.1218');
+      expect(
+        mockUrlLauncher.lastLaunchedUrl,
+        'https://www.google.com/maps/search/?api=1&query=52.2053,0.1218',
+      );
       expect(find.text('Could not open maps'), findsNothing);
       expect(find.text('Error opening maps'), findsNothing);
     });
@@ -246,37 +255,43 @@ void main() {
         await provider.setFestival(charityFestival);
       });
 
-      testWidgets('renders donate button when charity fields are set',
-          (WidgetTester tester) async {
+      testWidgets('renders donate button when charity fields are set', (
+        WidgetTester tester,
+      ) async {
         await tester.pumpWidget(createTestWidget());
 
         expect(find.text('Donate to Test Charity'), findsOneWidget);
       });
 
       testWidgets(
-          'does not render donate button when charity fields are absent',
-          (WidgetTester tester) async {
-        await provider.setFestival(testFestival);
-        await tester.pumpWidget(createTestWidget());
+        'does not render donate button when charity fields are absent',
+        (WidgetTester tester) async {
+          await provider.setFestival(testFestival);
+          await tester.pumpWidget(createTestWidget());
 
-        expect(find.textContaining('Donate to'), findsNothing);
-      });
+          expect(find.textContaining('Donate to'), findsNothing);
+        },
+      );
 
-      testWidgets('successfully launches donation URL',
-          (WidgetTester tester) async {
+      testWidgets('successfully launches donation URL', (
+        WidgetTester tester,
+      ) async {
         await tester.pumpWidget(createTestWidget());
 
         final donateButton = find.text('Donate to Test Charity');
         await tester.tap(donateButton);
         await tester.pumpAndSettle();
 
-        expect(mockUrlLauncher.lastLaunchedUrl,
-            'https://charity.example.com/donate');
+        expect(
+          mockUrlLauncher.lastLaunchedUrl,
+          'https://charity.example.com/donate',
+        );
         expect(find.text('Could not open donation page'), findsNothing);
       });
 
-      testWidgets('shows error SnackBar when donation URL cannot be launched',
-          (WidgetTester tester) async {
+      testWidgets('shows error SnackBar when donation URL cannot be launched', (
+        WidgetTester tester,
+      ) async {
         mockUrlLauncher.canLaunchResult = false;
 
         await tester.pumpWidget(createTestWidget());
@@ -289,18 +304,19 @@ void main() {
       });
 
       testWidgets(
-          'shows error SnackBar when donation URL launch throws exception',
-          (WidgetTester tester) async {
-        mockUrlLauncher.shouldThrowOnLaunch = true;
+        'shows error SnackBar when donation URL launch throws exception',
+        (WidgetTester tester) async {
+          mockUrlLauncher.shouldThrowOnLaunch = true;
 
-        await tester.pumpWidget(createTestWidget());
+          await tester.pumpWidget(createTestWidget());
 
-        final donateButton = find.text('Donate to Test Charity');
-        await tester.tap(donateButton);
-        await tester.pumpAndSettle();
+          final donateButton = find.text('Donate to Test Charity');
+          await tester.tap(donateButton);
+          await tester.pumpAndSettle();
 
-        expect(find.text('Could not open donation page'), findsOneWidget);
-      });
+          expect(find.text('Could not open donation page'), findsOneWidget);
+        },
+      );
     });
   });
 
@@ -339,9 +355,7 @@ void main() {
     Widget createTestWidget() {
       return ChangeNotifierProvider<BeerProvider>.value(
         value: provider,
-        child: const MaterialApp(
-          home: AboutScreen(),
-        ),
+        child: const MaterialApp(home: AboutScreen()),
       );
     }
 
@@ -365,8 +379,9 @@ void main() {
       expect(find.text('Legal'), findsOneWidget);
     });
 
-    testWidgets('successfully launches GitHub repository URL',
-        (WidgetTester tester) async {
+    testWidgets('successfully launches GitHub repository URL', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
 
       final githubButton = find.widgetWithText(ListTile, 'Source Code');
@@ -374,14 +389,17 @@ void main() {
       await tester.tap(githubButton);
       await tester.pumpAndSettle();
 
-      expect(mockUrlLauncher.lastLaunchedUrl,
-          'https://github.com/richardthe3rd/cambridge-beer-festival-app');
+      expect(
+        mockUrlLauncher.lastLaunchedUrl,
+        'https://github.com/richardthe3rd/cambridge-beer-festival-app',
+      );
       expect(find.text('Could not open GitHub'), findsNothing);
       expect(find.text('Error opening GitHub'), findsNothing);
     });
 
-    testWidgets('shows error SnackBar when GitHub URL cannot be launched',
-        (WidgetTester tester) async {
+    testWidgets('shows error SnackBar when GitHub URL cannot be launched', (
+      WidgetTester tester,
+    ) async {
       mockUrlLauncher.canLaunchResult = false;
 
       await tester.pumpWidget(createTestWidget());
@@ -394,23 +412,26 @@ void main() {
       expect(find.text('Could not open GitHub'), findsOneWidget);
     });
 
-    testWidgets('shows error SnackBar when GitHub URL launch throws exception',
-        (WidgetTester tester) async {
-      mockUrlLauncher.shouldThrowOnLaunch = true;
+    testWidgets(
+      'shows error SnackBar when GitHub URL launch throws exception',
+      (WidgetTester tester) async {
+        mockUrlLauncher.shouldThrowOnLaunch = true;
 
-      await tester.pumpWidget(createTestWidget());
+        await tester.pumpWidget(createTestWidget());
 
-      final githubButton = find.widgetWithText(ListTile, 'Source Code');
-      await tester.ensureVisible(githubButton);
-      await tester.tap(githubButton);
-      await tester.pumpAndSettle();
+        final githubButton = find.widgetWithText(ListTile, 'Source Code');
+        await tester.ensureVisible(githubButton);
+        await tester.tap(githubButton);
+        await tester.pumpAndSettle();
 
-      // Now using unified error message
-      expect(find.text('Could not open GitHub'), findsOneWidget);
-    });
+        // Now using unified error message
+        expect(find.text('Could not open GitHub'), findsOneWidget);
+      },
+    );
 
-    testWidgets('successfully launches GitHub Issues URL',
-        (WidgetTester tester) async {
+    testWidgets('successfully launches GitHub Issues URL', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
 
       final issuesButton = find.widgetWithText(ListTile, 'Report an Issue');
@@ -418,14 +439,17 @@ void main() {
       await tester.tap(issuesButton);
       await tester.pumpAndSettle();
 
-      expect(mockUrlLauncher.lastLaunchedUrl,
-          'https://github.com/richardthe3rd/cambridge-beer-festival-app/issues');
+      expect(
+        mockUrlLauncher.lastLaunchedUrl,
+        'https://github.com/richardthe3rd/cambridge-beer-festival-app/issues',
+      );
       expect(find.text('Could not open GitHub Issues'), findsNothing);
       expect(find.text('Error opening GitHub Issues'), findsNothing);
     });
 
-    testWidgets('shows error SnackBar when Issues URL cannot be launched',
-        (WidgetTester tester) async {
+    testWidgets('shows error SnackBar when Issues URL cannot be launched', (
+      WidgetTester tester,
+    ) async {
       mockUrlLauncher.canLaunchResult = false;
 
       await tester.pumpWidget(createTestWidget());
@@ -438,23 +462,26 @@ void main() {
       expect(find.text('Could not open GitHub Issues'), findsOneWidget);
     });
 
-    testWidgets('shows error SnackBar when Issues URL launch throws exception',
-        (WidgetTester tester) async {
-      mockUrlLauncher.shouldThrowOnLaunch = true;
+    testWidgets(
+      'shows error SnackBar when Issues URL launch throws exception',
+      (WidgetTester tester) async {
+        mockUrlLauncher.shouldThrowOnLaunch = true;
 
-      await tester.pumpWidget(createTestWidget());
+        await tester.pumpWidget(createTestWidget());
 
-      final issuesButton = find.widgetWithText(ListTile, 'Report an Issue');
-      await tester.ensureVisible(issuesButton);
-      await tester.tap(issuesButton);
-      await tester.pumpAndSettle();
+        final issuesButton = find.widgetWithText(ListTile, 'Report an Issue');
+        await tester.ensureVisible(issuesButton);
+        await tester.tap(issuesButton);
+        await tester.pumpAndSettle();
 
-      // Now using unified error message
-      expect(find.text('Could not open GitHub Issues'), findsOneWidget);
-    });
+        // Now using unified error message
+        expect(find.text('Could not open GitHub Issues'), findsOneWidget);
+      },
+    );
 
-    testWidgets('opens theme selector when theme tile is tapped',
-        (WidgetTester tester) async {
+    testWidgets('opens theme selector when theme tile is tapped', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
 
       final themeButton = find.widgetWithText(ListTile, 'Theme');
@@ -469,8 +496,9 @@ void main() {
       expect(find.text('Follow device settings'), findsOneWidget);
     });
 
-    testWidgets('changes theme mode when option is selected',
-        (WidgetTester tester) async {
+    testWidgets('changes theme mode when option is selected', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestWidget());
 
       // Initial theme mode should be system
@@ -494,8 +522,10 @@ void main() {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
-      final licenseButton =
-          find.widgetWithText(ListTile, 'Open Source Licenses');
+      final licenseButton = find.widgetWithText(
+        ListTile,
+        'Open Source Licenses',
+      );
       await tester.ensureVisible(licenseButton);
       await tester.pumpAndSettle();
 
@@ -507,8 +537,9 @@ void main() {
       expect(find.byType(LicensePage), findsOneWidget);
     });
 
-    testWidgets('shows home button when there is no back history',
-        (WidgetTester tester) async {
+    testWidgets('shows home button when there is no back history', (
+      WidgetTester tester,
+    ) async {
       // MaterialApp has no GoRouter, so canPopNavigation returns false
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
@@ -534,15 +565,18 @@ void main() {
         festivalRepository: mockFestivalRepository,
         analyticsService: mockAnalyticsService,
       );
-      await provider.setFestival(const Festival(
-        id: 'test-festival',
-        name: 'Test Festival',
-        dataBaseUrl: 'https://example.com',
-      ));
+      await provider.setFestival(
+        const Festival(
+          id: 'test-festival',
+          name: 'Test Festival',
+          dataBaseUrl: 'https://example.com',
+        ),
+      );
     });
 
-    testWidgets('shows home button when there is no back history',
-        (WidgetTester tester) async {
+    testWidgets('shows home button when there is no back history', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
@@ -592,12 +626,14 @@ void main() {
     }
 
     testWidgets('shows hashtag when festival has one', (tester) async {
-      await provider.setFestival(const Festival(
-        id: 'test-festival',
-        name: 'Test Festival',
-        dataBaseUrl: 'https://example.com',
-        hashtag: '#CBF2025',
-      ));
+      await provider.setFestival(
+        const Festival(
+          id: 'test-festival',
+          name: 'Test Festival',
+          dataBaseUrl: 'https://example.com',
+          hashtag: '#CBF2025',
+        ),
+      );
 
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
@@ -606,12 +642,14 @@ void main() {
     });
 
     testWidgets('shows ACTIVE badge for an active festival', (tester) async {
-      await provider.setFestival(const Festival(
-        id: 'test-festival',
-        name: 'Test Festival',
-        dataBaseUrl: 'https://example.com',
-        isActive: true,
-      ));
+      await provider.setFestival(
+        const Festival(
+          id: 'test-festival',
+          name: 'Test Festival',
+          dataBaseUrl: 'https://example.com',
+          isActive: true,
+        ),
+      );
 
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
@@ -619,14 +657,17 @@ void main() {
       expect(find.text('ACTIVE'), findsOneWidget);
     });
 
-    testWidgets('shows Festival Hours section when hours are provided',
-        (tester) async {
-      await provider.setFestival(const Festival(
-        id: 'test-festival',
-        name: 'Test Festival',
-        dataBaseUrl: 'https://example.com',
-        hours: {'Monday': '12:00–22:00', 'Tuesday': '12:00–22:00'},
-      ));
+    testWidgets('shows Festival Hours section when hours are provided', (
+      tester,
+    ) async {
+      await provider.setFestival(
+        const Festival(
+          id: 'test-festival',
+          name: 'Test Festival',
+          dataBaseUrl: 'https://example.com',
+          hours: {'Monday': '12:00–22:00', 'Tuesday': '12:00–22:00'},
+        ),
+      );
 
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
@@ -636,14 +677,17 @@ void main() {
       expect(find.text('12:00–22:00'), findsAtLeastNWidgets(1));
     });
 
-    testWidgets('shows About section when description is provided',
-        (tester) async {
-      await provider.setFestival(const Festival(
-        id: 'test-festival',
-        name: 'Test Festival',
-        dataBaseUrl: 'https://example.com',
-        description: 'A great festival of fine ales.',
-      ));
+    testWidgets('shows About section when description is provided', (
+      tester,
+    ) async {
+      await provider.setFestival(
+        const Festival(
+          id: 'test-festival',
+          name: 'Test Festival',
+          dataBaseUrl: 'https://example.com',
+          description: 'A great festival of fine ales.',
+        ),
+      );
 
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
@@ -652,11 +696,13 @@ void main() {
     });
 
     testWidgets('GitHub button launches correct URL', (tester) async {
-      await provider.setFestival(const Festival(
-        id: 'test-festival',
-        name: 'Test Festival',
-        dataBaseUrl: 'https://example.com',
-      ));
+      await provider.setFestival(
+        const Festival(
+          id: 'test-festival',
+          name: 'Test Festival',
+          dataBaseUrl: 'https://example.com',
+        ),
+      );
 
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
@@ -666,8 +712,10 @@ void main() {
       await tester.tap(githubButton);
       await tester.pumpAndSettle();
 
-      expect(mockUrlLauncher.lastLaunchedUrl,
-          'https://github.com/richardthe3rd/cambridge-beer-festival-app');
+      expect(
+        mockUrlLauncher.lastLaunchedUrl,
+        'https://github.com/richardthe3rd/cambridge-beer-festival-app',
+      );
     });
   });
 
@@ -704,8 +752,9 @@ void main() {
       );
     }
 
-    testWidgets('selects system theme from theme selector sheet',
-        (tester) async {
+    testWidgets('selects system theme from theme selector sheet', (
+      tester,
+    ) async {
       await provider.setThemeMode(ThemeMode.light);
       await tester.pumpWidget(createTestWidget());
 

--- a/test/services/festival_service_test.dart
+++ b/test/services/festival_service_test.dart
@@ -6,73 +6,70 @@ void main() {
     const baseUrl = 'https://example.com';
 
     Map<String, dynamic> validFestivalJson({String id = 'cbf2025'}) => {
-          'id': id,
-          'name': 'Cambridge Beer Festival 2025',
-          'data_base_url': 'https://data.example.com/$id',
-        };
+      'id': id,
+      'name': 'Cambridge Beer Festival 2025',
+      'data_base_url': 'https://data.example.com/$id',
+    };
 
     test('parses a valid response with one festival', () {
-      final response = FestivalsResponse.fromJson(
-        {
-          'festivals': [validFestivalJson()],
-          'default_festival_id': 'cbf2025',
-        },
-        baseUrl,
-      );
+      final response = FestivalsResponse.fromJson({
+        'festivals': [validFestivalJson()],
+        'default_festival_id': 'cbf2025',
+      }, baseUrl);
 
       expect(response.festivals.length, 1);
       expect(response.festivals.single.id, 'cbf2025');
       expect(response.defaultFestivalId, 'cbf2025');
     });
 
-    test('skips a festival entry with a null id and returns the valid ones',
-        () {
-      final response = FestivalsResponse.fromJson(
-        {
+    test(
+      'skips a festival entry with a null id and returns the valid ones',
+      () {
+        final response = FestivalsResponse.fromJson({
           'festivals': [
             validFestivalJson(id: 'cbf2025'),
             {
               'id': null,
               'name': 'Bad Festival',
-              'data_base_url': 'https://data.example.com/bad'
+              'data_base_url': 'https://data.example.com/bad',
             },
             validFestivalJson(id: 'cbf2024'),
           ],
           'default_festival_id': 'cbf2025',
-        },
-        baseUrl,
-      );
+        }, baseUrl);
 
-      expect(response.festivals.length, 2);
-      expect(response.festivals.map((f) => f.id),
-          containsAll(['cbf2025', 'cbf2024']));
-    });
+        expect(response.festivals.length, 2);
+        expect(
+          response.festivals.map((f) => f.id),
+          containsAll(['cbf2025', 'cbf2024']),
+        );
+      },
+    );
 
     test(
-        'skips a festival entry with a missing data_base_url and returns the valid ones',
-        () {
-      final response = FestivalsResponse.fromJson(
-        {
+      'skips a festival entry with a missing data_base_url and returns the valid ones',
+      () {
+        final response = FestivalsResponse.fromJson({
           'festivals': [
             validFestivalJson(id: 'cbf2025'),
             {'id': 'bad', 'name': 'No URL Festival'},
             validFestivalJson(id: 'cbf2024'),
           ],
           'default_festival_id': 'cbf2025',
-        },
-        baseUrl,
-      );
+        }, baseUrl);
 
-      expect(response.festivals.length, 2);
-      expect(response.festivals.map((f) => f.id),
-          containsAll(['cbf2025', 'cbf2024']));
-    });
+        expect(response.festivals.length, 2);
+        expect(
+          response.festivals.map((f) => f.id),
+          containsAll(['cbf2025', 'cbf2024']),
+        );
+      },
+    );
 
     test(
-        'skips a festival entry whose value is not a Map and returns the valid ones',
-        () {
-      final response = FestivalsResponse.fromJson(
-        {
+      'skips a festival entry whose value is not a Map and returns the valid ones',
+      () {
+        final response = FestivalsResponse.fromJson({
           'festivals': [
             validFestivalJson(id: 'cbf2025'),
             'this is not a map',
@@ -80,68 +77,56 @@ void main() {
             validFestivalJson(id: 'cbf2024'),
           ],
           'default_festival_id': 'cbf2025',
-        },
-        baseUrl,
-      );
+        }, baseUrl);
 
-      expect(response.festivals.length, 2);
-      expect(response.festivals.map((f) => f.id),
-          containsAll(['cbf2025', 'cbf2024']));
-    });
+        expect(response.festivals.length, 2);
+        expect(
+          response.festivals.map((f) => f.id),
+          containsAll(['cbf2025', 'cbf2024']),
+        );
+      },
+    );
 
     test('returns an empty festival list when all entries are malformed', () {
-      final response = FestivalsResponse.fromJson(
-        {
-          'festivals': [
-            {
-              'id': null,
-              'name': 'Bad1',
-              'data_base_url': 'https://data.example.com/bad'
-            },
-            {'name': 'Bad2'},
-          ],
-          'default_festival_id': 'cbf2025',
-        },
-        baseUrl,
-      );
+      final response = FestivalsResponse.fromJson({
+        'festivals': [
+          {
+            'id': null,
+            'name': 'Bad1',
+            'data_base_url': 'https://data.example.com/bad',
+          },
+          {'name': 'Bad2'},
+        ],
+        'default_festival_id': 'cbf2025',
+      }, baseUrl);
 
       expect(response.festivals, isEmpty);
     });
 
     test('handles a null or missing "festivals" key without throwing', () {
-      final responseWithNull = FestivalsResponse.fromJson(
-        {
-          'festivals': null,
-          'default_festival_id': 'cbf2025',
-        },
-        baseUrl,
-      );
+      final responseWithNull = FestivalsResponse.fromJson({
+        'festivals': null,
+        'default_festival_id': 'cbf2025',
+      }, baseUrl);
       expect(responseWithNull.festivals, isEmpty);
 
-      final responseWithMissing = FestivalsResponse.fromJson(
-        {'default_festival_id': 'cbf2025'},
-        baseUrl,
-      );
+      final responseWithMissing = FestivalsResponse.fromJson({
+        'default_festival_id': 'cbf2025',
+      }, baseUrl);
       expect(responseWithMissing.festivals, isEmpty);
     });
 
     test('handles a non-List value for "festivals" key without throwing', () {
-      final responseWithMap = FestivalsResponse.fromJson(
-        {
-          'festivals': {'unexpected': 'map'},
-          'default_festival_id': 'cbf2025',
-        },
-        baseUrl,
-      );
+      final responseWithMap = FestivalsResponse.fromJson({
+        'festivals': {'unexpected': 'map'},
+        'default_festival_id': 'cbf2025',
+      }, baseUrl);
       expect(responseWithMap.festivals, isEmpty);
 
-      final responseWithString = FestivalsResponse.fromJson(
-        {
-          'festivals': 'not a list',
-          'default_festival_id': 'cbf2025',
-        },
-        baseUrl,
-      );
+      final responseWithString = FestivalsResponse.fromJson({
+        'festivals': 'not a list',
+        'default_festival_id': 'cbf2025',
+      }, baseUrl);
       expect(responseWithString.festivals, isEmpty);
     });
   });

--- a/test/services_test.dart
+++ b/test/services_test.dart
@@ -104,13 +104,19 @@ void main() {
         'default_festival_id': 'cbf2025',
       };
 
-      final response =
-          FestivalsResponse.fromJson(json, 'https://data.cambeerfestival.app');
+      final response = FestivalsResponse.fromJson(
+        json,
+        'https://data.cambeerfestival.app',
+      );
 
-      expect(response.festivals[0].dataBaseUrl,
-          'https://data.cambeerfestival.app/cbf2025');
-      expect(response.festivals[1].dataBaseUrl,
-          'https://data.cambeerfestival.app/cbfw2025');
+      expect(
+        response.festivals[0].dataBaseUrl,
+        'https://data.cambeerfestival.app/cbf2025',
+      );
+      expect(
+        response.festivals[1].dataBaseUrl,
+        'https://data.cambeerfestival.app/cbfw2025',
+      );
     });
 
     test('fromJson handles missing optional fields', () {
@@ -304,9 +310,9 @@ void main() {
       );
 
       // Mock a quick successful response
-      when(mockClient.get(any)).thenAnswer(
-        (_) async => http.Response('{"producers": []}', 200),
-      );
+      when(
+        mockClient.get(any),
+      ).thenAnswer((_) async => http.Response('{"producers": []}', 200));
 
       // Should complete successfully
       final result = await service.fetchDrinks(festival, 'beer');
@@ -386,14 +392,19 @@ void main() {
       final mockClient = MockClient();
       final service = FestivalService(client: mockClient);
 
-      when(mockClient.get(any)).thenAnswer(
-        (_) async => http.Response('Service unavailable', 503),
-      );
+      when(
+        mockClient.get(any),
+      ).thenAnswer((_) async => http.Response('Service unavailable', 503));
 
       await expectLater(
         service.fetchFestivals(),
-        throwsA(isA<FestivalServiceException>()
-            .having((e) => e.statusCode, 'statusCode', 503)),
+        throwsA(
+          isA<FestivalServiceException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            503,
+          ),
+        ),
       );
 
       service.dispose();

--- a/test/services_test.mocks.dart
+++ b/test/services_test.mocks.dart
@@ -27,24 +27,14 @@ import 'package:mockito/src/dummies.dart' as _i5;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeResponse_0 extends _i1.SmartFake implements _i2.Response {
-  _FakeResponse_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeResponse_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeStreamedResponse_1 extends _i1.SmartFake
     implements _i2.StreamedResponse {
-  _FakeStreamedResponse_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeStreamedResponse_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [Client].
@@ -56,46 +46,30 @@ class MockClient extends _i1.Mock implements _i2.Client {
   }
 
   @override
-  _i3.Future<_i2.Response> head(
-    Uri? url, {
-    Map<String, String>? headers,
-  }) =>
+  _i3.Future<_i2.Response> head(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #head,
-          [url],
-          {#headers: headers},
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #head,
-            [url],
-            {#headers: headers},
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(#head, [url], {#headers: headers}),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(#head, [url], {#headers: headers}),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i3.Future<_i2.Response> get(
-    Uri? url, {
-    Map<String, String>? headers,
-  }) =>
+  _i3.Future<_i2.Response> get(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #get,
-          [url],
-          {#headers: headers},
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #get,
-            [url],
-            {#headers: headers},
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(#get, [url], {#headers: headers}),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(#get, [url], {#headers: headers}),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> post(
@@ -105,28 +79,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #post,
-          [url],
-          {
-            #headers: headers,
-            #body: body,
-            #encoding: encoding,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #post,
-            [url],
-            {
-              #headers: headers,
-              #body: body,
-              #encoding: encoding,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #post,
+              [url],
+              {#headers: headers, #body: body, #encoding: encoding},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(
+                  #post,
+                  [url],
+                  {#headers: headers, #body: body, #encoding: encoding},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> put(
@@ -136,28 +105,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #put,
-          [url],
-          {
-            #headers: headers,
-            #body: body,
-            #encoding: encoding,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #put,
-            [url],
-            {
-              #headers: headers,
-              #body: body,
-              #encoding: encoding,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #put,
+              [url],
+              {#headers: headers, #body: body, #encoding: encoding},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(
+                  #put,
+                  [url],
+                  {#headers: headers, #body: body, #encoding: encoding},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> patch(
@@ -167,28 +131,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #patch,
-          [url],
-          {
-            #headers: headers,
-            #body: body,
-            #encoding: encoding,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #patch,
-            [url],
-            {
-              #headers: headers,
-              #body: body,
-              #encoding: encoding,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #patch,
+              [url],
+              {#headers: headers, #body: body, #encoding: encoding},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(
+                  #patch,
+                  [url],
+                  {#headers: headers, #body: body, #encoding: encoding},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> delete(
@@ -198,49 +157,36 @@ class MockClient extends _i1.Mock implements _i2.Client {
     _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #delete,
-          [url],
-          {
-            #headers: headers,
-            #body: body,
-            #encoding: encoding,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #delete,
-            [url],
-            {
-              #headers: headers,
-              #body: body,
-              #encoding: encoding,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #delete,
+              [url],
+              {#headers: headers, #body: body, #encoding: encoding},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(
+                  #delete,
+                  [url],
+                  {#headers: headers, #body: body, #encoding: encoding},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i3.Future<String> read(
-    Uri? url, {
-    Map<String, String>? headers,
-  }) =>
+  _i3.Future<String> read(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #read,
-          [url],
-          {#headers: headers},
-        ),
-        returnValue: _i3.Future<String>.value(_i5.dummyValue<String>(
-          this,
-          Invocation.method(
-            #read,
-            [url],
-            {#headers: headers},
-          ),
-        )),
-      ) as _i3.Future<String>);
+            Invocation.method(#read, [url], {#headers: headers}),
+            returnValue: _i3.Future<String>.value(
+              _i5.dummyValue<String>(
+                this,
+                Invocation.method(#read, [url], {#headers: headers}),
+              ),
+            ),
+          )
+          as _i3.Future<String>);
 
   @override
   _i3.Future<_i6.Uint8List> readBytes(
@@ -248,37 +194,27 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #readBytes,
-          [url],
-          {#headers: headers},
-        ),
-        returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
-      ) as _i3.Future<_i6.Uint8List>);
+            Invocation.method(#readBytes, [url], {#headers: headers}),
+            returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
+          )
+          as _i3.Future<_i6.Uint8List>);
 
   @override
   _i3.Future<_i2.StreamedResponse> send(_i2.BaseRequest? request) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #send,
-          [request],
-        ),
-        returnValue:
-            _i3.Future<_i2.StreamedResponse>.value(_FakeStreamedResponse_1(
-          this,
-          Invocation.method(
-            #send,
-            [request],
-          ),
-        )),
-      ) as _i3.Future<_i2.StreamedResponse>);
+            Invocation.method(#send, [request]),
+            returnValue: _i3.Future<_i2.StreamedResponse>.value(
+              _FakeStreamedResponse_1(
+                this,
+                Invocation.method(#send, [request]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.StreamedResponse>);
 
   @override
   void close() => super.noSuchMethod(
-        Invocation.method(
-          #close,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#close, []),
+    returnValueForMissingStub: null,
+  );
 }

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -68,8 +68,10 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       favoritesService = FavoritesService(prefs);
 
-      final result =
-          await favoritesService.toggleFavorite('cbf2025', 'drink-123');
+      final result = await favoritesService.toggleFavorite(
+        'cbf2025',
+        'drink-123',
+      );
 
       expect(result, isTrue);
       expect(favoritesService.isFavorite('cbf2025', 'drink-123'), isTrue);
@@ -80,8 +82,10 @@ void main() {
       favoritesService = FavoritesService(prefs);
 
       await favoritesService.addFavorite('cbf2025', 'drink-123');
-      final result =
-          await favoritesService.toggleFavorite('cbf2025', 'drink-123');
+      final result = await favoritesService.toggleFavorite(
+        'cbf2025',
+        'drink-123',
+      );
 
       expect(result, isFalse);
       expect(favoritesService.isFavorite('cbf2025', 'drink-123'), isFalse);
@@ -116,23 +120,25 @@ void main() {
       expect(favoritesService.isFavorite('cbf2024', 'drink-123'), isFalse);
     });
 
-    test('getFavorites returns separate sets for different festivals',
-        () async {
-      final prefs = await SharedPreferences.getInstance();
-      favoritesService = FavoritesService(prefs);
+    test(
+      'getFavorites returns separate sets for different festivals',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        favoritesService = FavoritesService(prefs);
 
-      await favoritesService.addFavorite('cbf2025', 'drink-a');
-      await favoritesService.addFavorite('cbf2025', 'drink-b');
-      await favoritesService.addFavorite('cbf2024', 'drink-c');
+        await favoritesService.addFavorite('cbf2025', 'drink-a');
+        await favoritesService.addFavorite('cbf2025', 'drink-b');
+        await favoritesService.addFavorite('cbf2024', 'drink-c');
 
-      final favorites2025 = favoritesService.getFavorites('cbf2025');
-      final favorites2024 = favoritesService.getFavorites('cbf2024');
+        final favorites2025 = favoritesService.getFavorites('cbf2025');
+        final favorites2024 = favoritesService.getFavorites('cbf2024');
 
-      expect(favorites2025.length, 2);
-      expect(favorites2024.length, 1);
-      expect(favorites2025, containsAll(['drink-a', 'drink-b']));
-      expect(favorites2024, contains('drink-c'));
-    });
+        expect(favorites2025.length, 2);
+        expect(favorites2024.length, 1);
+        expect(favorites2025, containsAll(['drink-a', 'drink-b']));
+        expect(favorites2024, contains('drink-c'));
+      },
+    );
   });
 
   group('RatingsService', () {
@@ -265,15 +271,17 @@ void main() {
       SharedPreferences.setMockInitialValues({});
     });
 
-    test('getSelectedFestivalId returns null when no festival is selected',
-        () async {
-      final prefs = await SharedPreferences.getInstance();
-      festivalStorageService = FestivalStorageService(prefs);
+    test(
+      'getSelectedFestivalId returns null when no festival is selected',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        festivalStorageService = FestivalStorageService(prefs);
 
-      final festivalId = festivalStorageService.getSelectedFestivalId();
+        final festivalId = festivalStorageService.getSelectedFestivalId();
 
-      expect(festivalId, isNull);
-    });
+        expect(festivalId, isNull);
+      },
+    );
 
     test('setSelectedFestivalId saves festival ID', () async {
       final prefs = await SharedPreferences.getInstance();
@@ -307,17 +315,19 @@ void main() {
       expect(festivalId, isNull);
     });
 
-    test('clearSelectedFestival handles no saved festival gracefully',
-        () async {
-      final prefs = await SharedPreferences.getInstance();
-      festivalStorageService = FestivalStorageService(prefs);
+    test(
+      'clearSelectedFestival handles no saved festival gracefully',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        festivalStorageService = FestivalStorageService(prefs);
 
-      // Should not throw
-      await festivalStorageService.clearSelectedFestival();
+        // Should not throw
+        await festivalStorageService.clearSelectedFestival();
 
-      final festivalId = festivalStorageService.getSelectedFestivalId();
-      expect(festivalId, isNull);
-    });
+        final festivalId = festivalStorageService.getSelectedFestivalId();
+        expect(festivalId, isNull);
+      },
+    );
 
     test('festival selection persists across service instances', () async {
       final prefs = await SharedPreferences.getInstance();

--- a/test/string_comparison_helper_test.dart
+++ b/test/string_comparison_helper_test.dart
@@ -27,13 +27,19 @@ void main() {
       // Verify Cafe comes before Café, and Rose comes before Rosé
       final cafeIndex = sorted.indexWhere((s) => s == 'Cafe');
       final cafeAccentIndex = sorted.indexWhere((s) => s == 'Café');
-      expect(cafeIndex, lessThan(cafeAccentIndex),
-          reason: 'Cafe should come before Café');
+      expect(
+        cafeIndex,
+        lessThan(cafeAccentIndex),
+        reason: 'Cafe should come before Café',
+      );
 
       final roseIndex = sorted.indexWhere((s) => s == 'Rose');
       final roseAccentIndex = sorted.indexWhere((s) => s == 'Rosé');
-      expect(roseIndex, lessThan(roseAccentIndex),
-          reason: 'Rose should come before Rosé');
+      expect(
+        roseIndex,
+        lessThan(roseAccentIndex),
+        reason: 'Rose should come before Rosé',
+      );
     });
 
     test('maintains consistent alphabetical ordering', () {
@@ -45,7 +51,7 @@ void main() {
         'Café',
         'Cafe',
         'Pilsner',
-        'Stout'
+        'Stout',
       ];
       final sorted = List<String>.from(unsorted);
       sorted.sort(StringComparisonHelper.compareLocaleAware);
@@ -80,10 +86,12 @@ void main() {
 
       // Verify basic alphabetical grouping works
       // All K's should come before M's, M's before N's
-      final kCount =
-          sorted.where((s) => s.toLowerCase().startsWith('k')).length;
-      final mCount =
-          sorted.where((s) => s.toLowerCase().startsWith('m')).length;
+      final kCount = sorted
+          .where((s) => s.toLowerCase().startsWith('k'))
+          .length;
+      final mCount = sorted
+          .where((s) => s.toLowerCase().startsWith('m'))
+          .length;
 
       expect(kCount, 2);
       expect(mCount, 2);
@@ -104,8 +112,11 @@ void main() {
 
       StringComparisonHelper.compareLocaleAware(original, copy);
 
-      expect(original, 'Rosé Cider',
-          reason: 'Original string should not be modified');
+      expect(
+        original,
+        'Rosé Cider',
+        reason: 'Original string should not be modified',
+      );
       expect(copy, 'Rosé Cider', reason: 'Copy string should not be modified');
     });
 
@@ -113,7 +124,9 @@ void main() {
       expect(StringComparisonHelper.compareLocaleAware('', ''), 0);
       expect(StringComparisonHelper.compareLocaleAware('', 'a'), lessThan(0));
       expect(
-          StringComparisonHelper.compareLocaleAware('a', ''), greaterThan(0));
+        StringComparisonHelper.compareLocaleAware('a', ''),
+        greaterThan(0),
+      );
     });
 
     test('returns consistent ordering (transitivity)', () {
@@ -127,8 +140,11 @@ void main() {
       final ac = StringComparisonHelper.compareLocaleAware(a, c);
 
       if (ab < 0 && bc < 0) {
-        expect(ac, lessThan(0),
-            reason: 'Transitivity should hold: a < b < c => a < c');
+        expect(
+          ac,
+          lessThan(0),
+          reason: 'Transitivity should hold: a < b < c => a < c',
+        );
       }
     });
 
@@ -168,16 +184,28 @@ void main() {
       styles.sort(StringComparisonHelper.compareLocaleAware);
 
       // Verify the accented characters are preserved correctly
-      expect(styles.any((s) => s.contains('é')), true,
-          reason: 'Should contain é character');
-      expect(styles.any((s) => s.contains('ä')), true,
-          reason: 'Should contain ä character');
+      expect(
+        styles.any((s) => s.contains('é')),
+        true,
+        reason: 'Should contain é character',
+      );
+      expect(
+        styles.any((s) => s.contains('ä')),
+        true,
+        reason: 'Should contain ä character',
+      );
 
       // Verify they're not garbled (common mojibake patterns)
-      expect(styles.any((s) => s.contains('Ã©')), false,
-          reason: 'Should not contain mojibake Ã© (garbled é)');
-      expect(styles.any((s) => s.contains('Ã¤')), false,
-          reason: 'Should not contain mojibake Ã¤ (garbled ä)');
+      expect(
+        styles.any((s) => s.contains('Ã©')),
+        false,
+        reason: 'Should not contain mojibake Ã© (garbled é)',
+      );
+      expect(
+        styles.any((s) => s.contains('Ã¤')),
+        false,
+        reason: 'Should not contain mojibake Ã¤ (garbled ä)',
+      );
     });
   });
 }

--- a/test/string_formatting_helper_test.dart
+++ b/test/string_formatting_helper_test.dart
@@ -11,7 +11,9 @@ void main() {
 
       test('leaves the remaining characters untouched', () {
         expect(
-            StringFormattingHelper.capitalizeFirst('bag in box'), 'Bag in box');
+          StringFormattingHelper.capitalizeFirst('bag in box'),
+          'Bag in box',
+        );
       });
 
       test('is a no-op for an already capitalised string', () {

--- a/test/style_description_helper_test.dart
+++ b/test/style_description_helper_test.dart
@@ -12,8 +12,9 @@ void main() {
 
     testWidgets('returns null for unknown style', (tester) async {
       await tester.pumpWidget(const MaterialApp(home: SizedBox()));
-      final result =
-          await StyleDescriptionHelper.getStyleDescription('Unknown Style');
+      final result = await StyleDescriptionHelper.getStyleDescription(
+        'Unknown Style',
+      );
       expect(result, isNull);
     });
 
@@ -42,8 +43,9 @@ void main() {
     testWidgets('trims whitespace from style name', (tester) async {
       await tester.pumpWidget(const MaterialApp(home: SizedBox()));
 
-      final result =
-          await StyleDescriptionHelper.getStyleDescription('  IPA  ');
+      final result = await StyleDescriptionHelper.getStyleDescription(
+        '  IPA  ',
+      );
       expect(result, isNotNull);
       expect(result, isNotEmpty);
     });

--- a/test/style_screen_screenshot_test.dart
+++ b/test/style_screen_screenshot_test.dart
@@ -60,12 +60,21 @@ void main() {
       dispense: 'cask',
     );
 
-    final drink1 =
-        Drink(product: product1, producer: producer1, festivalId: 'cbf2025');
-    final drink2 =
-        Drink(product: product2, producer: producer2, festivalId: 'cbf2025');
-    final drink3 =
-        Drink(product: product3, producer: producer1, festivalId: 'cbf2025');
+    final drink1 = Drink(
+      product: product1,
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
+    final drink2 = Drink(
+      product: product2,
+      producer: producer2,
+      festivalId: 'cbf2025',
+    );
+    final drink3 = Drink(
+      product: product3,
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -81,8 +90,9 @@ void main() {
           baseUrl: 'https://data.cambeerfestival.app',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
 
       provider = BeerProvider(
@@ -113,10 +123,12 @@ void main() {
       );
     }
 
-    testWidgets('StyleScreen with description - light theme',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2, drink3]);
+    testWidgets('StyleScreen with description - light theme', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2, drink3]);
       await provider.loadDrinks();
 
       // Set a larger screen size for better screenshot
@@ -135,10 +147,12 @@ void main() {
       );
     });
 
-    testWidgets('StyleScreen with description - dark theme',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2, drink3]);
+    testWidgets('StyleScreen with description - dark theme', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2, drink3]);
       await provider.loadDrinks();
 
       // Set a larger screen size for better screenshot

--- a/test/style_screen_test.dart
+++ b/test/style_screen_test.dart
@@ -61,12 +61,21 @@ void main() {
       dispense: 'cask',
     );
 
-    final drink1 =
-        Drink(product: product1, producer: producer1, festivalId: 'cbf2025');
-    final drink2 =
-        Drink(product: product2, producer: producer2, festivalId: 'cbf2025');
-    final drink3 =
-        Drink(product: product3, producer: producer1, festivalId: 'cbf2025');
+    final drink1 = Drink(
+      product: product1,
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
+    final drink2 = Drink(
+      product: product2,
+      producer: producer2,
+      festivalId: 'cbf2025',
+    );
+    final drink3 = Drink(
+      product: product3,
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -82,8 +91,9 @@ void main() {
           baseUrl: 'https://data.cambeerfestival.app',
         ),
       );
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
 
       provider = BeerProvider(
@@ -107,54 +117,66 @@ void main() {
       );
     }
 
-    testWidgets('displays style not found when no drinks with that style exist',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget('NonExistent Style'));
-      await tester.pumpAndSettle();
+    testWidgets(
+      'displays style not found when no drinks with that style exist',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(createTestWidget('NonExistent Style'));
+        await tester.pumpAndSettle();
 
-      expect(find.text('Style Not Found'), findsOneWidget);
-      expect(find.text('No drinks found with this style.'), findsOneWidget);
-    });
-
-    testWidgets('displays style information when drinks with that style exist',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2]);
-      await provider.loadDrinks();
-
-      await tester.pumpWidget(createTestWidget('IPA'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('IPA'), findsWidgets);
-      // The new UI uses HeroInfoCard showing drink count
-      expect(find.textContaining('2 drinks at this festival'), findsOneWidget);
-      // Note: 'Drinks' section header with count
-      expect(find.text('Drinks (2)'), findsOneWidget);
-      // Festival name in breadcrumb
-      expect(find.textContaining('Festival'), findsWidgets);
-    });
+        expect(find.text('Style Not Found'), findsOneWidget);
+        expect(find.text('No drinks found with this style.'), findsOneWidget);
+      },
+    );
 
     testWidgets(
-        'displays original mixed-case style name for a lowercase URL param',
-        (WidgetTester tester) async {
-      // Style URLs use a lowercase canonical form (see buildStylePath), so the
-      // router passes a lowercased style. The screen must still display the
-      // original mixed-case name from the matched drinks.
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2]);
-      await provider.loadDrinks();
+      'displays style information when drinks with that style exist',
+      (WidgetTester tester) async {
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [drink1, drink2]);
+        await provider.loadDrinks();
 
-      await tester.pumpWidget(createTestWidget('ipa'));
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(createTestWidget('IPA'));
+        await tester.pumpAndSettle();
 
-      expect(find.text('IPA'), findsWidgets);
-      expect(find.text('ipa'), findsNothing);
-    });
+        expect(find.text('IPA'), findsWidgets);
+        // The new UI uses HeroInfoCard showing drink count
+        expect(
+          find.textContaining('2 drinks at this festival'),
+          findsOneWidget,
+        );
+        // Note: 'Drinks' section header with count
+        expect(find.text('Drinks (2)'), findsOneWidget);
+        // Festival name in breadcrumb
+        expect(find.textContaining('Festival'), findsWidgets);
+      },
+    );
 
-    testWidgets('displays drinks with the specified style',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2]);
+    testWidgets(
+      'displays original mixed-case style name for a lowercase URL param',
+      (WidgetTester tester) async {
+        // Style URLs use a lowercase canonical form (see buildStylePath), so the
+        // router passes a lowercased style. The screen must still display the
+        // original mixed-case name from the matched drinks.
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [drink1, drink2]);
+        await provider.loadDrinks();
+
+        await tester.pumpWidget(createTestWidget('ipa'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('IPA'), findsWidgets);
+        expect(find.text('ipa'), findsNothing);
+      },
+    );
+
+    testWidgets('displays drinks with the specified style', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2]);
       await provider.loadDrinks();
 
       await tester.binding.setSurfaceSize(const Size(400, 1200));
@@ -167,10 +189,12 @@ void main() {
       expect(find.text('Test IPA 2'), findsOneWidget);
     });
 
-    testWidgets('navigates to drink detail when drink card is tapped',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1]);
+    testWidgets('navigates to drink detail when drink card is tapped', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('IPA'));
@@ -184,10 +208,12 @@ void main() {
       // (test-e2e/routing.spec.ts) instead of unit tests.
     });
 
-    testWidgets('toggles favorite when favorite button is tapped',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1]);
+    testWidgets('toggles favorite when favorite button is tapped', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('IPA'));
@@ -197,8 +223,9 @@ void main() {
 
       // Mock toggleFavorite to properly toggle state
       final favorites = <String>{};
-      when(mockDrinkRepository.toggleFavorite(any, any))
-          .thenAnswer((invocation) async {
+      when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer((
+        invocation,
+      ) async {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
@@ -220,10 +247,12 @@ void main() {
       expect(drink1.isFavorite, true);
     });
 
-    testWidgets('displays correct count of drinks',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2]);
+    testWidgets('displays correct count of drinks', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('IPA'));
@@ -232,10 +261,12 @@ void main() {
       expect(find.text('Drinks (2)'), findsOneWidget);
     });
 
-    testWidgets('filters drinks to show only the specified style',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2, drink3]);
+    testWidgets('filters drinks to show only the specified style', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2, drink3]);
       await provider.loadDrinks();
 
       await tester.binding.setSurfaceSize(const Size(400, 1200));
@@ -250,10 +281,12 @@ void main() {
       expect(find.text('Drinks (2)'), findsOneWidget);
     });
 
-    testWidgets('shows drinks from different breweries with same style',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2]);
+    testWidgets('shows drinks from different breweries with same style', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2]);
       await provider.loadDrinks();
 
       await tester.binding.setSurfaceSize(const Size(400, 1200));
@@ -268,10 +301,12 @@ void main() {
       expect(find.textContaining('Test Brewery 2'), findsOneWidget);
     });
 
-    testWidgets('displays style description when available',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2]);
+    testWidgets('displays style description when available', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('IPA'));
@@ -281,10 +316,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Should display the IPA description
-      expect(
-        find.textContaining('heavily hopped'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('heavily hopped'), findsOneWidget);
 
       // Should still show the stats
       // Note: 'Drinks' section header with count
@@ -295,8 +327,9 @@ void main() {
       expect(find.textContaining('Average ABV:'), findsOneWidget);
     });
 
-    testWidgets('header without description when style has none',
-        (WidgetTester tester) async {
+    testWidgets('header without description when style has none', (
+      WidgetTester tester,
+    ) async {
       // Create a drink with a style that has no description
       const productUnknown = Product(
         id: 'drink4',
@@ -312,8 +345,9 @@ void main() {
         festivalId: 'cbf2025',
       );
 
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drinkUnknown]);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drinkUnknown]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('Unknown Style'));
@@ -331,10 +365,12 @@ void main() {
       expect(find.textContaining('Average ABV:'), findsOneWidget);
     });
 
-    testWidgets('can scroll when header is expanded',
-        (WidgetTester tester) async {
-      when(mockDrinkRepository.getDrinks(any))
-          .thenAnswer((_) async => [drink1, drink2, drink3]);
+    testWidgets('can scroll when header is expanded', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2, drink3]);
       await provider.loadDrinks();
 
       await tester.pumpWidget(createTestWidget('IPA'));
@@ -348,10 +384,7 @@ void main() {
       expect(scrollView, findsOneWidget);
 
       // Verify description is visible when expanded
-      expect(
-        find.textContaining('heavily hopped'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('heavily hopped'), findsOneWidget);
 
       // Scroll down to collapse the header
       await tester.drag(scrollView, const Offset(0, -200));

--- a/test/tasting_log_service_test.dart
+++ b/test/tasting_log_service_test.dart
@@ -139,16 +139,18 @@ void main() {
         expect(service.hasTasted('cbf2024', 'drink-2'), isTrue);
       });
 
-      test('does not clear logs from festivals with overlapping prefixes',
-          () async {
-        await service.markAsTasted('cbf2025', 'drink-1');
-        await service.markAsTasted('cbf2025-extra', 'drink-2');
+      test(
+        'does not clear logs from festivals with overlapping prefixes',
+        () async {
+          await service.markAsTasted('cbf2025', 'drink-1');
+          await service.markAsTasted('cbf2025-extra', 'drink-2');
 
-        await service.clearFestivalLog('cbf2025');
+          await service.clearFestivalLog('cbf2025');
 
-        expect(service.getTastedCount('cbf2025'), 0);
-        expect(service.hasTasted('cbf2025-extra', 'drink-2'), isTrue);
-      });
+          expect(service.getTastedCount('cbf2025'), 0);
+          expect(service.hasTasted('cbf2025-extra', 'drink-2'), isTrue);
+        },
+      );
 
       test('is a no-op when the festival has no logs', () async {
         await service.clearFestivalLog('cbf2025');

--- a/test/url_launcher_helper_test.dart
+++ b/test/url_launcher_helper_test.dart
@@ -105,8 +105,9 @@ void main() {
       expect(mockUrlLauncher.lastLaunchedUrl, 'https://example.com');
     });
 
-    testWidgets('launchURL shows error snackbar when URL cannot be launched',
-        (tester) async {
+    testWidgets('launchURL shows error snackbar when URL cannot be launched', (
+      tester,
+    ) async {
       mockUrlLauncher.canLaunchResult = false;
 
       await tester.pumpWidget(
@@ -137,8 +138,9 @@ void main() {
       expect(find.text('Could not open URL'), findsOneWidget);
     });
 
-    testWidgets('launchURL shows custom error message when provided',
-        (tester) async {
+    testWidgets('launchURL shows custom error message when provided', (
+      tester,
+    ) async {
       mockUrlLauncher.canLaunchResult = false;
 
       const customErrorMessage = 'Failed to open website';

--- a/test/utf8_encoding_test.dart
+++ b/test/utf8_encoding_test.dart
@@ -78,28 +78,52 @@ void main() {
 
       // Verify the UTF-8 characters are decoded correctly (not as mojibake)
       final roseDrink = drinks.firstWhere((d) => d.product.id == 'cider1');
-      expect(roseDrink.product.name, 'Rosé Cider',
-          reason: 'Name should have correct é character');
-      expect(roseDrink.product.style, 'Rosé',
-          reason: 'Style should have correct é character');
+      expect(
+        roseDrink.product.name,
+        'Rosé Cider',
+        reason: 'Name should have correct é character',
+      );
+      expect(
+        roseDrink.product.style,
+        'Rosé',
+        reason: 'Style should have correct é character',
+      );
 
       // Verify it's NOT the mojibake version
-      expect(roseDrink.product.name, isNot('RosÃ© Cider'),
-          reason: 'Should not be garbled as RosÃ©');
-      expect(roseDrink.product.style, isNot('RosÃ©'),
-          reason: 'Should not be garbled as RosÃ©');
+      expect(
+        roseDrink.product.name,
+        isNot('RosÃ© Cider'),
+        reason: 'Should not be garbled as RosÃ©',
+      );
+      expect(
+        roseDrink.product.style,
+        isNot('RosÃ©'),
+        reason: 'Should not be garbled as RosÃ©',
+      );
 
       final cafeDrink = drinks.firstWhere((d) => d.product.id == 'cider2');
-      expect(cafeDrink.product.name, 'Café Apple',
-          reason: 'Name should have correct é character');
-      expect(cafeDrink.product.style, 'Café',
-          reason: 'Style should have correct é character');
+      expect(
+        cafeDrink.product.name,
+        'Café Apple',
+        reason: 'Name should have correct é character',
+      );
+      expect(
+        cafeDrink.product.style,
+        'Café',
+        reason: 'Style should have correct é character',
+      );
 
       // Verify it's NOT the mojibake version
-      expect(cafeDrink.product.name, isNot('CafÃ© Apple'),
-          reason: 'Should not be garbled as CafÃ©');
-      expect(cafeDrink.product.style, isNot('CafÃ©'),
-          reason: 'Should not be garbled as CafÃ©');
+      expect(
+        cafeDrink.product.name,
+        isNot('CafÃ© Apple'),
+        reason: 'Should not be garbled as CafÃ©',
+      );
+      expect(
+        cafeDrink.product.style,
+        isNot('CafÃ©'),
+        reason: 'Should not be garbled as CafÃ©',
+      );
     });
 
     test('handles various European accented characters correctly', () async {
@@ -158,22 +182,31 @@ void main() {
       final kolsch = drinks.firstWhere((d) => d.product.id == 'beer1');
       expect(kolsch.product.style, 'Kölsch');
       expect(kolsch.product.style?.contains('ö'), true);
-      expect(kolsch.product.style, isNot(contains('Ã¶')), // mojibake for ö
-          reason: 'Should not be garbled');
+      expect(
+        kolsch.product.style,
+        isNot(contains('Ã¶')), // mojibake for ö
+        reason: 'Should not be garbled',
+      );
 
       // Verify German ä character
       final marzen = drinks.firstWhere((d) => d.product.id == 'beer2');
       expect(marzen.product.style, 'Märzen');
       expect(marzen.product.style?.contains('ä'), true);
-      expect(marzen.product.style, isNot(contains('Ã¤')), // mojibake for ä
-          reason: 'Should not be garbled');
+      expect(
+        marzen.product.style,
+        isNot(contains('Ã¤')), // mojibake for ä
+        reason: 'Should not be garbled',
+      );
 
       // Verify Spanish ñ character
       final nino = drinks.firstWhere((d) => d.product.id == 'beer3');
       expect(nino.product.name, 'Niño Porter');
       expect(nino.product.name.contains('ñ'), true);
-      expect(nino.product.name, isNot(contains('Ã±')), // mojibake for ñ
-          reason: 'Should not be garbled');
+      expect(
+        nino.product.name,
+        isNot(contains('Ã±')), // mojibake for ñ
+        reason: 'Should not be garbled',
+      );
     });
 
     test('handles response without explicit charset in Content-Type', () async {

--- a/test/utf8_encoding_test.mocks.dart
+++ b/test/utf8_encoding_test.mocks.dart
@@ -27,24 +27,14 @@ import 'package:mockito/src/dummies.dart' as _i5;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeResponse_0 extends _i1.SmartFake implements _i2.Response {
-  _FakeResponse_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeResponse_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeStreamedResponse_1 extends _i1.SmartFake
     implements _i2.StreamedResponse {
-  _FakeStreamedResponse_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeStreamedResponse_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [Client].
@@ -56,46 +46,30 @@ class MockClient extends _i1.Mock implements _i2.Client {
   }
 
   @override
-  _i3.Future<_i2.Response> head(
-    Uri? url, {
-    Map<String, String>? headers,
-  }) =>
+  _i3.Future<_i2.Response> head(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #head,
-          [url],
-          {#headers: headers},
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #head,
-            [url],
-            {#headers: headers},
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(#head, [url], {#headers: headers}),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(#head, [url], {#headers: headers}),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i3.Future<_i2.Response> get(
-    Uri? url, {
-    Map<String, String>? headers,
-  }) =>
+  _i3.Future<_i2.Response> get(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #get,
-          [url],
-          {#headers: headers},
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #get,
-            [url],
-            {#headers: headers},
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(#get, [url], {#headers: headers}),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(#get, [url], {#headers: headers}),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> post(
@@ -105,28 +79,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #post,
-          [url],
-          {
-            #headers: headers,
-            #body: body,
-            #encoding: encoding,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #post,
-            [url],
-            {
-              #headers: headers,
-              #body: body,
-              #encoding: encoding,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #post,
+              [url],
+              {#headers: headers, #body: body, #encoding: encoding},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(
+                  #post,
+                  [url],
+                  {#headers: headers, #body: body, #encoding: encoding},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> put(
@@ -136,28 +105,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #put,
-          [url],
-          {
-            #headers: headers,
-            #body: body,
-            #encoding: encoding,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #put,
-            [url],
-            {
-              #headers: headers,
-              #body: body,
-              #encoding: encoding,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #put,
+              [url],
+              {#headers: headers, #body: body, #encoding: encoding},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(
+                  #put,
+                  [url],
+                  {#headers: headers, #body: body, #encoding: encoding},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> patch(
@@ -167,28 +131,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #patch,
-          [url],
-          {
-            #headers: headers,
-            #body: body,
-            #encoding: encoding,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #patch,
-            [url],
-            {
-              #headers: headers,
-              #body: body,
-              #encoding: encoding,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #patch,
+              [url],
+              {#headers: headers, #body: body, #encoding: encoding},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(
+                  #patch,
+                  [url],
+                  {#headers: headers, #body: body, #encoding: encoding},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> delete(
@@ -198,49 +157,36 @@ class MockClient extends _i1.Mock implements _i2.Client {
     _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #delete,
-          [url],
-          {
-            #headers: headers,
-            #body: body,
-            #encoding: encoding,
-          },
-        ),
-        returnValue: _i3.Future<_i2.Response>.value(_FakeResponse_0(
-          this,
-          Invocation.method(
-            #delete,
-            [url],
-            {
-              #headers: headers,
-              #body: body,
-              #encoding: encoding,
-            },
-          ),
-        )),
-      ) as _i3.Future<_i2.Response>);
+            Invocation.method(
+              #delete,
+              [url],
+              {#headers: headers, #body: body, #encoding: encoding},
+            ),
+            returnValue: _i3.Future<_i2.Response>.value(
+              _FakeResponse_0(
+                this,
+                Invocation.method(
+                  #delete,
+                  [url],
+                  {#headers: headers, #body: body, #encoding: encoding},
+                ),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i3.Future<String> read(
-    Uri? url, {
-    Map<String, String>? headers,
-  }) =>
+  _i3.Future<String> read(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #read,
-          [url],
-          {#headers: headers},
-        ),
-        returnValue: _i3.Future<String>.value(_i5.dummyValue<String>(
-          this,
-          Invocation.method(
-            #read,
-            [url],
-            {#headers: headers},
-          ),
-        )),
-      ) as _i3.Future<String>);
+            Invocation.method(#read, [url], {#headers: headers}),
+            returnValue: _i3.Future<String>.value(
+              _i5.dummyValue<String>(
+                this,
+                Invocation.method(#read, [url], {#headers: headers}),
+              ),
+            ),
+          )
+          as _i3.Future<String>);
 
   @override
   _i3.Future<_i6.Uint8List> readBytes(
@@ -248,37 +194,27 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #readBytes,
-          [url],
-          {#headers: headers},
-        ),
-        returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
-      ) as _i3.Future<_i6.Uint8List>);
+            Invocation.method(#readBytes, [url], {#headers: headers}),
+            returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
+          )
+          as _i3.Future<_i6.Uint8List>);
 
   @override
   _i3.Future<_i2.StreamedResponse> send(_i2.BaseRequest? request) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #send,
-          [request],
-        ),
-        returnValue:
-            _i3.Future<_i2.StreamedResponse>.value(_FakeStreamedResponse_1(
-          this,
-          Invocation.method(
-            #send,
-            [request],
-          ),
-        )),
-      ) as _i3.Future<_i2.StreamedResponse>);
+            Invocation.method(#send, [request]),
+            returnValue: _i3.Future<_i2.StreamedResponse>.value(
+              _FakeStreamedResponse_1(
+                this,
+                Invocation.method(#send, [request]),
+              ),
+            ),
+          )
+          as _i3.Future<_i2.StreamedResponse>);
 
   @override
   void close() => super.noSuchMethod(
-        Invocation.method(
-          #close,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#close, []),
+    returnValueForMissingStub: null,
+  );
 }

--- a/test/utils/navigation_helpers_test.dart
+++ b/test/utils/navigation_helpers_test.dart
@@ -37,19 +37,13 @@ void main() {
 
     group('buildFestivalHome', () {
       test('builds home path', () {
-        expect(
-          buildFestivalHome('cbf2025'),
-          equals('/cbf2025'),
-        );
+        expect(buildFestivalHome('cbf2025'), equals('/cbf2025'));
       });
     });
 
     group('buildDrinksPath', () {
       test('builds drinks path without category', () {
-        expect(
-          buildDrinksPath('cbf2025'),
-          equals('/cbf2025/drinks'),
-        );
+        expect(buildDrinksPath('cbf2025'), equals('/cbf2025/drinks'));
       });
 
       test('builds drinks path with category', () {
@@ -62,19 +56,13 @@ void main() {
 
     group('buildFavoritesPath', () {
       test('builds favorites path', () {
-        expect(
-          buildFavoritesPath('cbf2025'),
-          equals('/cbf2025/favorites'),
-        );
+        expect(buildFavoritesPath('cbf2025'), equals('/cbf2025/favorites'));
       });
     });
 
     group('buildFestivalInfoPath', () {
       test('builds festival info path', () {
-        expect(
-          buildFestivalInfoPath('cbf2025'),
-          equals('/cbf2025/info'),
-        );
+        expect(buildFestivalInfoPath('cbf2025'), equals('/cbf2025/info'));
       });
     });
 
@@ -112,10 +100,7 @@ void main() {
 
     group('buildStylePath', () {
       test('builds style path with lowercase', () {
-        expect(
-          buildStylePath('cbf2025', 'IPA'),
-          equals('/cbf2025/style/ipa'),
-        );
+        expect(buildStylePath('cbf2025', 'IPA'), equals('/cbf2025/style/ipa'));
       });
 
       test('converts mixed case to lowercase and URL-encodes', () {
@@ -144,45 +129,27 @@ void main() {
 
     group('extractFestivalId', () {
       test('extracts festival ID from simple path', () {
-        expect(
-          extractFestivalId('/cbf2025/drinks'),
-          equals('cbf2025'),
-        );
+        expect(extractFestivalId('/cbf2025/drinks'), equals('cbf2025'));
       });
 
       test('extracts festival ID from nested path', () {
-        expect(
-          extractFestivalId('/cbf2025/brewery/123'),
-          equals('cbf2025'),
-        );
+        expect(extractFestivalId('/cbf2025/brewery/123'), equals('cbf2025'));
       });
 
       test('extracts festival ID from home path', () {
-        expect(
-          extractFestivalId('/cbf2025'),
-          equals('cbf2025'),
-        );
+        expect(extractFestivalId('/cbf2025'), equals('cbf2025'));
       });
 
       test('returns null for root path', () {
-        expect(
-          extractFestivalId('/'),
-          isNull,
-        );
+        expect(extractFestivalId('/'), isNull);
       });
 
       test('returns null for empty path', () {
-        expect(
-          extractFestivalId(''),
-          isNull,
-        );
+        expect(extractFestivalId(''), isNull);
       });
 
       test('handles paths without leading slash', () {
-        expect(
-          extractFestivalId('cbf2025/drinks'),
-          equals('cbf2025'),
-        );
+        expect(extractFestivalId('cbf2025/drinks'), equals('cbf2025'));
       });
     });
 
@@ -239,33 +206,29 @@ void main() {
         expect(
           buildDrinksPath('cbf2025', category: 'cider & perry'),
           equals(
-              '/cbf2025/drinks?category=cider+%26+perry'), // + is valid for spaces in query params
+            '/cbf2025/drinks?category=cider+%26+perry',
+          ), // + is valid for spaces in query params
         );
       });
 
       test(
-          'converts to lowercase and encodes Unicode characters in style names',
-          () {
-        expect(
-          buildStylePath('cbf2025', 'Märzen'),
-          equals('/cbf2025/style/m%C3%A4rzen'),
-        );
-      });
+        'converts to lowercase and encodes Unicode characters in style names',
+        () {
+          expect(
+            buildStylePath('cbf2025', 'Märzen'),
+            equals('/cbf2025/style/m%C3%A4rzen'),
+          );
+        },
+      );
     });
 
     group('Input validation', () {
       test('buildFestivalPath asserts on empty festival ID', () {
-        expect(
-          () => buildFestivalPath('', '/drinks'),
-          throwsAssertionError,
-        );
+        expect(() => buildFestivalPath('', '/drinks'), throwsAssertionError);
       });
 
       test('buildFestivalPath asserts on empty path', () {
-        expect(
-          () => buildFestivalPath('cbf2025', ''),
-          throwsAssertionError,
-        );
+        expect(() => buildFestivalPath('cbf2025', ''), throwsAssertionError);
       });
 
       test('buildDrinkDetailPath asserts on empty drink ID', () {
@@ -276,17 +239,11 @@ void main() {
       });
 
       test('buildBreweryPath asserts on empty brewery ID', () {
-        expect(
-          () => buildBreweryPath('cbf2025', ''),
-          throwsAssertionError,
-        );
+        expect(() => buildBreweryPath('cbf2025', ''), throwsAssertionError);
       });
 
       test('buildCategoryPath asserts on empty category', () {
-        expect(
-          () => buildCategoryPath('cbf2025', ''),
-          throwsAssertionError,
-        );
+        expect(() => buildCategoryPath('cbf2025', ''), throwsAssertionError);
       });
 
       test('buildDrinksPath handles empty category gracefully', () {
@@ -300,24 +257,15 @@ void main() {
     group('Edge cases', () {
       test('handles very long festival IDs', () {
         final longId = 'x' * 100;
-        expect(
-          buildFestivalHome(longId),
-          equals('/$longId'),
-        );
+        expect(buildFestivalHome(longId), equals('/$longId'));
       });
 
       test('handles paths with multiple slashes', () {
-        expect(
-          extractFestivalId('/cbf2025//drinks'),
-          equals('cbf2025'),
-        );
+        expect(extractFestivalId('/cbf2025//drinks'), equals('cbf2025'));
       });
 
       test('handles paths with trailing slashes', () {
-        expect(
-          extractFestivalId('/cbf2025/'),
-          equals('cbf2025'),
-        );
+        expect(extractFestivalId('/cbf2025/'), equals('cbf2025'));
       });
 
       test('handles URL-encoded characters in IDs', () {
@@ -364,17 +312,16 @@ void main() {
     });
 
     group('canPopNavigation', () {
-      testWidgets('returns false when GoRouter is not available',
-          (tester) async {
+      testWidgets('returns false when GoRouter is not available', (
+        tester,
+      ) async {
         // In test environment with MaterialApp but without GoRouter
         await tester.pumpWidget(
           MaterialApp(
             home: Builder(
               builder: (context) {
                 final result = canPopNavigation(context);
-                return Scaffold(
-                  body: Text('Can pop: $result'),
-                );
+                return Scaffold(body: Text('Can pop: $result'));
               },
             ),
           ),
@@ -393,8 +340,10 @@ void main() {
       });
 
       test('decodes unicode percent-encoding', () {
-        expect(safeDecodeComponent('Bi%C3%A8re%20de%20Garde'),
-            equals('Bière de Garde'));
+        expect(
+          safeDecodeComponent('Bi%C3%A8re%20de%20Garde'),
+          equals('Bière de Garde'),
+        );
       });
 
       test('returns unmodified string with no encoding', () {
@@ -418,8 +367,10 @@ void main() {
       });
 
       test('handles string with multiple valid encodings', () {
-        expect(safeDecodeComponent('IPA%20-%20American%20Pale'),
-            equals('IPA - American Pale'));
+        expect(
+          safeDecodeComponent('IPA%20-%20American%20Pale'),
+          equals('IPA - American Pale'),
+        );
       });
     });
   });

--- a/test/utils/widget_builders_test.dart
+++ b/test/utils/widget_builders_test.dart
@@ -6,11 +6,7 @@ void main() {
   group('Widget Builders', () {
     group('buildLoadingScaffold', () {
       testWidgets('creates scaffold with loading indicator', (tester) async {
-        await tester.pumpWidget(
-          MaterialApp(
-            home: buildLoadingScaffold(),
-          ),
-        );
+        await tester.pumpWidget(MaterialApp(home: buildLoadingScaffold()));
 
         // Verify AppBar with "Loading..." title
         expect(find.text('Loading...'), findsOneWidget);
@@ -24,11 +20,7 @@ void main() {
       });
 
       testWidgets('has correct widget structure', (tester) async {
-        await tester.pumpWidget(
-          MaterialApp(
-            home: buildLoadingScaffold(),
-          ),
-        );
+        await tester.pumpWidget(MaterialApp(home: buildLoadingScaffold()));
 
         // Verify Scaffold is the root
         expect(find.byType(Scaffold), findsOneWidget);
@@ -51,9 +43,7 @@ void main() {
                 result = buildHomeLeadingButton(context, 'cbf2025');
                 // If result is null, show placeholder
                 return Scaffold(
-                  appBar: AppBar(
-                    leading: result ?? const Icon(Icons.error),
-                  ),
+                  appBar: AppBar(leading: result ?? const Icon(Icons.error)),
                   body: const Text('Test'),
                 );
               },
@@ -103,8 +93,10 @@ void main() {
         );
 
         expect(customSemantics.properties.label, equals('Go to home screen'));
-        expect(customSemantics.properties.hint,
-            equals('Double tap to return to drinks list'));
+        expect(
+          customSemantics.properties.hint,
+          equals('Double tap to return to drinks list'),
+        );
         expect(customSemantics.properties.button, isTrue);
       });
 
@@ -223,10 +215,7 @@ void main() {
 
         // Find all Text widgets in the AppBar
         final textWidgets = tester.widgetList<Text>(
-          find.descendant(
-            of: find.byType(AppBar),
-            matching: find.byType(Text),
-          ),
+          find.descendant(of: find.byType(AppBar), matching: find.byType(Text)),
         );
 
         // Both text widgets should have ellipsis overflow
@@ -275,14 +264,20 @@ void main() {
         expect(textWidgets.length, equals(2));
 
         // First text should use titleLarge
-        expect(textWidgets[0].style?.fontSize,
-            equals(theme.textTheme.titleLarge?.fontSize));
+        expect(
+          textWidgets[0].style?.fontSize,
+          equals(theme.textTheme.titleLarge?.fontSize),
+        );
 
         // Second text should use bodySmall with onSurfaceVariant color
-        expect(textWidgets[1].style?.fontSize,
-            equals(theme.textTheme.bodySmall?.fontSize));
-        expect(textWidgets[1].style?.color,
-            equals(theme.colorScheme.onSurfaceVariant));
+        expect(
+          textWidgets[1].style?.fontSize,
+          equals(theme.textTheme.bodySmall?.fontSize),
+        );
+        expect(
+          textWidgets[1].style?.color,
+          equals(theme.colorScheme.onSurfaceVariant),
+        );
       });
     });
   });

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -9,8 +9,10 @@ void main() {
         MaterialApp(
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'beer');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'beer',
+              );
               expect(color, isNotNull);
               return Container();
             },
@@ -19,15 +21,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for cider category in light theme',
-        (tester) async {
+    testWidgets('returns correct color for cider category in light theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.light),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'cider');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'cider',
+              );
               expect(color, const Color(0xFF689F38));
               return Container();
             },
@@ -36,15 +41,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for cider category in dark theme',
-        (tester) async {
+    testWidgets('returns correct color for cider category in dark theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.dark),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'cider');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'cider',
+              );
               expect(color, const Color(0xFF8BC34A).withValues(alpha: 0.8));
               return Container();
             },
@@ -53,15 +61,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for perry category in light theme',
-        (tester) async {
+    testWidgets('returns correct color for perry category in light theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.light),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'perry');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'perry',
+              );
               expect(color, const Color(0xFFAFB42B));
               return Container();
             },
@@ -70,15 +81,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for perry category in dark theme',
-        (tester) async {
+    testWidgets('returns correct color for perry category in dark theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.dark),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'perry');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'perry',
+              );
               expect(color, const Color(0xFFCDDC39).withValues(alpha: 0.8));
               return Container();
             },
@@ -87,15 +101,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for mead category in light theme',
-        (tester) async {
+    testWidgets('returns correct color for mead category in light theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.light),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'mead');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'mead',
+              );
               expect(color, const Color(0xFFF9A825));
               return Container();
             },
@@ -104,15 +121,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for mead category in dark theme',
-        (tester) async {
+    testWidgets('returns correct color for mead category in dark theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.dark),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'mead');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'mead',
+              );
               expect(color, const Color(0xFFFFEB3B).withValues(alpha: 0.8));
               return Container();
             },
@@ -121,15 +141,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for wine category in light theme',
-        (tester) async {
+    testWidgets('returns correct color for wine category in light theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.light),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'wine');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'wine',
+              );
               expect(color, const Color(0xFF7B1FA2));
               return Container();
             },
@@ -138,15 +161,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for wine category in dark theme',
-        (tester) async {
+    testWidgets('returns correct color for wine category in dark theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.dark),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'wine');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'wine',
+              );
               expect(color, const Color(0xFF9C27B0).withValues(alpha: 0.8));
               return Container();
             },
@@ -155,15 +181,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for low-no category in light theme',
-        (tester) async {
+    testWidgets('returns correct color for low-no category in light theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.light),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'low-no');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'low-no',
+              );
               expect(color, isNotNull);
               return Container();
             },
@@ -172,15 +201,18 @@ void main() {
       );
     });
 
-    testWidgets('returns correct color for low-no category in dark theme',
-        (tester) async {
+    testWidgets('returns correct color for low-no category in dark theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(brightness: Brightness.dark),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'low-no');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'low-no',
+              );
               expect(color, isNotNull);
               return Container();
             },
@@ -195,8 +227,10 @@ void main() {
           theme: ThemeData(brightness: Brightness.light),
           home: Builder(
             builder: (context) {
-              final color =
-                  CategoryColorHelper.getCategoryColor(context, 'unknown');
+              final color = CategoryColorHelper.getCategoryColor(
+                context,
+                'unknown',
+              );
               expect(color, isNotNull);
               expect(color, isA<Color>());
               return Container();
@@ -211,12 +245,18 @@ void main() {
         MaterialApp(
           home: Builder(
             builder: (context) {
-              final colorLower =
-                  CategoryColorHelper.getCategoryColor(context, 'beer');
-              final colorUpper =
-                  CategoryColorHelper.getCategoryColor(context, 'BEER');
-              final colorMixed =
-                  CategoryColorHelper.getCategoryColor(context, 'BeEr');
+              final colorLower = CategoryColorHelper.getCategoryColor(
+                context,
+                'beer',
+              );
+              final colorUpper = CategoryColorHelper.getCategoryColor(
+                context,
+                'BEER',
+              );
+              final colorMixed = CategoryColorHelper.getCategoryColor(
+                context,
+                'BeEr',
+              );
 
               expect(colorLower, colorUpper);
               expect(colorUpper, colorMixed);
@@ -245,8 +285,9 @@ void main() {
       expect(ABVStrengthHelper.getABVStrengthLabel(10.5), '(High)');
     });
 
-    testWidgets('getABVColor returns correct colors for different ABV ranges',
-        (tester) async {
+    testWidgets('getABVColor returns correct colors for different ABV ranges', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Builder(
@@ -274,8 +315,10 @@ void main() {
   group('BeverageTypeHelper', () {
     test('formatBeverageType formats dash-separated strings', () {
       expect(BeverageTypeHelper.formatBeverageType('beer'), 'Beer');
-      expect(BeverageTypeHelper.formatBeverageType('international-beer'),
-          'International Beer');
+      expect(
+        BeverageTypeHelper.formatBeverageType('international-beer'),
+        'International Beer',
+      );
       expect(BeverageTypeHelper.formatBeverageType('low-no'), 'Low No');
     });
 
@@ -290,8 +333,10 @@ void main() {
 
     test('getBeverageIcon returns correct icons', () {
       expect(BeverageTypeHelper.getBeverageIcon('beer'), Icons.sports_bar);
-      expect(BeverageTypeHelper.getBeverageIcon('international-beer'),
-          Icons.public);
+      expect(
+        BeverageTypeHelper.getBeverageIcon('international-beer'),
+        Icons.public,
+      );
       expect(BeverageTypeHelper.getBeverageIcon('cider'), Icons.local_drink);
       expect(BeverageTypeHelper.getBeverageIcon('perry'), Icons.eco);
       expect(BeverageTypeHelper.getBeverageIcon('mead'), Icons.emoji_nature);

--- a/test/widgets/availability_badge_test.dart
+++ b/test/widgets/availability_badge_test.dart
@@ -5,8 +5,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AvailabilityBadge', () {
-    Widget buildBadge(AvailabilityStatus status,
-        {bool compact = true, String? customText}) {
+    Widget buildBadge(
+      AvailabilityStatus status, {
+      bool compact = true,
+      String? customText,
+    }) {
       return MaterialApp(
         home: Scaffold(
           body: AvailabilityBadge(
@@ -19,8 +22,9 @@ void main() {
     }
 
     group('compact mode (default)', () {
-      testWidgets('shows Available with check icon for plenty status',
-          (tester) async {
+      testWidgets('shows Available with check icon for plenty status', (
+        tester,
+      ) async {
         await tester.pumpWidget(buildBadge(AvailabilityStatus.plenty));
         expect(find.text('Available'), findsOneWidget);
         expect(find.byIcon(Icons.check_circle), findsOneWidget);
@@ -33,8 +37,9 @@ void main() {
         expect(find.byIcon(Icons.check_circle), findsOneWidget);
       });
 
-      testWidgets('shows Sold Out with cancel icon for out status',
-          (tester) async {
+      testWidgets('shows Sold Out with cancel icon for out status', (
+        tester,
+      ) async {
         await tester.pumpWidget(buildBadge(AvailabilityStatus.out));
         expect(find.text('Sold Out'), findsOneWidget);
         expect(find.byIcon(Icons.cancel), findsOneWidget);
@@ -46,8 +51,9 @@ void main() {
         expect(find.text('Available'), findsOneWidget);
       });
 
-      testWidgets('shows custom text instead of status-based text',
-          (tester) async {
+      testWidgets('shows custom text instead of status-based text', (
+        tester,
+      ) async {
         await tester.pumpWidget(
           buildBadge(AvailabilityStatus.plenty, customText: 'Just Tapped'),
         );
@@ -65,8 +71,9 @@ void main() {
     });
 
     group('full-width banner mode', () {
-      testWidgets('renders full-width banner with available status',
-          (tester) async {
+      testWidgets('renders full-width banner with available status', (
+        tester,
+      ) async {
         await tester.pumpWidget(
           buildBadge(AvailabilityStatus.plenty, compact: false),
         );
@@ -74,8 +81,9 @@ void main() {
         expect(find.byIcon(Icons.check_circle), findsOneWidget);
       });
 
-      testWidgets('renders full-width banner with sold-out status',
-          (tester) async {
+      testWidgets('renders full-width banner with sold-out status', (
+        tester,
+      ) async {
         await tester.pumpWidget(
           buildBadge(AvailabilityStatus.out, compact: false),
         );
@@ -83,8 +91,9 @@ void main() {
         expect(find.byIcon(Icons.cancel), findsOneWidget);
       });
 
-      testWidgets('full-width banner uses different icon size than compact',
-          (tester) async {
+      testWidgets('full-width banner uses different icon size than compact', (
+        tester,
+      ) async {
         await tester.pumpWidget(
           buildBadge(AvailabilityStatus.plenty, compact: false),
         );

--- a/test/widgets/breadcrumb_bar_test.dart
+++ b/test/widgets/breadcrumb_bar_test.dart
@@ -99,8 +99,10 @@ void main() {
       );
 
       // Filter to find our custom Semantics (has our label and button property)
-      final customSemantics = allSemantics.where((s) =>
-          s.properties.label == 'Back to Beer' && s.properties.button == true);
+      final customSemantics = allSemantics.where(
+        (s) =>
+            s.properties.label == 'Back to Beer' && s.properties.button == true,
+      );
 
       // Should have exactly one
       expect(customSemantics.length, equals(1));
@@ -115,18 +117,13 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: BreadcrumbBar(
-              backLabel: 'Beer',
-              onBack: () {},
-            ),
+            body: BreadcrumbBar(backLabel: 'Beer', onBack: () {}),
           ),
         ),
       );
 
       // Find IconButton
-      final iconButton = tester.widget<IconButton>(
-        find.byType(IconButton),
-      );
+      final iconButton = tester.widget<IconButton>(find.byType(IconButton));
 
       // Verify tooltip
       expect(iconButton.tooltip, equals('Back to Beer'));
@@ -138,10 +135,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: BreadcrumbBar(
-              backLabel: 'Beer',
-              onBack: () => callCount++,
-            ),
+            body: BreadcrumbBar(backLabel: 'Beer', onBack: () => callCount++),
           ),
         ),
       );
@@ -163,10 +157,7 @@ void main() {
           home: Scaffold(
             body: SizedBox(
               width: 200,
-              child: BreadcrumbBar(
-                backLabel: longLabel,
-                onBack: () {},
-              ),
+              child: BreadcrumbBar(backLabel: longLabel, onBack: () {}),
             ),
           ),
         ),
@@ -217,8 +208,10 @@ void main() {
       );
 
       // Filter to find our custom Semantics (has our label and button property)
-      final customSemantics = allSemantics.where((s) =>
-          s.properties.label == 'Back to Beer' && s.properties.button == true);
+      final customSemantics = allSemantics.where(
+        (s) =>
+            s.properties.label == 'Back to Beer' && s.properties.button == true,
+      );
 
       // Should have exactly one custom Semantics widget
       expect(customSemantics.length, equals(1));
@@ -230,10 +223,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: BreadcrumbBar(
-              backLabel: 'Beer',
-              onBack: () => counter++,
-            ),
+            body: BreadcrumbBar(backLabel: 'Beer', onBack: () => counter++),
           ),
         ),
       );
@@ -246,10 +236,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: BreadcrumbBar(
-              backLabel: 'Beer',
-              onBack: () => counter++,
-            ),
+            body: BreadcrumbBar(backLabel: 'Beer', onBack: () => counter++),
           ),
         ),
       );
@@ -259,8 +246,9 @@ void main() {
       expect(counter, equals(2));
     });
 
-    testWidgets('calls onBackLabelTap when back label is tapped',
-        (tester) async {
+    testWidgets('calls onBackLabelTap when back label is tapped', (
+      tester,
+    ) async {
       var backLabelTapCount = 0;
 
       await tester.pumpWidget(
@@ -280,8 +268,9 @@ void main() {
       expect(backLabelTapCount, equals(1));
     });
 
-    testWidgets('calls onContextLabelTap when context label is tapped',
-        (tester) async {
+    testWidgets('calls onContextLabelTap when context label is tapped', (
+      tester,
+    ) async {
       var contextLabelTapCount = 0;
 
       await tester.pumpWidget(
@@ -302,8 +291,9 @@ void main() {
       expect(contextLabelTapCount, equals(1));
     });
 
-    testWidgets('both labels are clickable when both callbacks provided',
-        (tester) async {
+    testWidgets('both labels are clickable when both callbacks provided', (
+      tester,
+    ) async {
       var backLabelTaps = 0;
       var contextLabelTaps = 0;
 
@@ -332,8 +322,9 @@ void main() {
       expect(contextLabelTaps, equals(1));
     });
 
-    testWidgets('text is not clickable when callbacks not provided',
-        (tester) async {
+    testWidgets('text is not clickable when callbacks not provided', (
+      tester,
+    ) async {
       var backTapCount = 0;
 
       await tester.pumpWidget(
@@ -373,21 +364,22 @@ void main() {
       );
 
       // Find all Semantics widgets
-      final allSemantics = tester.widgetList<Semantics>(
-        find.byType(Semantics),
-      );
+      final allSemantics = tester.widgetList<Semantics>(find.byType(Semantics));
 
       // Filter to find navigation semantics (button=true, label starts with 'Navigate to')
-      final navigationSemantics = allSemantics.where((s) =>
-          s.properties.button == true &&
-          s.properties.label?.startsWith('Navigate to') == true);
+      final navigationSemantics = allSemantics.where(
+        (s) =>
+            s.properties.button == true &&
+            s.properties.label?.startsWith('Navigate to') == true,
+      );
 
       // Should have two navigation semantics (back label + context label)
       expect(navigationSemantics.length, equals(2));
 
       // Check labels
-      final labels =
-          navigationSemantics.map((s) => s.properties.label).toList();
+      final labels = navigationSemantics
+          .map((s) => s.properties.label)
+          .toList();
       expect(labels, contains('Navigate to Drinks'));
       expect(labels, contains('Navigate to Oakham Ales'));
     });

--- a/test/widgets/festival_menu_sheets_test.dart
+++ b/test/widgets/festival_menu_sheets_test.dart
@@ -46,15 +46,17 @@ void main() {
 
       testFestivals = [testFestival];
 
-      when(mockFestivalRepository.getFestivals())
-          .thenAnswer((_) async => FestivalsResponse(
-                festivals: testFestivals,
-                defaultFestivalId: testFestival.id,
-                version: '1.0.0',
-                baseUrl: 'https://data.cambeerfestival.app',
-              ));
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(mockFestivalRepository.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: testFestivals,
+          defaultFestivalId: testFestival.id,
+          version: '1.0.0',
+          baseUrl: 'https://data.cambeerfestival.app',
+        ),
+      );
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
 
       provider = BeerProvider(
@@ -83,11 +85,14 @@ void main() {
 
       expect(find.text('Browse Festivals'), findsOneWidget);
       expect(
-          find.text('Choose a festival to browse its drinks'), findsOneWidget);
+        find.text('Choose a festival to browse its drinks'),
+        findsOneWidget,
+      );
     });
 
-    testWidgets('displays festival cards when festivals are loaded',
-        (tester) async {
+    testWidgets('displays festival cards when festivals are loaded', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildTestWidget());
 
       expect(find.byType(FestivalCard), findsOneWidget);
@@ -131,8 +136,9 @@ void main() {
       expect(semantics.properties.button, isTrue);
     });
 
-    testWidgets('uses high-contrast drag handle color in light theme',
-        (tester) async {
+    testWidgets('uses high-contrast drag handle color in light theme', (
+      tester,
+    ) async {
       final lightTheme = buildAppTheme(Brightness.light);
       await tester.pumpWidget(buildTestWidget(theme: lightTheme));
 
@@ -249,15 +255,17 @@ void main() {
       mockFestivalRepository = MockFestivalRepository();
       mockAnalyticsService = MockAnalyticsService();
 
-      when(mockFestivalRepository.getFestivals())
-          .thenAnswer((_) async => FestivalsResponse(
-                festivals: [],
-                defaultFestivalId: '',
-                version: '1.0.0',
-                baseUrl: 'https://data.cambeerfestival.app',
-              ));
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(mockFestivalRepository.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: [],
+          defaultFestivalId: '',
+          version: '1.0.0',
+          baseUrl: 'https://data.cambeerfestival.app',
+        ),
+      );
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
 
       provider = BeerProvider(
@@ -295,8 +303,9 @@ void main() {
       expect(find.byIcon(Icons.brightness_auto), findsOneWidget);
     });
 
-    testWidgets('uses high-contrast drag handle color in light theme',
-        (tester) async {
+    testWidgets('uses high-contrast drag handle color in light theme', (
+      tester,
+    ) async {
       final lightTheme = buildAppTheme(Brightness.light);
       await tester.pumpWidget(buildTestWidget(theme: lightTheme));
 
@@ -322,15 +331,17 @@ void main() {
       mockFestivalRepository = MockFestivalRepository();
       mockAnalyticsService = MockAnalyticsService();
 
-      when(mockFestivalRepository.getFestivals())
-          .thenAnswer((_) async => FestivalsResponse(
-                festivals: [],
-                defaultFestivalId: '',
-                version: '1.0.0',
-                baseUrl: 'https://data.cambeerfestival.app',
-              ));
-      when(mockFestivalRepository.getSelectedFestivalId())
-          .thenAnswer((_) async => null);
+      when(mockFestivalRepository.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: [],
+          defaultFestivalId: '',
+          version: '1.0.0',
+          baseUrl: 'https://data.cambeerfestival.app',
+        ),
+      );
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
 
       provider = BeerProvider(
@@ -388,8 +399,9 @@ void main() {
       expect(provider.themeMode, ThemeMode.dark);
     });
 
-    testWidgets('uses high-contrast drag handle color in light theme',
-        (tester) async {
+    testWidgets('uses high-contrast drag handle color in light theme', (
+      tester,
+    ) async {
       final lightTheme = buildAppTheme(Brightness.light);
       await tester.pumpWidget(buildTestWidget(theme: lightTheme));
 

--- a/test/widgets/festival_menu_sheets_test.mocks.dart
+++ b/test/widgets/festival_menu_sheets_test.mocks.dart
@@ -33,35 +33,20 @@ import 'package:mockito/mockito.dart' as _i1;
 
 class _FakeFestivalsResponse_0 extends _i1.SmartFake
     implements _i2.FestivalsResponse {
-  _FakeFestivalsResponse_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFestivalsResponse_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFirebaseAnalytics_1 extends _i1.SmartFake
     implements _i3.FirebaseAnalytics {
-  _FakeFirebaseAnalytics_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFirebaseAnalytics_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeFirebaseCrashlytics_2 extends _i1.SmartFake
     implements _i4.FirebaseCrashlytics {
-  _FakeFirebaseCrashlytics_2(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeFirebaseCrashlytics_2(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [DrinkRepository].
@@ -71,70 +56,51 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
   @override
   _i6.Future<List<_i7.Drink>> getDrinks(_i7.Festival? festival) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getDrinks,
-          [festival],
-        ),
-        returnValue: _i6.Future<List<_i7.Drink>>.value(<_i7.Drink>[]),
-        returnValueForMissingStub:
-            _i6.Future<List<_i7.Drink>>.value(<_i7.Drink>[]),
-      ) as _i6.Future<List<_i7.Drink>>);
+            Invocation.method(#getDrinks, [festival]),
+            returnValue: _i6.Future<List<_i7.Drink>>.value(<_i7.Drink>[]),
+            returnValueForMissingStub: _i6.Future<List<_i7.Drink>>.value(
+              <_i7.Drink>[],
+            ),
+          )
+          as _i6.Future<List<_i7.Drink>>);
 
   @override
   _i6.Future<List<_i7.Drink>?> getCachedDrinks(_i7.Festival? festival) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getCachedDrinks,
-          [festival],
-        ),
-        returnValue: _i6.Future<List<_i7.Drink>?>.value(),
-        returnValueForMissingStub: _i6.Future<List<_i7.Drink>?>.value(),
-      ) as _i6.Future<List<_i7.Drink>?>);
+            Invocation.method(#getCachedDrinks, [festival]),
+            returnValue: _i6.Future<List<_i7.Drink>?>.value(),
+            returnValueForMissingStub: _i6.Future<List<_i7.Drink>?>.value(),
+          )
+          as _i6.Future<List<_i7.Drink>?>);
 
   @override
   _i6.Future<List<String>> getFavorites(String? festivalId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getFavorites,
-          [festivalId],
-        ),
-        returnValue: _i6.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i6.Future<List<String>>.value(<String>[]),
-      ) as _i6.Future<List<String>>);
+            Invocation.method(#getFavorites, [festivalId]),
+            returnValue: _i6.Future<List<String>>.value(<String>[]),
+            returnValueForMissingStub: _i6.Future<List<String>>.value(
+              <String>[],
+            ),
+          )
+          as _i6.Future<List<String>>);
 
   @override
-  _i6.Future<bool> toggleFavorite(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<bool> toggleFavorite(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #toggleFavorite,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<bool>.value(false),
-        returnValueForMissingStub: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+            Invocation.method(#toggleFavorite, [festivalId, drinkId]),
+            returnValue: _i6.Future<bool>.value(false),
+            returnValueForMissingStub: _i6.Future<bool>.value(false),
+          )
+          as _i6.Future<bool>);
 
   @override
-  _i6.Future<int?> getRating(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<int?> getRating(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getRating,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<int?>.value(),
-        returnValueForMissingStub: _i6.Future<int?>.value(),
-      ) as _i6.Future<int?>);
+            Invocation.method(#getRating, [festivalId, drinkId]),
+            returnValue: _i6.Future<int?>.value(),
+            returnValueForMissingStub: _i6.Future<int?>.value(),
+          )
+          as _i6.Future<int?>);
 
   @override
   _i6.Future<void> setRating(
@@ -143,79 +109,49 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
     int? rating,
   ) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setRating,
-          [
-            festivalId,
-            drinkId,
-            rating,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#setRating, [festivalId, drinkId, rating]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> removeRating(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<void> removeRating(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #removeRating,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#removeRating, [festivalId, drinkId]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<bool> hasTasted(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<bool> hasTasted(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #hasTasted,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<bool>.value(false),
-        returnValueForMissingStub: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+            Invocation.method(#hasTasted, [festivalId, drinkId]),
+            returnValue: _i6.Future<bool>.value(false),
+            returnValueForMissingStub: _i6.Future<bool>.value(false),
+          )
+          as _i6.Future<bool>);
 
   @override
-  _i6.Future<bool> toggleTasted(
-    String? festivalId,
-    String? drinkId,
-  ) =>
+  _i6.Future<bool> toggleTasted(String? festivalId, String? drinkId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #toggleTasted,
-          [
-            festivalId,
-            drinkId,
-          ],
-        ),
-        returnValue: _i6.Future<bool>.value(false),
-        returnValueForMissingStub: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+            Invocation.method(#toggleTasted, [festivalId, drinkId]),
+            returnValue: _i6.Future<bool>.value(false),
+            returnValueForMissingStub: _i6.Future<bool>.value(false),
+          )
+          as _i6.Future<bool>);
 
   @override
   _i6.Future<List<String>> getTastedDrinks(String? festivalId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getTastedDrinks,
-          [festivalId],
-        ),
-        returnValue: _i6.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i6.Future<List<String>>.value(<String>[]),
-      ) as _i6.Future<List<String>>);
+            Invocation.method(#getTastedDrinks, [festivalId]),
+            returnValue: _i6.Future<List<String>>.value(<String>[]),
+            returnValueForMissingStub: _i6.Future<List<String>>.value(
+              <String>[],
+            ),
+          )
+          as _i6.Future<List<String>>);
 }
 
 /// A class which mocks [FestivalRepository].
@@ -224,60 +160,51 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
 class MockFestivalRepository extends _i1.Mock
     implements _i8.FestivalRepository {
   @override
-  _i6.Future<_i2.FestivalsResponse> getFestivals() => (super.noSuchMethod(
-        Invocation.method(
-          #getFestivals,
-          [],
-        ),
-        returnValue:
-            _i6.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_0(
-          this,
-          Invocation.method(
-            #getFestivals,
-            [],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i6.Future<_i2.FestivalsResponse>.value(_FakeFestivalsResponse_0(
-          this,
-          Invocation.method(
-            #getFestivals,
-            [],
-          ),
-        )),
-      ) as _i6.Future<_i2.FestivalsResponse>);
+  _i6.Future<_i2.FestivalsResponse> getFestivals() =>
+      (super.noSuchMethod(
+            Invocation.method(#getFestivals, []),
+            returnValue: _i6.Future<_i2.FestivalsResponse>.value(
+              _FakeFestivalsResponse_0(
+                this,
+                Invocation.method(#getFestivals, []),
+              ),
+            ),
+            returnValueForMissingStub: _i6.Future<_i2.FestivalsResponse>.value(
+              _FakeFestivalsResponse_0(
+                this,
+                Invocation.method(#getFestivals, []),
+              ),
+            ),
+          )
+          as _i6.Future<_i2.FestivalsResponse>);
 
   @override
   _i6.Future<_i2.FestivalsResponse?> getCachedFestivals() =>
       (super.noSuchMethod(
-        Invocation.method(
-          #getCachedFestivals,
-          [],
-        ),
-        returnValue: _i6.Future<_i2.FestivalsResponse?>.value(),
-        returnValueForMissingStub: _i6.Future<_i2.FestivalsResponse?>.value(),
-      ) as _i6.Future<_i2.FestivalsResponse?>);
+            Invocation.method(#getCachedFestivals, []),
+            returnValue: _i6.Future<_i2.FestivalsResponse?>.value(),
+            returnValueForMissingStub:
+                _i6.Future<_i2.FestivalsResponse?>.value(),
+          )
+          as _i6.Future<_i2.FestivalsResponse?>);
 
   @override
-  _i6.Future<String?> getSelectedFestivalId() => (super.noSuchMethod(
-        Invocation.method(
-          #getSelectedFestivalId,
-          [],
-        ),
-        returnValue: _i6.Future<String?>.value(),
-        returnValueForMissingStub: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
+  _i6.Future<String?> getSelectedFestivalId() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSelectedFestivalId, []),
+            returnValue: _i6.Future<String?>.value(),
+            returnValueForMissingStub: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
 
   @override
   _i6.Future<void> setSelectedFestivalId(String? festivalId) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setSelectedFestivalId,
-          [festivalId],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#setSelectedFestivalId, [festivalId]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 }
 
 /// A class which mocks [AnalyticsService].
@@ -285,188 +212,169 @@ class MockFestivalRepository extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockAnalyticsService extends _i1.Mock implements _i9.AnalyticsService {
   @override
-  _i3.FirebaseAnalytics get analytics => (super.noSuchMethod(
-        Invocation.getter(#analytics),
-        returnValue: _FakeFirebaseAnalytics_1(
-          this,
-          Invocation.getter(#analytics),
-        ),
-        returnValueForMissingStub: _FakeFirebaseAnalytics_1(
-          this,
-          Invocation.getter(#analytics),
-        ),
-      ) as _i3.FirebaseAnalytics);
+  _i3.FirebaseAnalytics get analytics =>
+      (super.noSuchMethod(
+            Invocation.getter(#analytics),
+            returnValue: _FakeFirebaseAnalytics_1(
+              this,
+              Invocation.getter(#analytics),
+            ),
+            returnValueForMissingStub: _FakeFirebaseAnalytics_1(
+              this,
+              Invocation.getter(#analytics),
+            ),
+          )
+          as _i3.FirebaseAnalytics);
 
   @override
-  _i4.FirebaseCrashlytics get crashlytics => (super.noSuchMethod(
-        Invocation.getter(#crashlytics),
-        returnValue: _FakeFirebaseCrashlytics_2(
-          this,
-          Invocation.getter(#crashlytics),
-        ),
-        returnValueForMissingStub: _FakeFirebaseCrashlytics_2(
-          this,
-          Invocation.getter(#crashlytics),
-        ),
-      ) as _i4.FirebaseCrashlytics);
+  _i4.FirebaseCrashlytics get crashlytics =>
+      (super.noSuchMethod(
+            Invocation.getter(#crashlytics),
+            returnValue: _FakeFirebaseCrashlytics_2(
+              this,
+              Invocation.getter(#crashlytics),
+            ),
+            returnValueForMissingStub: _FakeFirebaseCrashlytics_2(
+              this,
+              Invocation.getter(#crashlytics),
+            ),
+          )
+          as _i4.FirebaseCrashlytics);
 
   @override
-  _i6.Future<void> logAppLaunch() => (super.noSuchMethod(
-        Invocation.method(
-          #logAppLaunch,
-          [],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+  _i6.Future<void> logAppLaunch() =>
+      (super.noSuchMethod(
+            Invocation.method(#logAppLaunch, []),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
   _i6.Future<void> logFestivalSelected(_i7.Festival? festival) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logFestivalSelected,
-          [festival],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#logFestivalSelected, [festival]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> logSearch(String? query) => (super.noSuchMethod(
-        Invocation.method(
-          #logSearch,
-          [query],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logCategoryFilter(String? category) => (super.noSuchMethod(
-        Invocation.method(
-          #logCategoryFilter,
-          [category],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logStyleFilter(Set<String>? styles) => (super.noSuchMethod(
-        Invocation.method(
-          #logStyleFilter,
-          [styles],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logSortChange(String? sortType) => (super.noSuchMethod(
-        Invocation.method(
-          #logSortChange,
-          [sortType],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logFavoriteAdded(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logFavoriteAdded,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logFavoriteRemoved(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logFavoriteRemoved,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logTastedAdded(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logTastedAdded,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logTastedRemoved(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logTastedRemoved,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logDrinkViewed(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logDrinkViewed,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logBreweryViewed(String? breweryName) => (super.noSuchMethod(
-        Invocation.method(
-          #logBreweryViewed,
-          [breweryName],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logStyleViewed(String? style) => (super.noSuchMethod(
-        Invocation.method(
-          #logStyleViewed,
-          [style],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> logRatingGiven(
-    _i7.Drink? drink,
-    int? rating,
-  ) =>
+  _i6.Future<void> logSearch(String? query) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logRatingGiven,
-          [
-            drink,
-            rating,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#logSearch, [query]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> logDrinkShared(_i7.Drink? drink) => (super.noSuchMethod(
-        Invocation.method(
-          #logDrinkShared,
-          [drink],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+  _i6.Future<void> logCategoryFilter(String? category) =>
+      (super.noSuchMethod(
+            Invocation.method(#logCategoryFilter, [category]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logStyleFilter(Set<String>? styles) =>
+      (super.noSuchMethod(
+            Invocation.method(#logStyleFilter, [styles]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logSortChange(String? sortType) =>
+      (super.noSuchMethod(
+            Invocation.method(#logSortChange, [sortType]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFavoriteAdded(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFavoriteAdded, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFavoriteRemoved(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFavoriteRemoved, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logTastedAdded(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logTastedAdded, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logTastedRemoved(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logTastedRemoved, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logDrinkViewed(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logDrinkViewed, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logBreweryViewed(String? breweryName) =>
+      (super.noSuchMethod(
+            Invocation.method(#logBreweryViewed, [breweryName]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logStyleViewed(String? style) =>
+      (super.noSuchMethod(
+            Invocation.method(#logStyleViewed, [style]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logRatingGiven(_i7.Drink? drink, int? rating) =>
+      (super.noSuchMethod(
+            Invocation.method(#logRatingGiven, [drink, rating]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logDrinkShared(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logDrinkShared, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
   _i6.Future<void> logError(
@@ -475,42 +383,31 @@ class MockAnalyticsService extends _i1.Mock implements _i9.AnalyticsService {
     String? reason,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #logError,
-          [
-            error,
-            stackTrace,
-          ],
-          {#reason: reason},
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(
+              #logError,
+              [error, stackTrace],
+              {#reason: reason},
+            ),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> setUserProperty(
-    String? name,
-    String? value,
-  ) =>
+  _i6.Future<void> setUserProperty(String? name, String? value) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #setUserProperty,
-          [
-            name,
-            value,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+            Invocation.method(#setUserProperty, [name, value]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 
   @override
-  _i6.Future<void> setUserId(String? userId) => (super.noSuchMethod(
-        Invocation.method(
-          #setUserId,
-          [userId],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+  _i6.Future<void> setUserId(String? userId) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserId, [userId]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
 }

--- a/test/widgets/overflow_menu_test.dart
+++ b/test/widgets/overflow_menu_test.dart
@@ -8,11 +8,8 @@ void main() {
     Widget buildMenuWidget() {
       return MaterialApp(
         home: Builder(
-          builder: (context) => Scaffold(
-            body: Center(
-              child: buildOverflowMenu(context),
-            ),
-          ),
+          builder: (context) =>
+              Scaffold(body: Center(child: buildOverflowMenu(context))),
         ),
       );
     }
@@ -88,10 +85,7 @@ void main() {
       );
 
       expect(
-        find.descendant(
-          of: settingsRow,
-          matching: find.byIcon(Icons.settings),
-        ),
+        find.descendant(of: settingsRow, matching: find.byIcon(Icons.settings)),
         findsOneWidget,
       );
     });
@@ -116,17 +110,15 @@ void main() {
       );
     });
 
-    testWidgets('uses high-contrast menu item colors in light theme',
-        (tester) async {
+    testWidgets('uses high-contrast menu item colors in light theme', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: buildAppTheme(Brightness.light),
           home: Builder(
-            builder: (context) => Scaffold(
-              body: Center(
-                child: buildOverflowMenu(context),
-              ),
-            ),
+            builder: (context) =>
+                Scaffold(body: Center(child: buildOverflowMenu(context))),
           ),
         ),
       );
@@ -134,8 +126,9 @@ void main() {
       await tester.tap(find.byIcon(Icons.more_vert));
       await tester.pumpAndSettle();
 
-      final expectedColor =
-          buildAppTheme(Brightness.light).colorScheme.onSurface;
+      final expectedColor = buildAppTheme(
+        Brightness.light,
+      ).colorScheme.onSurface;
 
       final festivalIcon = tester.widget<Icon>(find.byIcon(Icons.festival));
       expect(festivalIcon.color, expectedColor);

--- a/test/widgets_test.dart
+++ b/test/widgets_test.dart
@@ -7,11 +7,7 @@ void main() {
   group('StarRating', () {
     testWidgets('displays 5 stars', (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: StarRating(),
-          ),
-        ),
+        const MaterialApp(home: Scaffold(body: StarRating())),
       );
 
       // Should find 5 star icons (star_border since no rating)
@@ -19,14 +15,11 @@ void main() {
       expect(find.byIcon(Icons.star), findsNothing);
     });
 
-    testWidgets('displays filled stars based on rating',
-        (WidgetTester tester) async {
+    testWidgets('displays filled stars based on rating', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: StarRating(rating: 3),
-          ),
-        ),
+        const MaterialApp(home: Scaffold(body: StarRating(rating: 3))),
       );
 
       // Should find 3 filled stars and 2 empty stars
@@ -34,14 +27,11 @@ void main() {
       expect(find.byIcon(Icons.star_border), findsNWidgets(2));
     });
 
-    testWidgets('displays all filled stars for rating of 5',
-        (WidgetTester tester) async {
+    testWidgets('displays all filled stars for rating of 5', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: StarRating(rating: 5),
-          ),
-        ),
+        const MaterialApp(home: Scaffold(body: StarRating(rating: 5))),
       );
 
       // Should find 5 filled stars and no empty stars
@@ -49,14 +39,11 @@ void main() {
       expect(find.byIcon(Icons.star_border), findsNothing);
     });
 
-    testWidgets('displays all empty stars for null rating',
-        (WidgetTester tester) async {
+    testWidgets('displays all empty stars for null rating', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: StarRating(rating: null),
-          ),
-        ),
+        const MaterialApp(home: Scaffold(body: StarRating(rating: null))),
       );
 
       // Should find 5 empty stars
@@ -64,8 +51,9 @@ void main() {
       expect(find.byIcon(Icons.star), findsNothing);
     });
 
-    testWidgets('calls onRatingChanged when editable star is tapped',
-        (WidgetTester tester) async {
+    testWidgets('calls onRatingChanged when editable star is tapped', (
+      WidgetTester tester,
+    ) async {
       int? selectedRating;
 
       await tester.pumpWidget(
@@ -89,8 +77,9 @@ void main() {
       expect(selectedRating, 3);
     });
 
-    testWidgets('tapping first star sets rating to 1',
-        (WidgetTester tester) async {
+    testWidgets('tapping first star sets rating to 1', (
+      WidgetTester tester,
+    ) async {
       int? selectedRating;
 
       await tester.pumpWidget(
@@ -111,8 +100,9 @@ void main() {
       expect(selectedRating, 1);
     });
 
-    testWidgets('tapping fifth star sets rating to 5',
-        (WidgetTester tester) async {
+    testWidgets('tapping fifth star sets rating to 5', (
+      WidgetTester tester,
+    ) async {
       int? selectedRating;
 
       await tester.pumpWidget(
@@ -133,8 +123,9 @@ void main() {
       expect(selectedRating, 5);
     });
 
-    testWidgets('does not call onRatingChanged when not editable',
-        (WidgetTester tester) async {
+    testWidgets('does not call onRatingChanged when not editable', (
+      WidgetTester tester,
+    ) async {
       int? selectedRating;
 
       await tester.pumpWidget(
@@ -157,11 +148,7 @@ void main() {
 
     testWidgets('uses custom star size', (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: StarRating(starSize: 48),
-          ),
-        ),
+        const MaterialApp(home: Scaffold(body: StarRating(starSize: 48))),
       );
 
       final iconFinder = find.byIcon(Icons.star_border);
@@ -172,12 +159,7 @@ void main() {
     testWidgets('uses custom active color', (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: Scaffold(
-            body: StarRating(
-              rating: 1,
-              activeColor: Colors.red,
-            ),
-          ),
+          home: Scaffold(body: StarRating(rating: 1, activeColor: Colors.red)),
         ),
       );
 
@@ -190,10 +172,7 @@ void main() {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
-            body: StarRating(
-              rating: 1,
-              inactiveColor: Colors.blue,
-            ),
+            body: StarRating(rating: 1, inactiveColor: Colors.blue),
           ),
         ),
       );
@@ -203,15 +182,14 @@ void main() {
       expect(iconWidget.color, Colors.blue);
     });
 
-    testWidgets('uses high-contrast default inactive color in light theme',
-        (WidgetTester tester) async {
+    testWidgets('uses high-contrast default inactive color in light theme', (
+      WidgetTester tester,
+    ) async {
       final lightTheme = buildAppTheme(Brightness.light);
       await tester.pumpWidget(
         MaterialApp(
           theme: lightTheme,
-          home: const Scaffold(
-            body: StarRating(rating: 1),
-          ),
+          home: const Scaffold(body: StarRating(rating: 1)),
         ),
       );
 
@@ -244,8 +222,9 @@ void main() {
       expect(selectedRating, isNull);
     });
 
-    testWidgets('tapping different star changes rating',
-        (WidgetTester tester) async {
+    testWidgets('tapping different star changes rating', (
+      WidgetTester tester,
+    ) async {
       int? selectedRating;
 
       await tester.pumpWidget(
@@ -269,8 +248,9 @@ void main() {
       expect(selectedRating, 5);
     });
 
-    testWidgets('tapping star when rating is null sets rating',
-        (WidgetTester tester) async {
+    testWidgets('tapping star when rating is null sets rating', (
+      WidgetTester tester,
+    ) async {
       int? selectedRating;
 
       await tester.pumpWidget(
@@ -294,8 +274,9 @@ void main() {
       expect(selectedRating, 4);
     });
 
-    testWidgets('tapping first star when rating is 1 clears rating',
-        (WidgetTester tester) async {
+    testWidgets('tapping first star when rating is 1 clears rating', (
+      WidgetTester tester,
+    ) async {
       int? selectedRating;
 
       await tester.pumpWidget(
@@ -319,8 +300,9 @@ void main() {
       expect(selectedRating, isNull);
     });
 
-    testWidgets('tapping fifth star when rating is 5 clears rating',
-        (WidgetTester tester) async {
+    testWidgets('tapping fifth star when rating is 5 clears rating', (
+      WidgetTester tester,
+    ) async {
       int? selectedRating;
 
       await tester.pumpWidget(
@@ -344,26 +326,19 @@ void main() {
       expect(selectedRating, isNull);
     });
 
-    testWidgets('editable rating includes clear instruction in semantic hint',
-        (WidgetTester tester) async {
+    testWidgets('editable rating includes clear instruction in semantic hint', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: Scaffold(
-            body: StarRating(
-              rating: 3,
-              isEditable: true,
-            ),
-          ),
+          home: Scaffold(body: StarRating(rating: 3, isEditable: true)),
         ),
       );
 
       // Find the Semantics widget and check its properties
       final semantics = tester.widget<Semantics>(
         find
-            .ancestor(
-              of: find.byType(Row),
-              matching: find.byType(Semantics),
-            )
+            .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
             .first,
       );
 
@@ -372,26 +347,19 @@ void main() {
       expect(semantics.properties.hint, contains('Tap again'));
     });
 
-    testWidgets('non-editable rating does not include hint',
-        (WidgetTester tester) async {
+    testWidgets('non-editable rating does not include hint', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: Scaffold(
-            body: StarRating(
-              rating: 3,
-              isEditable: false,
-            ),
-          ),
+          home: Scaffold(body: StarRating(rating: 3, isEditable: false)),
         ),
       );
 
       // Find the Semantics widget and check its properties
       final semantics = tester.widget<Semantics>(
         find
-            .ancestor(
-              of: find.byType(Row),
-              matching: find.byType(Semantics),
-            )
+            .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
             .first,
       );
 


### PR DESCRIPTION
Bumps 9 of the 10 packages from the dart-dependencies Dependabot group (supersedes #346):

| Package | From | To |
| --- | --- | --- |
| `firebase_analytics` | 11.6.0 | 12.4.1 |
| `firebase_core` | 3.15.2 | 4.9.0 |
| `firebase_crashlytics` | 4.3.10 | 5.2.2 |
| `flutter_lints` | 3.0.2 | 6.0.0 |
| `go_router` | 14.8.1 | 17.2.3 |
| `google_fonts` | 6.3.3 | 8.1.0 |
| `intl` | 0.19.0 | 0.20.2 |
| `package_info_plus` | 8.3.1 | 9.0.1 |
| `share_plus` | 10.1.4 | 12.0.2 |

**`mockito` is intentionally held at `^5.4.4`** (resolves to 5.6.4). Version 5.7.0 requires `analyzer 13 → meta ^1.18.0`, which conflicts with `flutter_test`'s pinned `meta 1.17.0` in Flutter 3.38.3. Will unblock when Flutter ships a release with `meta >=1.18.0`.

## Code changes

- `share_plus` v11 deprecated the `Share` class — migrated `Share.share()` → `SharePlus.instance.share(ShareParams(...))` in `drink_detail_screen.dart`
- Tightened SDK constraint to `>=3.10.0` (Flutter 3.38.3 ships Dart 3.10.1; the bumped packages require at least that)
- Reformatted 78 files and regenerated 6 mock files for Dart 3.10.1 — isolated in a single commit to keep the diff reviewable