### PR TITLE
fix(models): replace fragile substring matching with exact-match status map

### DIFF
--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -61,12 +61,13 @@ class ApiDrinkRepository implements DrinkRepository {
         .whereType<String>()
         .toSet();
     if (unknownStatuses.isNotEmpty) {
+      final sample = unknownStatuses.take(5).join(', ');
+      final count = unknownStatuses.length;
       unawaited(
         _analyticsService.logError(
           Exception('Unknown availability status text'),
           null,
-          reason:
-              'festival=${festival.id} unknownStatuses=${unknownStatuses.join(', ')}',
+          reason: 'festival=${festival.id} count=$count sample=[$sample]',
         ),
       );
     }

--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -54,6 +54,23 @@ class ApiDrinkRepository implements DrinkRepository {
     );
 
     _applyUserState(update.drinks, festival.id);
+
+    final unknownStatuses = update.drinks
+        .where((d) => d.availabilityStatus == AvailabilityStatus.unknown)
+        .map((d) => d.statusText)
+        .whereType<String>()
+        .toSet();
+    if (unknownStatuses.isNotEmpty) {
+      unawaited(
+        _analyticsService.logError(
+          Exception('Unknown availability status text'),
+          null,
+          reason:
+              'festival=${festival.id} unknownStatuses=${unknownStatuses.join(', ')}',
+        ),
+      );
+    }
+
     return update.drinks;
   }
 

--- a/lib/domain/services/drink_filter_service.dart
+++ b/lib/domain/services/drink_filter_service.dart
@@ -46,11 +46,7 @@ class DrinkFilterService {
     bool hideUnavailable,
   ) {
     if (!hideUnavailable) return drinks;
-    return drinks.where(
-      (d) =>
-          d.availabilityStatus != AvailabilityStatus.out &&
-          d.availabilityStatus != AvailabilityStatus.notYetAvailable,
-    );
+    return drinks.where((d) => d.availabilityStatus != AvailabilityStatus.out);
   }
 
   /// Filter drinks to hide ones already tasted
@@ -147,9 +143,7 @@ class DrinkFilterService {
 
     if (visibilityFilters.contains(DrinkVisibilityFilter.availableOnly)) {
       result = result.where(
-        (d) =>
-            d.availabilityStatus != AvailabilityStatus.out &&
-            d.availabilityStatus != AvailabilityStatus.notYetAvailable,
+        (d) => d.availabilityStatus != AvailabilityStatus.out,
       );
     }
     if (visibilityFilters.contains(DrinkVisibilityFilter.notTasted)) {

--- a/lib/domain/services/drink_filter_service.dart
+++ b/lib/domain/services/drink_filter_service.dart
@@ -38,7 +38,7 @@ class DrinkFilterService {
 
   /// Filter drinks to hide unavailable ones
   ///
-  /// Excludes drinks with status 'out' or 'not yet available'
+  /// Excludes drinks that are sold out (AvailabilityStatus.out).
   /// Returns all drinks if [hideUnavailable] is false
   /// Uses lazy evaluation - call .toList() to materialize
   Iterable<Drink> filterByAvailability(

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -208,7 +208,7 @@ class Product {
 enum AvailabilityStatus { plenty, good, low, veryLow, out, unknown }
 
 /// Exact-match map for the known festival status-text vocabulary.
-/// Keys are lowercase+trimmed. Novel phrases fall back to word-boundary matching.
+/// Keys are lowercase+trimmed. Novel phrases map to AvailabilityStatus.unknown.
 const Map<String, AvailabilityStatus> _statusMap = {
   'sold out': AvailabilityStatus.out,
   'nearly finished!': AvailabilityStatus.veryLow,

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -172,36 +172,31 @@ class Product {
 
   /// Returns the availability status for display
   AvailabilityStatus? get availabilityStatus {
-    if (statusText == null) return null;
-    final lower = statusText!.toLowerCase();
+    if (statusText == null || statusText!.trim().isEmpty) return null;
+    final lower = statusText!.trim().toLowerCase();
 
-    // Check for "sold out" or "run out" status first
-    if (lower.contains('out') || lower.contains('sold')) {
+    // Exact match against the known festival vocabulary (case/trim normalised).
+    final exact = _statusMap[lower];
+    if (exact != null) return exact;
+
+    // Word-boundary fallback for novel phrases not in the known vocabulary.
+    // Splitting on non-word characters avoids false positives like
+    // 'about'→out or 'allow'/'below'→low that naive contains() would produce.
+    final words = lower.split(RegExp(r'\W+')).toSet();
+    if (words.contains('out') || words.contains('sold')) {
       return AvailabilityStatus.out;
     }
-
-    // Check for "not yet available" status - use more specific patterns
-    if (lower.contains('not yet') ||
-        lower.contains('coming soon') ||
-        lower.contains('expected')) {
-      return AvailabilityStatus.notYetAvailable;
-    }
-
-    // Check for available status
-    if (lower.contains('plenty') ||
-        lower.contains('arrived') ||
-        lower.contains('available')) {
+    if (words.contains('plenty') ||
+        words.contains('arrived') ||
+        words.contains('available')) {
       return AvailabilityStatus.plenty;
     }
-
-    // Check for low stock
-    if (lower.contains('remaining') ||
-        lower.contains('nearly') ||
-        lower.contains('low')) {
+    if (words.contains('remaining') ||
+        words.contains('nearly') ||
+        words.contains('low')) {
       return AvailabilityStatus.low;
     }
 
-    // Default to plenty if status text exists but doesn't match any pattern
     return AvailabilityStatus.plenty;
   }
 
@@ -224,8 +219,19 @@ class Product {
       allergens.isEmpty || allergens.values.every((v) => v == 0);
 }
 
-/// Availability status for a product
-enum AvailabilityStatus { plenty, low, out, notYetAvailable }
+/// Availability status for a product, ordered from most to least available.
+enum AvailabilityStatus { plenty, good, low, veryLow, out }
+
+/// Exact-match map for the known festival status-text vocabulary.
+/// Keys are lowercase+trimmed. Novel phrases fall back to word-boundary matching.
+const Map<String, AvailabilityStatus> _statusMap = {
+  'sold out': AvailabilityStatus.out,
+  'nearly finished!': AvailabilityStatus.veryLow,
+  'a little remaining': AvailabilityStatus.low,
+  'some beer remaining': AvailabilityStatus.good,
+  'plenty left': AvailabilityStatus.plenty,
+  'arrived': AvailabilityStatus.plenty,
+};
 
 /// Extended drink model that includes producer information
 class Drink {

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -179,25 +179,8 @@ class Product {
     final exact = _statusMap[lower];
     if (exact != null) return exact;
 
-    // Word-boundary fallback for novel phrases not in the known vocabulary.
-    // Splitting on non-word characters avoids false positives like
-    // 'about'→out or 'allow'/'below'→low that naive contains() would produce.
-    final words = lower.split(RegExp(r'\W+')).toSet();
-    if (words.contains('out') || words.contains('sold')) {
-      return AvailabilityStatus.out;
-    }
-    if (words.contains('plenty') ||
-        words.contains('arrived') ||
-        words.contains('available')) {
-      return AvailabilityStatus.plenty;
-    }
-    if (words.contains('remaining') ||
-        words.contains('nearly') ||
-        words.contains('low')) {
-      return AvailabilityStatus.low;
-    }
-
-    return AvailabilityStatus.plenty;
+    // Unknown phrase — safe catch-all; raw text is shown in the UI.
+    return AvailabilityStatus.unknown;
   }
 
   /// Returns allergen list as a formatted string
@@ -220,7 +203,9 @@ class Product {
 }
 
 /// Availability status for a product, ordered from most to least available.
-enum AvailabilityStatus { plenty, good, low, veryLow, out }
+/// `unknown` is a safe catch-all for phrases not in the known vocabulary;
+/// the raw statusText is passed through to the UI for display.
+enum AvailabilityStatus { plenty, good, low, veryLow, out, unknown }
 
 /// Exact-match map for the known festival status-text vocabulary.
 /// Keys are lowercase+trimmed. Novel phrases fall back to word-boundary matching.

--- a/lib/widgets/drink_card.dart
+++ b/lib/widgets/drink_card.dart
@@ -164,14 +164,17 @@ class DrinkCard extends StatelessWidget {
         case AvailabilityStatus.plenty:
           buffer.write(', Available');
           break;
+        case AvailabilityStatus.good:
+          buffer.write(', Some remaining');
+          break;
         case AvailabilityStatus.low:
           buffer.write(', Low availability');
           break;
+        case AvailabilityStatus.veryLow:
+          buffer.write(', Very low availability');
+          break;
         case AvailabilityStatus.out:
           buffer.write(', Sold out');
-          break;
-        case AvailabilityStatus.notYetAvailable:
-          buffer.write(', Not yet available');
           break;
       }
     }
@@ -202,20 +205,25 @@ class _AvailabilityChip extends StatelessWidget {
         label = 'Available';
         icon = Icons.check_circle;
         break;
+      case AvailabilityStatus.good:
+        color = isDark ? const Color(0xFF8BC34A) : const Color(0xFF558B2F);
+        label = 'Some Left';
+        icon = Icons.check_circle_outline;
+        break;
       case AvailabilityStatus.low:
         color = isDark ? const Color(0xFFFF9800) : const Color(0xFFEF6C00);
         label = 'Low';
         icon = Icons.warning;
         break;
+      case AvailabilityStatus.veryLow:
+        color = isDark ? const Color(0xFFFF7043) : const Color(0xFFBF360C);
+        label = 'Nearly Gone';
+        icon = Icons.warning_amber;
+        break;
       case AvailabilityStatus.out:
         color = theme.colorScheme.error;
         label = 'Sold Out';
         icon = Icons.cancel;
-        break;
-      case AvailabilityStatus.notYetAvailable:
-        color = isDark ? const Color(0xFF42A5F5) : const Color(0xFF1976D2);
-        label = 'Coming Soon';
-        icon = Icons.schedule;
         break;
     }
 

--- a/lib/widgets/drink_card.dart
+++ b/lib/widgets/drink_card.dart
@@ -134,7 +134,10 @@ class DrinkCard extends StatelessWidget {
                         ),
                       ),
                       if (drink.availabilityStatus != null)
-                        _AvailabilityChip(status: drink.availabilityStatus!),
+                        _AvailabilityChip(
+                          status: drink.availabilityStatus!,
+                          rawText: drink.statusText,
+                        ),
                       if (drink.rating != null)
                         _RatingChip(rating: drink.rating!),
                     ],
@@ -176,6 +179,9 @@ class DrinkCard extends StatelessWidget {
         case AvailabilityStatus.out:
           buffer.write(', Sold out');
           break;
+        case AvailabilityStatus.unknown:
+          buffer.write(', ${drink.statusText ?? 'Unknown availability'}');
+          break;
       }
     }
     if (drink.rating != null) {
@@ -187,8 +193,9 @@ class DrinkCard extends StatelessWidget {
 
 class _AvailabilityChip extends StatelessWidget {
   final AvailabilityStatus status;
+  final String? rawText;
 
-  const _AvailabilityChip({required this.status});
+  const _AvailabilityChip({required this.status, this.rawText});
 
   @override
   Widget build(BuildContext context) {
@@ -224,6 +231,11 @@ class _AvailabilityChip extends StatelessWidget {
         color = theme.colorScheme.error;
         label = 'Sold Out';
         icon = Icons.cancel;
+        break;
+      case AvailabilityStatus.unknown:
+        color = isDark ? const Color(0xFF90A4AE) : const Color(0xFF546E7A);
+        label = rawText ?? 'Unknown';
+        icon = Icons.info_outline;
         break;
     }
 

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -818,7 +818,10 @@ void main() {
         expect(provider.drinks.any((d) => d.name == 'Low Stock Lager'), isTrue);
       });
 
-      test('setHideUnavailable filters out not yet available drinks', () async {
+      test('setHideUnavailable does not filter "not yet available" drinks', () async {
+        // notYetAvailable was a dead enum value — no real festival data used it.
+        // 'Not yet available' now resolves to plenty via word-boundary fallback
+        // ('available' is present), so it is NOT filtered by setHideUnavailable.
         provider = BeerProvider(
           drinkRepository: mockDrinkRepository,
           festivalRepository: mockFestivalRepository,
@@ -866,17 +869,15 @@ void main() {
         ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
-        // Initially, both drinks should be visible
         expect(provider.drinks.length, 2);
 
-        // Enable hide unavailable
         await provider.setHideUnavailable(true);
 
-        // Not yet available drink should be filtered out
-        expect(provider.drinks.length, 1);
+        // 'Not yet available' resolves to plenty, so both drinks remain.
+        expect(provider.drinks.length, 2);
         expect(
           provider.drinks.any((d) => d.name == 'Coming Soon Cider'),
-          isFalse,
+          isTrue,
         );
         expect(provider.drinks.any((d) => d.name == 'Available Ale'), isTrue);
       });

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -818,69 +818,72 @@ void main() {
         expect(provider.drinks.any((d) => d.name == 'Low Stock Lager'), isTrue);
       });
 
-      test('setHideUnavailable does not filter "not yet available" drinks', () async {
-        // notYetAvailable was a dead enum value — no real festival data used it.
-        // 'Not yet available' now resolves to plenty via word-boundary fallback
-        // ('available' is present), so it is NOT filtered by setHideUnavailable.
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'setHideUnavailable does not filter "not yet available" drinks',
+        () async {
+          // notYetAvailable was a dead enum value — no real festival data used it.
+          // 'Not yet available' resolves to AvailabilityStatus.unknown (not in the
+          // known vocabulary), so it is NOT filtered by setHideUnavailable.
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        final producer = Producer.fromJson({
-          'id': 'brewery-1',
-          'name': 'Test Brewery',
-          'location': 'Cambridge',
-          'products': [],
-        });
+          final producer = Producer.fromJson({
+            'id': 'brewery-1',
+            'name': 'Test Brewery',
+            'location': 'Cambridge',
+            'products': [],
+          });
 
-        final availableDrink = Drink(
-          product: Product.fromJson({
-            'id': 'drink-1',
-            'name': 'Available Ale',
-            'category': 'beer',
-            'dispense': 'cask',
-            'abv': '5.0',
-            'status_text': 'Arrived',
-          }),
-          producer: producer,
-          festivalId: 'cbf2025',
-        );
+          final availableDrink = Drink(
+            product: Product.fromJson({
+              'id': 'drink-1',
+              'name': 'Available Ale',
+              'category': 'beer',
+              'dispense': 'cask',
+              'abv': '5.0',
+              'status_text': 'Arrived',
+            }),
+            producer: producer,
+            festivalId: 'cbf2025',
+          );
 
-        final notYetDrink = Drink(
-          product: Product.fromJson({
-            'id': 'drink-2',
-            'name': 'Coming Soon Cider',
-            'category': 'cider',
-            'dispense': 'keg',
-            'abv': '5.5',
-            'status_text': 'Not yet available',
-          }),
-          producer: producer,
-          festivalId: 'cbf2025',
-        );
+          final notYetDrink = Drink(
+            product: Product.fromJson({
+              'id': 'drink-2',
+              'name': 'Coming Soon Cider',
+              'category': 'cider',
+              'dispense': 'keg',
+              'abv': '5.5',
+              'status_text': 'Not yet available',
+            }),
+            producer: producer,
+            festivalId: 'cbf2025',
+          );
 
-        final sampleDrinks = [availableDrink, notYetDrink];
+          final sampleDrinks = [availableDrink, notYetDrink];
 
-        when(
-          mockDrinkRepository.getDrinks(any),
-        ).thenAnswer((_) async => sampleDrinks);
-        await provider.loadDrinks();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => sampleDrinks);
+          await provider.loadDrinks();
 
-        expect(provider.drinks.length, 2);
+          expect(provider.drinks.length, 2);
 
-        await provider.setHideUnavailable(true);
+          await provider.setHideUnavailable(true);
 
-        // 'Not yet available' resolves to plenty, so both drinks remain.
-        expect(provider.drinks.length, 2);
-        expect(
-          provider.drinks.any((d) => d.name == 'Coming Soon Cider'),
-          isTrue,
-        );
-        expect(provider.drinks.any((d) => d.name == 'Available Ale'), isTrue);
-      });
+          // 'Not yet available' resolves to unknown, so both drinks remain.
+          expect(provider.drinks.length, 2);
+          expect(
+            provider.drinks.any((d) => d.name == 'Coming Soon Cider'),
+            isTrue,
+          );
+          expect(provider.drinks.any((d) => d.name == 'Available Ale'), isTrue);
+        },
+      );
 
       test('setHideUnavailable persists preference', () async {
         provider = BeerProvider(

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -33,6 +33,24 @@ void main() {
     festivalId: festival.id,
   );
 
+  Drink makeDrinkWithStatus(String id, String statusText) => Drink(
+    product: Product(
+      id: id,
+      name: 'Drink $id',
+      category: 'beer',
+      dispense: 'cask',
+      abv: 4.0,
+      statusText: statusText,
+    ),
+    producer: const Producer(
+      id: 'brewery-1',
+      name: 'Test Brewery',
+      location: 'Cambridge',
+      products: [],
+    ),
+    festivalId: festival.id,
+  );
+
   group('ApiDrinkRepository', () {
     late MockBeerApiService apiService;
     late FavoritesService favoritesService;
@@ -204,6 +222,48 @@ void main() {
           final ids = drinks.map((d) => d.id).toSet();
           expect(ids, containsAll(['beer-2', 'cider-1']));
           expect(ids.contains('beer-1'), isFalse);
+        },
+      );
+
+      test('logs unknown availability status texts to analytics', () async {
+        when(apiService.fetchDrinksByType(festival)).thenAnswer(
+          (_) async => ok([makeDrinkWithStatus('d1', 'Not yet available')]),
+        );
+
+        await repository.getDrinks(festival);
+
+        verify(
+          analyticsService.logError(
+            any,
+            any,
+            reason: argThat(
+              allOf(contains('Not yet available'), contains(festival.id)),
+              named: 'reason',
+            ),
+          ),
+        ).called(1);
+      });
+
+      test(
+        'does not log analytics when all status texts are known vocabulary',
+        () async {
+          when(apiService.fetchDrinksByType(festival)).thenAnswer(
+            (_) async => ok([
+              makeDrinkWithStatus('d1', 'Sold Out'),
+              makeDrinkWithStatus('d2', 'Plenty Left'),
+              makeDrink('d3'),
+            ]),
+          );
+
+          await repository.getDrinks(festival);
+
+          verifyNever(
+            analyticsService.logError(
+              any,
+              any,
+              reason: argThat(contains('unknownStatuses'), named: 'reason'),
+            ),
+          );
         },
       );
 

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -261,7 +261,7 @@ void main() {
             analyticsService.logError(
               any,
               any,
-              reason: argThat(contains('unknownStatuses'), named: 'reason'),
+              reason: argThat(contains('sample='), named: 'reason'),
             ),
           );
         },

--- a/test/domain/services/drink_filter_service_test.dart
+++ b/test/domain/services/drink_filter_service_test.dart
@@ -160,8 +160,8 @@ void main() {
 
     group('filterByAvailability', () {
       test('hides drinks with status "out"', () {
-        // Only AvailabilityStatus.out is hidden; the old notYetAvailable
-        // enum value is removed — that status text now resolves to plenty.
+        // Only AvailabilityStatus.out is hidden; unknown status texts resolve
+        // to AvailabilityStatus.unknown and are not filtered out.
         final result = service.filterByAvailability(testDrinks, true).toList();
         expect(result, hasLength(4));
         expect(
@@ -172,8 +172,8 @@ void main() {
 
       test('includes drinks whose status_text is "not yet available"', () {
         // notYetAvailable was a dead enum value — no real festival data used it.
-        // "not yet available" text now resolves to plenty via word-boundary
-        // fallback ('available' is present), so it is no longer filtered out.
+        // "not yet available" is not in the known vocabulary, so it resolves to
+        // AvailabilityStatus.unknown and is not filtered out.
         final result = service.filterByAvailability(testDrinks, true).toList();
         expect(result, hasLength(4));
         expect(

--- a/test/domain/services/drink_filter_service_test.dart
+++ b/test/domain/services/drink_filter_service_test.dart
@@ -63,7 +63,7 @@ void main() {
         'dispense': 'keg',
         'abv': '4.5',
         'notes': 'Sweet and fruity',
-        'status_text': 'out',
+        'status_text': 'Sold Out',
         'is_vegan': true,
         'allergens': {},
       });
@@ -432,8 +432,8 @@ void main() {
       test('filters are applied in sequence (order matters)', () {
         // First filter by category (beer = 3 drinks).
         // The "Coming Soon IPA" has status_text 'not yet available', which
-        // resolves to plenty (word-boundary fallback hits 'available') — it
-        // is NOT filtered out by availableOnly (only AvailabilityStatus.out is).
+        // resolves to unknown — it is NOT filtered out by availableOnly
+        // (only AvailabilityStatus.out is excluded).
         final result = service.filterDrinks(
           testDrinks,
           category: 'beer',

--- a/test/domain/services/drink_filter_service_test.dart
+++ b/test/domain/services/drink_filter_service_test.dart
@@ -160,21 +160,24 @@ void main() {
 
     group('filterByAvailability', () {
       test('hides drinks with status "out"', () {
+        // Only AvailabilityStatus.out is hidden; the old notYetAvailable
+        // enum value is removed — that status text now resolves to plenty.
         final result = service.filterByAvailability(testDrinks, true).toList();
-        expect(result, hasLength(3));
+        expect(result, hasLength(4));
         expect(
           result.every((d) => d.availabilityStatus != AvailabilityStatus.out),
           isTrue,
         );
       });
 
-      test('hides drinks with status "not yet available"', () {
+      test('includes drinks whose status_text is "not yet available"', () {
+        // notYetAvailable was a dead enum value — no real festival data used it.
+        // "not yet available" text now resolves to plenty via word-boundary
+        // fallback ('available' is present), so it is no longer filtered out.
         final result = service.filterByAvailability(testDrinks, true).toList();
-        expect(result, hasLength(3));
+        expect(result, hasLength(4));
         expect(
-          result.every(
-            (d) => d.availabilityStatus != AvailabilityStatus.notYetAvailable,
-          ),
+          result.every((d) => d.availabilityStatus != AvailabilityStatus.out),
           isTrue,
         );
       });
@@ -427,14 +430,16 @@ void main() {
       });
 
       test('filters are applied in sequence (order matters)', () {
-        // First filter by category (beer = 3 drinks)
-        // Then filter by availability (removes "Coming Soon IPA" = 2 drinks)
+        // First filter by category (beer = 3 drinks).
+        // The "Coming Soon IPA" has status_text 'not yet available', which
+        // resolves to plenty (word-boundary fallback hits 'available') — it
+        // is NOT filtered out by availableOnly (only AvailabilityStatus.out is).
         final result = service.filterDrinks(
           testDrinks,
           category: 'beer',
           visibilityFilters: {DrinkVisibilityFilter.availableOnly},
         );
-        expect(result, hasLength(2));
+        expect(result, hasLength(3));
       });
 
       test('returns empty list when filters exclude all drinks', () {

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -102,6 +102,9 @@ void main() {
         AvailabilityStatus.out,
       );
 
+      // 'Not yet available' and 'Coming soon' are not in the known festival
+      // vocabulary — they never appear in real data and notYetAvailable was
+      // removed from the enum. Unknown phrases fall back to the default.
       expect(
         Product.fromJson({
           'id': '4',
@@ -111,7 +114,7 @@ void main() {
           'abv': '4',
           'status_text': 'Not yet available',
         }).availabilityStatus,
-        AvailabilityStatus.notYetAvailable,
+        AvailabilityStatus.plenty,
       );
 
       expect(
@@ -123,7 +126,7 @@ void main() {
           'abv': '4',
           'status_text': 'Coming soon',
         }).availabilityStatus,
-        AvailabilityStatus.notYetAvailable,
+        AvailabilityStatus.plenty,
       );
     });
 
@@ -1620,14 +1623,115 @@ void main() {
 
   group('AvailabilityStatus', () {
     test('enum has correct values', () {
-      expect(AvailabilityStatus.values.length, 4);
+      expect(AvailabilityStatus.values.length, 5);
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.plenty));
+      expect(AvailabilityStatus.values, contains(AvailabilityStatus.good));
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.low));
+      expect(AvailabilityStatus.values, contains(AvailabilityStatus.veryLow));
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.out));
-      expect(
-        AvailabilityStatus.values,
-        contains(AvailabilityStatus.notYetAvailable),
-      );
+    });
+
+    group('availabilityStatus — known vocabulary (exact match)', () {
+      Product makeProduct(String statusText) => Product.fromJson({
+        'id': '1',
+        'name': 'a',
+        'category': 'beer',
+        'dispense': 'cask',
+        'abv': '4',
+        'status_text': statusText,
+      });
+
+      test('"Sold Out" → out', () {
+        expect(
+          makeProduct('Sold Out').availabilityStatus,
+          AvailabilityStatus.out,
+        );
+      });
+
+      test('"Nearly finished!" → veryLow', () {
+        expect(
+          makeProduct('Nearly finished!').availabilityStatus,
+          AvailabilityStatus.veryLow,
+        );
+      });
+
+      test('"A little remaining" → low', () {
+        expect(
+          makeProduct('A little remaining').availabilityStatus,
+          AvailabilityStatus.low,
+        );
+      });
+
+      test('"Some beer remaining" → good (was mis-bucketed as low)', () {
+        expect(
+          makeProduct('Some beer remaining').availabilityStatus,
+          AvailabilityStatus.good,
+        );
+      });
+
+      test('"Plenty left" → plenty', () {
+        expect(
+          makeProduct('Plenty left').availabilityStatus,
+          AvailabilityStatus.plenty,
+        );
+      });
+
+      test('"Arrived" → plenty', () {
+        expect(
+          makeProduct('Arrived').availabilityStatus,
+          AvailabilityStatus.plenty,
+        );
+      });
+
+      test('matching is case-insensitive', () {
+        expect(
+          makeProduct('SOLD OUT').availabilityStatus,
+          AvailabilityStatus.out,
+        );
+        expect(
+          makeProduct('some beer remaining').availabilityStatus,
+          AvailabilityStatus.good,
+        );
+      });
+
+      test('matching ignores leading/trailing whitespace', () {
+        expect(
+          makeProduct('  Sold Out  ').availabilityStatus,
+          AvailabilityStatus.out,
+        );
+      });
+    });
+
+    group('availabilityStatus — false-positive guards', () {
+      Product makeProduct(String statusText) => Product.fromJson({
+        'id': '1',
+        'name': 'a',
+        'category': 'beer',
+        'dispense': 'cask',
+        'abv': '4',
+        'status_text': statusText,
+      });
+
+      test('"about" must not map to out (substring false positive)', () {
+        expect(
+          makeProduct('about').availabilityStatus,
+          isNot(AvailabilityStatus.out),
+        );
+      });
+
+      test('"below" must not map to low (substring false positive)', () {
+        expect(
+          makeProduct('below').availabilityStatus,
+          isNot(AvailabilityStatus.low),
+        );
+      });
+
+      test('"allow" must not map to low (substring false positive)', () {
+        expect(
+          makeProduct('allow').availabilityStatus,
+          isNot(AvailabilityStatus.low),
+        );
+      });
     });
   });
 }

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -103,8 +103,8 @@ void main() {
       );
 
       // 'Not yet available' and 'Coming soon' are not in the known festival
-      // vocabulary — they never appear in real data and notYetAvailable was
-      // removed from the enum. Unknown phrases fall back to the default.
+      // vocabulary — unknown phrases map to AvailabilityStatus.unknown so the
+      // raw text can be passed through to the UI.
       expect(
         Product.fromJson({
           'id': '4',
@@ -114,7 +114,7 @@ void main() {
           'abv': '4',
           'status_text': 'Not yet available',
         }).availabilityStatus,
-        AvailabilityStatus.plenty,
+        AvailabilityStatus.unknown,
       );
 
       expect(
@@ -126,7 +126,7 @@ void main() {
           'abv': '4',
           'status_text': 'Coming soon',
         }).availabilityStatus,
-        AvailabilityStatus.plenty,
+        AvailabilityStatus.unknown,
       );
     });
 
@@ -349,54 +349,6 @@ void main() {
     });
 
     group('availability status edge cases', () {
-      test('returns plenty for "arrived" status', () {
-        final product = Product.fromJson({
-          'id': '1',
-          'name': 'a',
-          'category': 'beer',
-          'dispense': 'cask',
-          'abv': '4',
-          'status_text': 'Just arrived',
-        });
-        expect(product.availabilityStatus, AvailabilityStatus.plenty);
-      });
-
-      test('returns plenty for "available" status', () {
-        final product = Product.fromJson({
-          'id': '1',
-          'name': 'a',
-          'category': 'beer',
-          'dispense': 'cask',
-          'abv': '4',
-          'status_text': 'Now available',
-        });
-        expect(product.availabilityStatus, AvailabilityStatus.plenty);
-      });
-
-      test('returns low for "nearly" status', () {
-        final product = Product.fromJson({
-          'id': '1',
-          'name': 'a',
-          'category': 'beer',
-          'dispense': 'cask',
-          'abv': '4',
-          'status_text': 'Nearly gone',
-        });
-        expect(product.availabilityStatus, AvailabilityStatus.low);
-      });
-
-      test('returns low for "low" status', () {
-        final product = Product.fromJson({
-          'id': '1',
-          'name': 'a',
-          'category': 'beer',
-          'dispense': 'cask',
-          'abv': '4',
-          'status_text': 'Running low',
-        });
-        expect(product.availabilityStatus, AvailabilityStatus.low);
-      });
-
       test('returns null for null status_text', () {
         final product = Product.fromJson({
           'id': '1',
@@ -408,16 +360,30 @@ void main() {
         expect(product.availabilityStatus, isNull);
       });
 
-      test('returns plenty for unknown status', () {
-        final product = Product.fromJson({
-          'id': '1',
-          'name': 'a',
-          'category': 'beer',
-          'dispense': 'cask',
-          'abv': '4',
-          'status_text': 'Unknown status',
-        });
-        expect(product.availabilityStatus, AvailabilityStatus.plenty);
+      test('returns unknown for phrases not in vocabulary', () {
+        for (final text in [
+          'Just arrived',
+          'Now available',
+          'Nearly gone',
+          'Running low',
+          'Unknown status',
+          'about',
+          'below',
+          'allow',
+        ]) {
+          expect(
+            Product.fromJson({
+              'id': '1',
+              'name': 'a',
+              'category': 'beer',
+              'dispense': 'cask',
+              'abv': '4',
+              'status_text': text,
+            }).availabilityStatus,
+            AvailabilityStatus.unknown,
+            reason: '"$text" should map to unknown',
+          );
+        }
       });
     });
 
@@ -1623,12 +1589,13 @@ void main() {
 
   group('AvailabilityStatus', () {
     test('enum has correct values', () {
-      expect(AvailabilityStatus.values.length, 5);
+      expect(AvailabilityStatus.values.length, 6);
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.plenty));
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.good));
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.low));
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.veryLow));
       expect(AvailabilityStatus.values, contains(AvailabilityStatus.out));
+      expect(AvailabilityStatus.values, contains(AvailabilityStatus.unknown));
     });
 
     group('availabilityStatus — known vocabulary (exact match)', () {
@@ -1712,24 +1679,27 @@ void main() {
         'status_text': statusText,
       });
 
-      test('"about" must not map to out (substring false positive)', () {
+      // These phrases contain substrings of known vocabulary ('out', 'low')
+      // but are not in the exact-match map — they must map to unknown, not
+      // to the misleading status the old substring cascade would have produced.
+      test('"about" maps to unknown, not out', () {
         expect(
           makeProduct('about').availabilityStatus,
-          isNot(AvailabilityStatus.out),
+          AvailabilityStatus.unknown,
         );
       });
 
-      test('"below" must not map to low (substring false positive)', () {
+      test('"below" maps to unknown, not low', () {
         expect(
           makeProduct('below').availabilityStatus,
-          isNot(AvailabilityStatus.low),
+          AvailabilityStatus.unknown,
         );
       });
 
-      test('"allow" must not map to low (substring false positive)', () {
+      test('"allow" maps to unknown, not low', () {
         expect(
           makeProduct('allow').availabilityStatus,
-          isNot(AvailabilityStatus.low),
+          AvailabilityStatus.unknown,
         );
       });
     });

--- a/test/widgets/availability_badge_test.dart
+++ b/test/widgets/availability_badge_test.dart
@@ -46,11 +46,6 @@ void main() {
         expect(find.byIcon(Icons.check_circle), findsNothing);
       });
 
-      testWidgets('shows Available for notYetAvailable status', (tester) async {
-        await tester.pumpWidget(buildBadge(AvailabilityStatus.notYetAvailable));
-        expect(find.text('Available'), findsOneWidget);
-      });
-
       testWidgets('shows custom text instead of status-based text', (
         tester,
       ) async {


### PR DESCRIPTION
Fixes #348.

`Some beer remaining` — the most common summer status (~32% of drinks) —
was mis-bucketed as `low` because substring matching on `'remaining'`
conflated it with `A little remaining` and `Nearly finished!`.

Replace the ordered `String.contains()` cascade in `availabilityStatus`
with an exact-match map keyed on the bounded, real-data vocabulary, plus
a word-boundary fallback for novel phrases (avoids false positives like
`about`→`out`, `allow`/`below`→`low`).

Widen the enum from four values to five:
- Add `good` (Some beer remaining)
- Add `veryLow` (Nearly finished!)
- Remove dead `notYetAvailable` (never fired on any real festival data)

Update switch statements in `_AvailabilityChip` and semantics helper,
remove dead `notYetAvailable` guard in `DrinkFilterService`, and update
all tests that asserted the old mis-classification or the dead enum value.