### PR TITLE
fix(provider): refresh _currentFestival from live registry on background reload

### DIFF
--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -329,9 +329,23 @@ class BeerProvider extends ChangeNotifier {
       final response = await _festivalRepository!.getFestivals();
       _festivals = response.festivals;
 
-      // Set default festival if not already set
-      if (_currentFestival == null && response.defaultFestival != null) {
+      if (_currentFestival == null) {
         _currentFestival = response.defaultFestival;
+      } else {
+        // Refresh the current festival reference with data from the new registry
+        // so all fields (name, hours, charityPartnerName, etc.) stay current.
+        // Only re-trigger loadDrinks when the types to fetch have changed.
+        final fresh = response.festivals
+            .where((f) => f.id == _currentFestival!.id)
+            .firstOrNull;
+        if (fresh != null) {
+          final oldTypes = _currentFestival!.availableBeverageTypes.toSet();
+          final newTypes = fresh.availableBeverageTypes.toSet();
+          final typesChanged = oldTypes.length != newTypes.length ||
+              !oldTypes.containsAll(newTypes);
+          _currentFestival = fresh;
+          if (typesChanged) unawaited(loadDrinks());
+        }
       }
 
       _festivalsError = null;

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -81,6 +81,18 @@ List<Drink> createSampleDrinks() {
   ];
 }
 
+Festival createSampleFestival({
+  String id = 'cbf2025',
+  String name = 'Cambridge Beer Festival 2025',
+  List<String> availableBeverageTypes = const ['beer'],
+}) =>
+    Festival(
+      id: id,
+      name: name,
+      dataBaseUrl: 'https://data.cambeerfestival.app',
+      availableBeverageTypes: availableBeverageTypes,
+    );
+
 void main() {
   group('BeerProvider', () {
     late MockDrinkRepository mockDrinkRepository;
@@ -1507,6 +1519,140 @@ void main() {
         await provider.initialize();
 
         expect(provider.currentFestival.id, 'cbf2025');
+      });
+    });
+
+    group('loadFestivals background refresh', () {
+      FestivalsResponse festivalsResponseFor(List<Festival> festivals) =>
+          FestivalsResponse(
+            festivals: festivals,
+            defaultFestivalId: festivals.first.id,
+            baseUrl: 'https://data.cambeerfestival.app',
+            version: '1.0',
+          );
+
+      test('refreshes _currentFestival reference even when already set',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => festivalsResponseFor(
+            [createSampleFestival(name: 'Old Name')],
+          ),
+        );
+        await provider.initialize();
+        expect(provider.currentFestival.name, 'Old Name');
+
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => festivalsResponseFor(
+            [createSampleFestival(name: 'New Name')],
+          ),
+        );
+        await provider.loadFestivals();
+
+        expect(provider.currentFestival.name, 'New Name');
+        verifyNever(mockDrinkRepository.getDrinks(any));
+      });
+
+      test('triggers loadDrinks when availableBeverageTypes expand', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => festivalsResponseFor(
+            [
+              createSampleFestival(availableBeverageTypes: ['beer'])
+            ],
+          ),
+        );
+        await provider.initialize();
+
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => festivalsResponseFor(
+            [
+              createSampleFestival(
+                availableBeverageTypes: ['beer', 'cider'],
+              ),
+            ],
+          ),
+        );
+        await provider.loadFestivals();
+        // Drain the event queue so the unawaited loadDrinks() call completes.
+        await Future.delayed(Duration.zero);
+
+        verify(mockDrinkRepository.getDrinks(any)).called(1);
+      });
+
+      test(
+          'does not trigger loadDrinks when availableBeverageTypes are the same',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => festivalsResponseFor(
+            [
+              createSampleFestival(
+                availableBeverageTypes: ['beer', 'cider'],
+              ),
+            ],
+          ),
+        );
+        await provider.initialize();
+
+        // Same types, different order — must not re-trigger.
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => festivalsResponseFor(
+            [
+              createSampleFestival(
+                name: 'Updated Name',
+                availableBeverageTypes: ['cider', 'beer'],
+              ),
+            ],
+          ),
+        );
+        await provider.loadFestivals();
+        await Future.delayed(Duration.zero);
+
+        verifyNever(mockDrinkRepository.getDrinks(any));
+      });
+
+      test(
+          'leaves _currentFestival unchanged when its id is absent from fresh registry',
+          () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async =>
+              festivalsResponseFor([createSampleFestival(id: 'cbf2025')]),
+        );
+        await provider.initialize();
+        expect(provider.currentFestival.id, 'cbf2025');
+
+        // Fresh registry no longer includes cbf2025.
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => festivalsResponseFor(
+            [createSampleFestival(id: 'cbf2024')],
+          ),
+        );
+        await provider.loadFestivals();
+
+        expect(provider.currentFestival.id, 'cbf2025');
+        verifyNever(mockDrinkRepository.getDrinks(any));
       });
     });
 


### PR DESCRIPTION
When the app launches with cached festival data, initialize() fires
loadFestivals() in the background. Previously, loadFestivals() only set
_currentFestival when it was null, so the stale cached Festival object was
used for the entire session — silently missing any new beverage types added
server-side (e.g. cider appearing mid-festival).

Fix: in the loadFestivals() success branch, always replace _currentFestival
with the fresh object for the same ID so all fields (name, hours,
charityPartnerName, etc.) stay current. Re-trigger loadDrinks() only when
availableBeverageTypes changes, since that's the field that controls which
drink endpoints are fetched.

Fixes #306