### PR TITLE
fix(provider): refresh current festival reference on registry update

### DIFF
--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -290,9 +290,32 @@ class BeerProvider extends ChangeNotifier {
       final response = await _festivalRepository!.getFestivals();
       _festivals = response.festivals;
 
-      // Set default festival if not already set
-      if (_currentFestival == null && response.defaultFestival != null) {
-        _currentFestival = response.defaultFestival;
+      if (_currentFestival == null) {
+        // Set default festival if not already set.
+        if (response.defaultFestival != null) {
+          _currentFestival = response.defaultFestival;
+        }
+      } else {
+        // A festival is already selected (typically from the cached registry).
+        // The fresh registry may carry an updated copy of that same festival —
+        // e.g. a beverage type added server-side. Re-point _currentFestival at
+        // the fresh object so its metadata is current, and re-fetch drinks if
+        // the set of beverage types actually changed. Without this, an
+        // in-flight loadDrinks captured against the stale object would silently
+        // never load the newly-added type this session (see #306).
+        final refreshed = _festivals
+            .where((f) => f.id == _currentFestival!.id)
+            .firstOrNull;
+        if (refreshed != null) {
+          final beverageTypesChanged = !_sameBeverageTypes(
+            _currentFestival!.availableBeverageTypes,
+            refreshed.availableBeverageTypes,
+          );
+          _currentFestival = refreshed;
+          if (beverageTypesChanged) {
+            unawaited(loadDrinks());
+          }
+        }
       }
 
       _festivalsError = null;
@@ -316,6 +339,14 @@ class BeerProvider extends ChangeNotifier {
       _isFestivalsLoading = false;
       notifyListeners();
     }
+  }
+
+  /// Compares two beverage-type lists as unordered sets, so a harmless
+  /// reordering in the registry doesn't trigger a needless drinks refetch.
+  static bool _sameBeverageTypes(List<String> a, List<String> b) {
+    final setA = a.toSet();
+    final setB = b.toSet();
+    return setA.length == setB.length && setA.containsAll(setB);
   }
 
   /// Load drinks for the current festival.

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -1389,6 +1389,123 @@ void main() {
       });
     });
 
+    group('registry refresh updates current festival (#306)', () {
+      Festival festivalWith(String id, List<String> types) => Festival(
+        id: id,
+        name: 'CBF 2026',
+        dataBaseUrl: 'https://example.com/$id',
+        availableBeverageTypes: types,
+      );
+
+      void stubRegistry(Festival festival) {
+        when(mockFestivalRepository.getFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: [festival],
+            defaultFestivalId: festival.id,
+            baseUrl: 'https://example.com',
+            version: '1.0.0',
+          ),
+        );
+      }
+
+      test('refreshes current festival reference and refetches drinks when '
+          'beverage types change', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+
+        stubRegistry(festivalWith('cbf2026', const ['beer']));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
+
+        await provider.initialize();
+        await provider.loadDrinks();
+        expect(provider.currentFestival.availableBeverageTypes, ['beer']);
+
+        // The live registry now advertises an extra beverage type for the
+        // same festival id.
+        stubRegistry(festivalWith('cbf2026', const ['beer', 'cider']));
+        clearInteractions(mockDrinkRepository);
+
+        await provider.loadFestivals();
+        await pumpEventQueue();
+
+        // Reference is repointed at the fresh festival...
+        expect(
+          provider.currentFestival.availableBeverageTypes,
+          containsAll(<String>['beer', 'cider']),
+        );
+        // ...and drinks were refetched against the updated festival, so the
+        // newly-added type is actually loaded this session.
+        final captured = verify(
+          mockDrinkRepository.getDrinks(captureAny),
+        ).captured.cast<Festival>();
+        expect(captured.last.availableBeverageTypes, contains('cider'));
+      });
+
+      test(
+        'does not refetch drinks when beverage types are unchanged',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+
+          stubRegistry(festivalWith('cbf2026', const ['beer', 'cider']));
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+
+          await provider.initialize();
+          await provider.loadDrinks();
+
+          // Registry refresh returns the same beverage types with the order
+          // swapped, proving the comparison is set-based not order-sensitive.
+          stubRegistry(festivalWith('cbf2026', const ['cider', 'beer']));
+          clearInteractions(mockDrinkRepository);
+
+          await provider.loadFestivals();
+          await pumpEventQueue();
+
+          verifyNever(mockDrinkRepository.getDrinks(any));
+        },
+      );
+
+      test('ignores registry updates for an unrelated festival id', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+
+        stubRegistry(festivalWith('cbf2026', const ['beer']));
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
+
+        await provider.initialize();
+        await provider.loadDrinks();
+        expect(provider.currentFestival.id, 'cbf2026');
+
+        // The registry no longer lists the selected festival; a different one
+        // appears in its place.
+        stubRegistry(festivalWith('cbfw2026', const ['beer', 'cider']));
+        clearInteractions(mockDrinkRepository);
+
+        await provider.loadFestivals();
+        await pumpEventQueue();
+
+        // Selection is left untouched and no refetch is triggered.
+        expect(provider.currentFestival.id, 'cbf2026');
+        expect(provider.currentFestival.availableBeverageTypes, ['beer']);
+        verifyNever(mockDrinkRepository.getDrinks(any));
+      });
+    });
+
     group('combined filters', () {
       test('applies category and style filters together', () async {
         provider = BeerProvider(

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -81,6 +81,18 @@ List<Drink> createSampleDrinks() {
   ];
 }
 
+/// Test-data factory for a [Festival] with sensible defaults.
+Festival createSampleFestival({
+  String id = 'cbf2025',
+  String name = 'Cambridge Beer Festival 2025',
+  List<String> availableBeverageTypes = const ['beer'],
+}) => Festival(
+  id: id,
+  name: name,
+  dataBaseUrl: 'https://data.cambeerfestival.app/$id',
+  availableBeverageTypes: availableBeverageTypes,
+);
+
 void main() {
   group('BeerProvider', () {
     late MockDrinkRepository mockDrinkRepository;
@@ -1390,13 +1402,6 @@ void main() {
     });
 
     group('registry refresh updates current festival (#306)', () {
-      Festival festivalWith(String id, List<String> types) => Festival(
-        id: id,
-        name: 'CBF 2026',
-        dataBaseUrl: 'https://example.com/$id',
-        availableBeverageTypes: types,
-      );
-
       void stubRegistry(Festival festival) {
         when(mockFestivalRepository.getFestivals()).thenAnswer(
           (_) async => FestivalsResponse(
@@ -1408,43 +1413,82 @@ void main() {
         );
       }
 
-      test('refreshes current festival reference and refetches drinks when '
-          'beverage types change', () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
+      test(
+        'refreshes current festival metadata even when the id is unchanged',
+        () async {
+          // A non-beverage field (name) changing in the registry should be
+          // reflected, but it must not trigger a needless drinks refetch.
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
 
-        stubRegistry(festivalWith('cbf2026', const ['beer']));
-        when(
-          mockDrinkRepository.getDrinks(any),
-        ).thenAnswer((_) async => createSampleDrinks());
+          stubRegistry(createSampleFestival(name: 'Old Name'));
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
 
-        await provider.initialize();
-        await provider.loadDrinks();
-        expect(provider.currentFestival.availableBeverageTypes, ['beer']);
+          await provider.initialize();
+          await provider.loadDrinks();
+          expect(provider.currentFestival.name, 'Old Name');
 
-        // The live registry now advertises an extra beverage type for the
-        // same festival id.
-        stubRegistry(festivalWith('cbf2026', const ['beer', 'cider']));
-        clearInteractions(mockDrinkRepository);
+          stubRegistry(createSampleFestival(name: 'New Name'));
+          clearInteractions(mockDrinkRepository);
 
-        await provider.loadFestivals();
-        await pumpEventQueue();
+          await provider.loadFestivals();
+          await pumpEventQueue();
 
-        // Reference is repointed at the fresh festival...
-        expect(
-          provider.currentFestival.availableBeverageTypes,
-          containsAll(<String>['beer', 'cider']),
-        );
-        // ...and drinks were refetched against the updated festival, so the
-        // newly-added type is actually loaded this session.
-        final captured = verify(
-          mockDrinkRepository.getDrinks(captureAny),
-        ).captured.cast<Festival>();
-        expect(captured.last.availableBeverageTypes, contains('cider'));
-      });
+          expect(provider.currentFestival.name, 'New Name');
+          verifyNever(mockDrinkRepository.getDrinks(any));
+        },
+      );
+
+      test(
+        'refreshes reference and refetches drinks when beverage types change',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+
+          stubRegistry(
+            createSampleFestival(availableBeverageTypes: const ['beer']),
+          );
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+
+          await provider.initialize();
+          await provider.loadDrinks();
+          expect(provider.currentFestival.availableBeverageTypes, ['beer']);
+
+          // The live registry now advertises an extra beverage type for the
+          // same festival id.
+          stubRegistry(
+            createSampleFestival(
+              availableBeverageTypes: const ['beer', 'cider'],
+            ),
+          );
+          clearInteractions(mockDrinkRepository);
+
+          await provider.loadFestivals();
+          await pumpEventQueue();
+
+          // Reference is repointed at the fresh festival...
+          expect(
+            provider.currentFestival.availableBeverageTypes,
+            containsAll(<String>['beer', 'cider']),
+          );
+          // ...and drinks were refetched against the updated festival, so the
+          // newly-added type is actually loaded this session.
+          final captured = verify(
+            mockDrinkRepository.getDrinks(captureAny),
+          ).captured.cast<Festival>();
+          expect(captured.last.availableBeverageTypes, contains('cider'));
+        },
+      );
 
       test(
         'does not refetch drinks when beverage types are unchanged',
@@ -1455,7 +1499,11 @@ void main() {
             analyticsService: mockAnalyticsService,
           );
 
-          stubRegistry(festivalWith('cbf2026', const ['beer', 'cider']));
+          stubRegistry(
+            createSampleFestival(
+              availableBeverageTypes: const ['beer', 'cider'],
+            ),
+          );
           when(
             mockDrinkRepository.getDrinks(any),
           ).thenAnswer((_) async => createSampleDrinks());
@@ -1465,7 +1513,11 @@ void main() {
 
           // Registry refresh returns the same beverage types with the order
           // swapped, proving the comparison is set-based not order-sensitive.
-          stubRegistry(festivalWith('cbf2026', const ['cider', 'beer']));
+          stubRegistry(
+            createSampleFestival(
+              availableBeverageTypes: const ['cider', 'beer'],
+            ),
+          );
           clearInteractions(mockDrinkRepository);
 
           await provider.loadFestivals();
@@ -1482,25 +1534,30 @@ void main() {
           analyticsService: mockAnalyticsService,
         );
 
-        stubRegistry(festivalWith('cbf2026', const ['beer']));
+        stubRegistry(createSampleFestival(id: 'cbf2025'));
         when(
           mockDrinkRepository.getDrinks(any),
         ).thenAnswer((_) async => createSampleDrinks());
 
         await provider.initialize();
         await provider.loadDrinks();
-        expect(provider.currentFestival.id, 'cbf2026');
+        expect(provider.currentFestival.id, 'cbf2025');
 
         // The registry no longer lists the selected festival; a different one
         // appears in its place.
-        stubRegistry(festivalWith('cbfw2026', const ['beer', 'cider']));
+        stubRegistry(
+          createSampleFestival(
+            id: 'cbf2024',
+            availableBeverageTypes: const ['beer', 'cider'],
+          ),
+        );
         clearInteractions(mockDrinkRepository);
 
         await provider.loadFestivals();
         await pumpEventQueue();
 
         // Selection is left untouched and no refetch is triggered.
-        expect(provider.currentFestival.id, 'cbf2026');
+        expect(provider.currentFestival.id, 'cbf2025');
         expect(provider.currentFestival.availableBeverageTypes, ['beer']);
         verifyNever(mockDrinkRepository.getDrinks(any));
       });


### PR DESCRIPTION
## Summary

Fixes #306.

When the app launches with a cached registry, `initialize()` seeds `_currentFestival` from the cache and fires `loadFestivals()` in the background. The success branch previously only assigned `_currentFestival` **when it was null**, so the stale cached `Festival` object stayed referenced for the whole session. If the live registry returned the same festival id with updated `availableBeverageTypes` (e.g. `cider` added server-side), the in-flight `loadDrinks` — which captured the old object — never fetched the new type.

### Fix

In the `loadFestivals()` success branch, when a festival is already selected:
- Re-point `_currentFestival` at the fresh object for the same id, so all metadata (name, hours, charity fields, etc.) stays current.
- Re-trigger `loadDrinks()` **only when** the set of `availableBeverageTypes` actually changed — the field that controls which drink endpoints are fetched. The comparison is unordered (set-based) to avoid needless refetches on harmless reordering, and the existing `_drinksLoadToken` cleanly supersedes the stale in-flight load.

The original `null`-guarded default assignment is preserved, so the no-selection path is unchanged.

### Why not a shallow fix

Just re-pointing the reference is insufficient: `_refreshDrinksFromNetwork(token, festival)` already captured the old `festival`, and `BeerApiService` iterates *that* object's `availableBeverageTypes`. The fix must also re-trigger the drinks load so the newly-added type is actually fetched.

## Tests

New `registry refresh updates current festival (#306)` group in `test/beer_provider_test.dart`:
1. Metadata (`name`) refreshes from the live registry without a needless refetch.
2. Reference refreshes **and** drinks refetch when beverage types change (verified by capturing the festival passed to `getDrinks` and asserting it carries the new type).
3. No refetch when beverage types are unchanged (order swapped, proving set-based comparison).
4. Unrelated festival id leaves the current selection untouched and triggers no refetch.

Verified red→green: the beverage-types-change case fails without the fix and passes with it. Adds a top-level `createSampleFestival()` factory following the `createSample{Model}()` convention.

`./bin/mise run check` passes — 862 tests green; the only analyzer infos are pre-existing and in an unrelated file.

## Note

This supersedes the parallel PR #361, which fixes the same issue. This branch keeps the stronger half of each: the null-guarded default assignment + documented `_sameBeverageTypes` helper from here, and the `createSampleFestival()` factory + metadata-refresh test case from #361. One of the two should be closed.

## Outstanding

- Manual verification on a real device/browser during a live registry update (cannot be performed by an agent).

https://claude.ai/code/session_01Psi8iZ9VhGhASqBNnNJB3W

---
_Generated by [Claude Code](https://claude.ai/code/session_01Psi8iZ9VhGhASqBNnNJB3W)_