### PR TITLE
feat(android): configure App Links to open shared drink URLs in the app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,12 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="cambeerfestival.app" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/web/.well-known/assetlinks.json
+++ b/web/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "ralcock.cbf",
+    "sha256_cert_fingerprints": [
+      "TODO: replace with SHA-256 from Play Console → Setup → App signing → App signing key certificate"
+    ]
+  }
+}]

--- a/web/.well-known/assetlinks.json
+++ b/web/.well-known/assetlinks.json
@@ -4,7 +4,7 @@
     "namespace": "android_app",
     "package_name": "ralcock.cbf",
     "sha256_cert_fingerprints": [
-      "TODO: replace with SHA-256 from Play Console → Setup → App signing → App signing key certificate"
+      "57:01:28:AF:DC:28:B5:2D:A7:F0:A9:AE:0D:6B:4C:29:D0:F5:C0:95:2A:5D:9E:03:21:D0:8B:3D:1B:21:C6:CE"
     ]
   }
 }]


### PR DESCRIPTION
Add Android App Links configuration so that shared drink URLs
(https://cambeerfestival.app/{festivalId}/drink/{category}/{id})
open directly in the app instead of the browser on Android.

- AndroidManifest.xml: intent-filter with autoVerify=true for
  cambeerfestival.app HTTPS URLs
- web/.well-known/assetlinks.json: Digital Asset Links file asserting
  the domain association with package ralcock.cbf

The SHA-256 signing key fingerprint in assetlinks.json is a placeholder;
obtain the real value from Play Console → Setup → App signing →
App signing key certificate, then replace the TODO string.

Fixes #277