### PR TITLE
fix(models): make Drink user-state fields immutable with copyWith

### DIFF
--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -87,10 +87,13 @@ class ApiDrinkRepository implements DrinkRepository {
   /// Populate favorite status, ratings, and tasted status in a single pass.
   void _applyUserState(List<Drink> drinks, String festivalId) {
     final favorites = _favoritesService.getFavorites(festivalId);
-    for (final drink in drinks) {
-      drink.isFavorite = favorites.contains(drink.id);
-      drink.rating = _ratingsService.getRating(festivalId, drink.id);
-      drink.isTasted = _tastingLogService.hasTasted(festivalId, drink.id);
+    for (var i = 0; i < drinks.length; i++) {
+      final drink = drinks[i];
+      drinks[i] = drink.copyWith(
+        isFavorite: favorites.contains(drink.id),
+        rating: _ratingsService.getRating(festivalId, drink.id),
+        isTasted: _tastingLogService.hasTasted(festivalId, drink.id),
+      );
     }
   }
 

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -223,9 +223,11 @@ class Drink {
   final Product product;
   final Producer producer;
   final String festivalId;
-  bool isFavorite;
-  int? rating;
-  bool isTasted;
+  final bool isFavorite;
+  final int? rating;
+  final bool isTasted;
+
+  static const _absent = Object();
 
   Drink({
     required this.product,
@@ -235,6 +237,17 @@ class Drink {
     this.rating,
     this.isTasted = false,
   });
+
+  Drink copyWith({bool? isFavorite, Object? rating = _absent, bool? isTasted}) {
+    return Drink(
+      product: product,
+      producer: producer,
+      festivalId: festivalId,
+      isFavorite: isFavorite ?? this.isFavorite,
+      rating: identical(rating, _absent) ? this.rating : rating as int?,
+      isTasted: isTasted ?? this.isTasted,
+    );
+  }
 
   String get id => product.id;
   String get name => product.name;

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -680,6 +680,18 @@ class BeerProvider extends ChangeNotifier {
     await prefs.setInt(PreferenceKeys.themeMode, mode.index);
   }
 
+  /// Replace a drink in [_allDrinks] with [updated] and recompute filters.
+  ///
+  /// Returns [updated] for convenience.
+  Drink _replaceDrink(Drink old, Drink updated) {
+    final idx = _allDrinks.indexOf(old);
+    if (idx != -1) {
+      _allDrinks[idx] = updated;
+    }
+    _filter.recompute();
+    return updated;
+  }
+
   /// Toggle favorite status for a drink
   Future<void> toggleFavorite(Drink drink) async {
     if (_drinkRepository == null) return;
@@ -688,11 +700,7 @@ class BeerProvider extends ChangeNotifier {
       currentFestival.id,
       drink.id,
     );
-    drink.isFavorite = newStatus;
-
-    if (_filter.showFavoritesOnly) {
-      _filter.recompute();
-    }
+    _replaceDrink(drink, drink.copyWith(isFavorite: newStatus));
 
     notifyListeners();
 
@@ -710,13 +718,12 @@ class BeerProvider extends ChangeNotifier {
 
     if (rating == null) {
       await _drinkRepository!.removeRating(currentFestival.id, drink.id);
-      drink.rating = null;
     } else {
       await _drinkRepository!.setRating(currentFestival.id, drink.id, rating);
-      drink.rating = rating;
       // Log analytics event for rating (fire and forget)
       unawaited(_analyticsService.logRatingGiven(drink, rating));
     }
+    _replaceDrink(drink, drink.copyWith(rating: rating));
     notifyListeners();
   }
 
@@ -728,13 +735,7 @@ class BeerProvider extends ChangeNotifier {
       currentFestival.id,
       drink.id,
     );
-    drink.isTasted = newStatus;
-
-    // Re-filter so the drink appears/disappears immediately when the
-    // not-tasted visibility filter is active.
-    if (_filter.visibilityFilters.contains(DrinkVisibilityFilter.notTasted)) {
-      _filter.recompute();
-    }
+    _replaceDrink(drink, drink.copyWith(isTasted: newStatus));
 
     notifyListeners();
 

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -684,7 +684,9 @@ class BeerProvider extends ChangeNotifier {
   ///
   /// Returns [updated] for convenience.
   Drink _replaceDrink(Drink old, Drink updated) {
-    final idx = _allDrinks.indexOf(old);
+    final idx = _allDrinks.indexWhere(
+      (d) => d.id == old.id && d.festivalId == old.festivalId,
+    );
     if (idx != -1) {
       _allDrinks[idx] = updated;
     }

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -1034,7 +1034,7 @@ void main() {
         await provider.initialize();
 
         final sampleDrinks = createSampleDrinks();
-        sampleDrinks[0].isTasted = true;
+        sampleDrinks[0] = sampleDrinks[0].copyWith(isTasted: true);
         when(
           mockDrinkRepository.getDrinks(any),
         ).thenAnswer((_) async => sampleDrinks);
@@ -2337,15 +2337,16 @@ void main() {
           mockDrinkRepository.toggleTasted(any, any),
         ).thenAnswer((_) async => true);
         await provider.toggleTasted(drink);
-        expect(drink.isTasted, isTrue);
+        expect(provider.getDrinkById(drink.id)!.isTasted, isTrue);
         verify(mockAnalyticsService.logTastedAdded(drink)).called(1);
 
         when(
           mockDrinkRepository.toggleTasted(any, any),
         ).thenAnswer((_) async => false);
-        await provider.toggleTasted(drink);
-        expect(drink.isTasted, isFalse);
-        verify(mockAnalyticsService.logTastedRemoved(drink)).called(1);
+        final drink2 = provider.getDrinkById(drink.id)!;
+        await provider.toggleTasted(drink2);
+        expect(provider.getDrinkById(drink.id)!.isTasted, isFalse);
+        verify(mockAnalyticsService.logTastedRemoved(drink2)).called(1);
       });
 
       test(
@@ -2502,8 +2503,8 @@ void main() {
           ).thenAnswer((_) async => true);
           await provider.toggleFavorite(drink);
 
-          // The favourites-only list is refreshed in place by toggleFavorite.
-          expect(provider.drinks, contains(drink));
+          // The favourites-only list is refreshed by toggleFavorite.
+          expect(provider.drinks.any((d) => d.id == drink.id), isTrue);
         },
       );
 

--- a/test/brewery_screen_test.dart
+++ b/test/brewery_screen_test.dart
@@ -200,7 +200,7 @@ void main() {
       await tester.pumpWidget(createTestWidget('brewery1'));
       await tester.pumpAndSettle();
 
-      expect(drink1.isFavorite, false);
+      expect(provider.getDrinkById(drink1.id)!.isFavorite, false);
 
       // Mock toggleFavorite to properly toggle state
       final favorites = <String>{};
@@ -225,7 +225,7 @@ void main() {
       await tester.tap(favoriteButton);
       await tester.pumpAndSettle();
 
-      expect(drink1.isFavorite, true);
+      expect(provider.getDrinkById(drink1.id)!.isFavorite, true);
     });
 
     testWidgets('displays correct count of drinks', (

--- a/test/domain/controllers/drink_filter_controller_test.dart
+++ b/test/domain/controllers/drink_filter_controller_test.dart
@@ -181,7 +181,7 @@ void main() {
     group('favorites filter', () {
       test('shows only favourites when enabled', () {
         final drinks = _sampleDrinks();
-        drinks[0].isFavorite = true;
+        drinks[0] = drinks[0].copyWith(isFavorite: true);
         controller.setSource(drinks);
 
         controller.setShowFavoritesOnly(true);
@@ -221,7 +221,7 @@ void main() {
 
       test('notTasted filter hides tasted drinks', () {
         final drinks = _sampleDrinks();
-        drinks[0].isTasted = true;
+        drinks[0] = drinks[0].copyWith(isTasted: true);
         controller.setSource(drinks);
         controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
         expect(
@@ -327,18 +327,21 @@ void main() {
     });
 
     group('recompute', () {
-      test('reflects in-place favourite mutation when favourites-only', () {
-        final drinks = _sampleDrinks();
-        controller.setSource(drinks);
-        controller.setShowFavoritesOnly(true);
-        expect(controller.filteredDrinks, isEmpty);
+      test(
+        'reflects favourite change via list replacement when favourites-only',
+        () {
+          final drinks = _sampleDrinks();
+          controller.setSource(drinks);
+          controller.setShowFavoritesOnly(true);
+          expect(controller.filteredDrinks, isEmpty);
 
-        // Simulate BeerProvider mutating the drink in place, then asking the
-        // controller to re-run the pipeline.
-        drinks[1].isFavorite = true;
-        controller.recompute();
-        expect(controller.filteredDrinks.map((d) => d.name), ['Beta Bitter']);
-      });
+          // Simulate BeerProvider replacing a list element via copyWith, then
+          // asking the controller to re-run the pipeline.
+          drinks[1] = drinks[1].copyWith(isFavorite: true);
+          controller.setSource(drinks);
+          expect(controller.filteredDrinks.map((d) => d.name), ['Beta Bitter']);
+        },
+      );
     });
 
     group('clearCategoryStyleSearch', () {

--- a/test/domain/services/drink_filter_service_test.dart
+++ b/test/domain/services/drink_filter_service_test.dart
@@ -137,8 +137,8 @@ void main() {
 
     group('filterByFavorites', () {
       test('filters to show only favorites', () {
-        testDrinks[0].isFavorite = true;
-        testDrinks[2].isFavorite = true;
+        testDrinks[0] = testDrinks[0].copyWith(isFavorite: true);
+        testDrinks[2] = testDrinks[2].copyWith(isFavorite: true);
 
         final result = service.filterByFavorites(testDrinks, true).toList();
         expect(result, hasLength(2));
@@ -146,7 +146,7 @@ void main() {
       });
 
       test('returns all drinks when favoritesOnly is false', () {
-        testDrinks[0].isFavorite = true;
+        testDrinks[0] = testDrinks[0].copyWith(isFavorite: true);
 
         final result = service.filterByFavorites(testDrinks, false).toList();
         expect(result, hasLength(5));
@@ -190,8 +190,8 @@ void main() {
 
     group('filterByNotTasted', () {
       test('hides drinks already tasted', () {
-        testDrinks[0].isTasted = true;
-        testDrinks[1].isTasted = true;
+        testDrinks[0] = testDrinks[0].copyWith(isTasted: true);
+        testDrinks[1] = testDrinks[1].copyWith(isTasted: true);
 
         final result = service.filterByNotTasted(testDrinks, true).toList();
         expect(result, hasLength(3));
@@ -199,7 +199,7 @@ void main() {
       });
 
       test('returns all drinks when notTastedOnly is false', () {
-        testDrinks[0].isTasted = true;
+        testDrinks[0] = testDrinks[0].copyWith(isTasted: true);
 
         final result = service.filterByNotTasted(testDrinks, false).toList();
         expect(result, hasLength(5));
@@ -390,7 +390,7 @@ void main() {
 
     group('filterDrinks', () {
       test('applies all filters in combination', () {
-        testDrinks[0].isFavorite = true; // Hoppy IPA
+        testDrinks[0] = testDrinks[0].copyWith(isFavorite: true); // Hoppy IPA
 
         final result = service.filterDrinks(
           testDrinks,

--- a/test/drink_card_test.dart
+++ b/test/drink_card_test.dart
@@ -115,7 +115,7 @@ void main() {
     testWidgets('shows favorite icon as outlined when not favorite', (
       WidgetTester tester,
     ) async {
-      testDrink.isFavorite = false;
+      testDrink = testDrink.copyWith(isFavorite: false);
       await tester.pumpWidget(createTestWidget(drink: testDrink));
 
       expect(find.byIcon(Icons.favorite_border), findsOneWidget);
@@ -125,7 +125,7 @@ void main() {
     testWidgets('shows favorite icon as filled when favorite', (
       WidgetTester tester,
     ) async {
-      testDrink.isFavorite = true;
+      testDrink = testDrink.copyWith(isFavorite: true);
       await tester.pumpWidget(createTestWidget(drink: testDrink));
 
       expect(find.byIcon(Icons.favorite), findsOneWidget);

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -312,7 +312,7 @@ void main() {
       await tester.pumpWidget(createTestWidget('drink1'));
       await tester.pumpAndSettle();
 
-      expect(drink.isFavorite, false);
+      expect(provider.getDrinkById('drink1')!.isFavorite, false);
       expect(find.byIcon(Icons.favorite_border), findsOneWidget);
 
       // Mock toggleFavorite to properly toggle state
@@ -334,7 +334,7 @@ void main() {
       await tester.tap(find.byIcon(Icons.favorite_border));
       await tester.pumpAndSettle();
 
-      expect(drink.isFavorite, true);
+      expect(provider.getDrinkById('drink1')!.isFavorite, true);
       expect(find.byIcon(Icons.favorite), findsOneWidget);
     });
 
@@ -410,10 +410,11 @@ void main() {
     testWidgets('displays rating value when drink has rating', (
       WidgetTester tester,
     ) async {
-      when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
+      final ratedDrink = drink.copyWith(rating: 4);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [ratedDrink]);
       await provider.loadDrinks();
-
-      drink.rating = 4;
 
       await tester.pumpWidget(createTestWidget('drink1'));
       await tester.pumpAndSettle();
@@ -426,8 +427,6 @@ void main() {
     ) async {
       when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => [drink]);
       await provider.loadDrinks();
-
-      drink.rating = null;
 
       await tester.pumpWidget(createTestWidget('drink1'));
       await tester.pumpAndSettle();
@@ -444,13 +443,16 @@ void main() {
       await tester.pumpWidget(createTestWidget('drink1'));
       await tester.pumpAndSettle();
 
-      expect(drink.rating, null);
+      expect(provider.getDrinkById('drink1')!.rating, null);
 
       // Simulate rating change through provider
-      provider.setRating(drink, 5);
+      when(
+        mockDrinkRepository.setRating(any, any, any),
+      ).thenAnswer((_) async {});
+      provider.setRating(provider.getDrinkById('drink1')!, 5);
       await tester.pumpAndSettle();
 
-      expect(drink.rating, 5);
+      expect(provider.getDrinkById('drink1')!.rating, 5);
       expect(find.text('5/5'), findsOneWidget);
     });
 

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -449,7 +449,7 @@ void main() {
       when(
         mockDrinkRepository.setRating(any, any, any),
       ).thenAnswer((_) async {});
-      provider.setRating(provider.getDrinkById('drink1')!, 5);
+      await provider.setRating(provider.getDrinkById('drink1')!, 5);
       await tester.pumpAndSettle();
 
       expect(provider.getDrinkById('drink1')!.rating, 5);

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -905,7 +905,7 @@ void main() {
       expect(drink.rating, isNull);
     });
 
-    test('can set isFavorite', () {
+    test('copyWith changes isFavorite', () {
       final drink = Drink(
         product: testProduct,
         producer: testProducer,
@@ -913,13 +913,13 @@ void main() {
         isFavorite: true,
       );
 
+      final updated = drink.copyWith(isFavorite: false);
+      expect(updated.isFavorite, isFalse);
+      // Original is unchanged
       expect(drink.isFavorite, isTrue);
-
-      drink.isFavorite = false;
-      expect(drink.isFavorite, isFalse);
     });
 
-    test('can set rating', () {
+    test('copyWith changes rating', () {
       final drink = Drink(
         product: testProduct,
         producer: testProducer,
@@ -927,10 +927,14 @@ void main() {
         rating: 4,
       );
 
+      final updated = drink.copyWith(rating: 5);
+      expect(updated.rating, 5);
+      // Original is unchanged
       expect(drink.rating, 4);
 
-      drink.rating = 5;
-      expect(drink.rating, 5);
+      // Clearing the rating to null
+      final cleared = drink.copyWith(rating: null);
+      expect(cleared.rating, isNull);
     });
 
     group('getShareMessage', () {

--- a/test/style_screen_test.dart
+++ b/test/style_screen_test.dart
@@ -219,7 +219,7 @@ void main() {
       await tester.pumpWidget(createTestWidget('IPA'));
       await tester.pumpAndSettle();
 
-      expect(drink1.isFavorite, false);
+      expect(provider.getDrinkById(drink1.id)!.isFavorite, false);
 
       // Mock toggleFavorite to properly toggle state
       final favorites = <String>{};
@@ -244,7 +244,7 @@ void main() {
       await tester.tap(favoriteButton);
       await tester.pumpAndSettle();
 
-      expect(drink1.isFavorite, true);
+      expect(provider.getDrinkById(drink1.id)!.isFavorite, true);
     });
 
     testWidgets('displays correct count of drinks', (


### PR DESCRIPTION
## Summary

- `isFavorite`, `rating`, and `isTasted` on `Drink` are now `final`
- Added `copyWith` with `_absent` sentinel pattern for the nullable `rating` field
- `BeerProvider` replaces list elements via `_replaceDrink` helper (calls `recompute()` unconditionally) instead of mutating shared objects
- `_applyUserState` in `ApiDrinkRepository` updated to use `copyWith`
- Removes conditional `recompute()` calls in `toggleFavorite` and `toggleTasted` — now handled uniformly by `_replaceDrink`

## Why

Mutating shared `Drink` objects in-place means widgets holding a reference to the old object won't reflect the change, and equality-based optimisations (e.g. `ListView` diffing) can't work. This also unblocks adding `==`/`hashCode` to `Drink` (see #323).

## Test plan

- [ ] 870 tests pass (no regressions)
- [ ] `toggleFavorite`, `setRating`, `toggleTasted` tests updated to re-read from `provider.allDrinks` after mutation
- [ ] Filter/sort service tests updated to use `copyWith` instead of direct field assignment

Fixes #322

---
_Generated by [Claude Code](https://claude.ai/code/session_01X94N9bSg25ktv4Yrx1ghFp)_