### PR TITLE
refactor(models): add Drink-level accessors to remove feature envy in screens

### DIFF
--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -252,6 +252,9 @@ class Drink {
   String? get allergenText => product.allergenText;
   bool? get isVegan => product.isVegan;
   bool get isAllergenFree => product.isAllergenFree;
+  String get producerId => producer.id;
+
+  bool isSameBrewery(Drink other) => producer.id == other.producer.id;
 
   /// Generate a share message for this drink.
   ///

--- a/lib/screens/brewery_screen.dart
+++ b/lib/screens/brewery_screen.dart
@@ -29,7 +29,7 @@ class _BreweryScreenState extends State<BreweryScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider = context.read<BeerProvider>();
       final breweryDrinks = provider.allDrinks
-          .where((d) => d.producer.id == widget.breweryId)
+          .where((d) => d.producerId == widget.breweryId)
           .toList();
       if (breweryDrinks.isNotEmpty) {
         final producer = breweryDrinks.first.producer;
@@ -49,7 +49,7 @@ class _BreweryScreenState extends State<BreweryScreen> {
 
     // Get all drinks from this brewery
     final breweryDrinks = provider.allDrinks
-        .where((drink) => drink.producer.id == widget.breweryId)
+        .where((drink) => drink.producerId == widget.breweryId)
         .toList();
 
     if (breweryDrinks.isEmpty) {

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -308,7 +308,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () => navigateToRoute(
                   context,
-                  buildBreweryPath(widget.festivalId, drink.producer.id),
+                  buildBreweryPath(widget.festivalId, drink.producerId),
                 ),
               ),
             ),
@@ -346,7 +346,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
     for (final d in allDrinks) {
       if (d.id == drink.id) continue;
 
-      if (d.producer.id == drink.producer.id) {
+      if (drink.isSameBrewery(d)) {
         results.add((d, 'Same brewery'));
         continue;
       }

--- a/lib/screens/style_screen.dart
+++ b/lib/screens/style_screen.dart
@@ -41,7 +41,7 @@ class _StyleScreenState extends State<StyleScreen> {
     final styleDrinks = provider.allDrinks
         .where(
           (drink) =>
-              drink.product.style?.toLowerCase() == widget.style.toLowerCase(),
+              drink.style?.toLowerCase() == widget.style.toLowerCase(),
         )
         .toList();
 
@@ -142,7 +142,7 @@ class _StyleScreenState extends State<StyleScreen> {
     // Calculate average ABV
     final avgABV = styleDrinks.isEmpty
         ? 0.0
-        : styleDrinks.map((d) => d.product.abv).reduce((a, b) => a + b) /
+        : styleDrinks.map((d) => d.abv).reduce((a, b) => a + b) /
               styleDrinks.length;
 
     final rows = <HeroInfoRow>[

--- a/lib/screens/style_screen.dart
+++ b/lib/screens/style_screen.dart
@@ -40,8 +40,7 @@ class _StyleScreenState extends State<StyleScreen> {
     // Get all drinks with this style
     final styleDrinks = provider.allDrinks
         .where(
-          (drink) =>
-              drink.style?.toLowerCase() == widget.style.toLowerCase(),
+          (drink) => drink.style?.toLowerCase() == widget.style.toLowerCase(),
         )
         .toList();
 

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1011,6 +1011,57 @@ void main() {
         );
       });
     });
+
+    group('producerId and isSameBrewery', () {
+      test('producerId delegates to producer.id', () {
+        final drink = Drink(
+          product: testProduct,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+        );
+
+        expect(drink.producerId, 'brew-456');
+      });
+
+      test('isSameBrewery returns true for same producer', () {
+        final drink1 = Drink(
+          product: testProduct,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+        );
+
+        final drink2 = Drink(
+          product: testProduct,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+        );
+
+        expect(drink1.isSameBrewery(drink2), isTrue);
+      });
+
+      test('isSameBrewery returns false for different producer', () {
+        final differentProducer = Producer.fromJson({
+          'id': 'brew-999',
+          'name': 'Different Brewery',
+          'location': 'London',
+          'products': [],
+        });
+
+        final drink1 = Drink(
+          product: testProduct,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+        );
+
+        final drink2 = Drink(
+          product: testProduct,
+          producer: differentProducer,
+          festivalId: 'cbf2025',
+        );
+
+        expect(drink1.isSameBrewery(drink2), isFalse);
+      });
+    });
   });
 
   group('Festival', () {


### PR DESCRIPTION
## Summary

- Added `producerId` accessor and `isSameBrewery()` predicate to `Drink` (`style` and `abv` already existed)
- Replaced all `drink.producer.id` / `drink.product.style` / `d.product.abv` deep chains in the three detail screens with `Drink`-level accessors
- No behaviour change — pure refactor

## Screens updated

| File | Before | After |
|------|--------|-------|
| `drink_detail_screen.dart` | `drink.producer.id`, `d.producer.id == drink.producer.id` | `drink.producerId`, `drink.isSameBrewery(d)` |
| `brewery_screen.dart` | `d.producer.id == widget.breweryId` (×2) | `d.producerId == widget.breweryId` |
| `style_screen.dart` | `drink.product.style?.toLowerCase()`, `d.product.abv` | `drink.style?.toLowerCase()`, `d.abv` |

## Test plan

- [ ] 873 tests pass (3 new tests for `producerId` and `isSameBrewery`)
- [ ] `grep -r "\.producer\.\|\.product\." lib/screens/` returns nothing

Fixes #354

---
_Generated by [Claude Code](https://claude.ai/code/session_01X94N9bSg25ktv4Yrx1ghFp)_