### PR TITLE
ci: fix scripts dep coverage gap and wrong self-reference path

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -1,4 +1,4 @@
-name: Deploy Worker
+name: Cloudflare Worker
 
 on:
   push:
@@ -7,13 +7,13 @@ on:
       - 'cloudflare-worker/**'
       - 'data/festivals.json'
       - 'scripts/**'
-      - '.github/workflows/deploy-worker.yml'
+      - '.github/workflows/cloudflare-worker.yml'
   pull_request:
     paths:
       - 'cloudflare-worker/**'
       - 'data/festivals.json'
       - 'scripts/**'
-      - '.github/workflows/deploy-worker.yml'
+      - '.github/workflows/cloudflare-worker.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'cloudflare-worker/**'
       - 'data/festivals.json'
-      - '.github/workflows/cloudflare-worker.yml'
+      - 'scripts/**'
+      - '.github/workflows/deploy-worker.yml'
   pull_request:
     paths:
       - 'cloudflare-worker/**'
       - 'data/festivals.json'
-      - '.github/workflows/cloudflare-worker.yml'
+      - 'scripts/**'
+      - '.github/workflows/deploy-worker.yml'
   workflow_dispatch:
 
 permissions:
@@ -42,6 +44,7 @@ jobs:
               - 'cloudflare-worker/**'
             festivals:
               - 'data/festivals.json'
+              - 'scripts/**'
 
   # Validate festivals.json against schema
   validate-festivals:


### PR DESCRIPTION
- Add scripts/** to deploy-worker.yml path triggers so dependabot PRs
  bumping ajv/ajv-formats route through validate-festivals instead of
  silently skipping all CI jobs
- Add scripts/** to the festivals path filter in the changes job so
  validate-festivals actually runs on those PRs
- Fix self-referencing path filter: was cloudflare-worker.yml (wrong
  filename), now correctly points to deploy-worker.yml