### PR TITLE
fix(analytics): filter connectivity failures from partial-fetch log

### DIFF
--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -40,15 +40,19 @@ class ApiDrinkRepository implements DrinkRepository {
     // Log partial failures (some types loaded, others didn't) to Crashlytics
     // so we have visibility into recurring per-type errors. Skip logging when
     // every failure is a connectivity issue — those are expected offline
-    // behaviour and would only add noise.
-    if (result.failedTypes.isNotEmpty &&
-        !result.failedTypes.values.every(isConnectivityFailure)) {
-      final failedNames = result.failedTypes.keys.join(', ');
+    // behaviour and would only add noise. Also filter out connectivity failures
+    // from the log message to avoid misleading reports that mix network timeouts
+    // with real data errors.
+    final nonConnectivityFailed = result.failedTypes.entries
+        .where((e) => !isConnectivityFailure(e.value))
+        .map((e) => e.key)
+        .toList();
+    if (nonConnectivityFailed.isNotEmpty) {
       unawaited(
         _analyticsService.logError(
           Exception('Partial beverage-type fetch failure'),
           null,
-          reason: 'festival=${festival.id} failed=[$failedNames]',
+          reason: 'festival=${festival.id} failed=[$nonConnectivityFailed]',
         ),
       );
     }

--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -52,7 +52,7 @@ class ApiDrinkRepository implements DrinkRepository {
         _analyticsService.logError(
           Exception('Partial beverage-type fetch failure'),
           null,
-          reason: 'festival=${festival.id} failed=[$nonConnectivityFailed]',
+          reason: 'festival=${festival.id} failed=$nonConnectivityFailed',
         ),
       );
     }

--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -37,6 +37,22 @@ class ApiDrinkRepository implements DrinkRepository {
     // showing cached data or display an error.
     result.throwIfCompleteFailure();
 
+    // Log partial failures (some types loaded, others didn't) to Crashlytics
+    // so we have visibility into recurring per-type errors. Skip logging when
+    // every failure is a connectivity issue — those are expected offline
+    // behaviour and would only add noise.
+    if (result.failedTypes.isNotEmpty &&
+        !result.failedTypes.values.every(isConnectivityFailure)) {
+      final failedNames = result.failedTypes.keys.join(', ');
+      unawaited(
+        _analyticsService.logError(
+          Exception('Partial beverage-type fetch failure'),
+          null,
+          reason: 'festival=${festival.id} failed=[$failedNames]',
+        ),
+      );
+    }
+
     // Merge the types that succeeded over the cached snapshot, keeping the
     // last-good data for any type that failed to refresh this time. The cache
     // write happens in the background so it stays off the load critical path;

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -355,6 +355,41 @@ void main() {
           );
         },
       );
+
+      test(
+        'logs only non-connectivity failures when mixed with connectivity errors',
+        () async {
+          when(apiService.fetchDrinksByType(festival)).thenAnswer(
+            (_) async => FestivalDrinksResult(
+              drinksByType: {
+                'beer': [makeDrink('beer-1')],
+              },
+              failedTypes: {
+                'cider': TimeoutException('timeout'), // connectivity
+                'perry': BeerApiException('HTTP 500'), // non-connectivity
+              },
+            ),
+          );
+
+          await repository.getDrinks(festival);
+          await pumpEventQueue();
+
+          verify(
+            analyticsService.logError(
+              any,
+              any,
+              reason: argThat(
+                allOf(
+                  contains('perry'),
+                  contains(festival.id),
+                  isNot(contains('cider')), // connectivity failure excluded
+                ),
+                named: 'reason',
+              ),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('getCachedDrinks', () {

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cambridge_beer_festival/domain/repositories/repositories.dart';
 import 'package:cambridge_beer_festival/models/models.dart';
 import 'package:cambridge_beer_festival/services/services.dart';
@@ -298,6 +300,59 @@ void main() {
               reason: argThat(contains('cache write failed'), named: 'reason'),
             ),
           ).called(1);
+        },
+      );
+
+      test(
+        'logs partial failure to analytics when a non-connectivity type fails',
+        () async {
+          when(apiService.fetchDrinksByType(festival)).thenAnswer(
+            (_) async => FestivalDrinksResult(
+              drinksByType: {
+                'beer': [makeDrink('beer-1')],
+              },
+              failedTypes: {'cider': BeerApiException('HTTP 500')},
+            ),
+          );
+
+          await repository.getDrinks(festival);
+          await pumpEventQueue();
+
+          verify(
+            analyticsService.logError(
+              any,
+              any,
+              reason: argThat(
+                allOf(contains('cider'), contains(festival.id)),
+                named: 'reason',
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'does not log partial failure to analytics when all failures are connectivity errors',
+        () async {
+          when(apiService.fetchDrinksByType(festival)).thenAnswer(
+            (_) async => FestivalDrinksResult(
+              drinksByType: {
+                'beer': [makeDrink('beer-1')],
+              },
+              failedTypes: {'cider': TimeoutException('timeout')},
+            ),
+          );
+
+          await repository.getDrinks(festival);
+          await pumpEventQueue();
+
+          verifyNever(
+            analyticsService.logError(
+              any,
+              any,
+              reason: argThat(contains('failed='), named: 'reason'),
+            ),
+          );
         },
       );
     });


### PR DESCRIPTION
## Summary

- Filters connectivity-failed types out of the log message so mixed failures (some connectivity, some real errors) don't produce misleading Crashlytics reports
- Simplifies the guard: `nonConnectivityFailed.isNotEmpty` replaces the previous double-check
- Adds a test for the mixed-failure scenario (connectivity + non-connectivity in the same result)

Fixes #270

## Test plan

- [ ] `./bin/mise run test` passes
- [ ] New test: `logs only non-connectivity failures when mixed with connectivity errors` — verifies `cider` (TimeoutException) is excluded and `perry` (BeerApiException) is included in the log reason