### PR TITLE
fix(connectivity): replace runtimeType string-matching with conditional imports

### DIFF
--- a/lib/services/beer_api_service.dart
+++ b/lib/services/beer_api_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/models.dart';
+import 'connectivity_web.dart' if (dart.library.io) 'connectivity_io.dart';
 
 /// Service for fetching beer festival data from the API
 class BeerApiService {
@@ -197,14 +198,5 @@ class BeerApiException implements Exception {
 /// per-type fetch logic share a single source of truth.
 bool isConnectivityFailure(Object error) {
   if (error is http.ClientException || error is TimeoutException) return true;
-  // dart:io types aren't available on web; match by runtime type name to
-  // cover SocketException, HandshakeException, and HttpException without an
-  // unconditional dart:io import.
-  const connectivityTypeNames = {
-    'SocketException',
-    'HandshakeException',
-    'HttpException',
-    'TlsException',
-  };
-  return connectivityTypeNames.contains(error.runtimeType.toString());
+  return isIoConnectivityError(error);
 }

--- a/lib/services/connectivity_io.dart
+++ b/lib/services/connectivity_io.dart
@@ -1,0 +1,7 @@
+import 'dart:io';
+
+bool isIoConnectivityError(Object e) =>
+    e is SocketException ||
+    e is HandshakeException ||
+    e is HttpException ||
+    e is TlsException;

--- a/lib/services/connectivity_io.dart
+++ b/lib/services/connectivity_io.dart
@@ -1,7 +1,4 @@
 import 'dart:io';
 
 bool isIoConnectivityError(Object e) =>
-    e is SocketException ||
-    e is HandshakeException ||
-    e is HttpException ||
-    e is TlsException;
+    e is SocketException || e is HttpException || e is TlsException;

--- a/lib/services/connectivity_web.dart
+++ b/lib/services/connectivity_web.dart
@@ -1,2 +1,2 @@
-// ignore: avoid_unused_parameters
+// Parameter matches the IO stub signature; always returns false on web.
 bool isIoConnectivityError(Object e) => false;

--- a/lib/services/connectivity_web.dart
+++ b/lib/services/connectivity_web.dart
@@ -1,0 +1,2 @@
+// ignore: avoid_unused_parameters
+bool isIoConnectivityError(Object e) => false;

--- a/test/beer_api_service_test.dart
+++ b/test/beer_api_service_test.dart
@@ -576,5 +576,16 @@ void main() {
     test('returns false for FormatException', () {
       expect(isConnectivityFailure(const FormatException()), isFalse);
     });
+
+    test('returns true for TlsException', () {
+      expect(isConnectivityFailure(const TlsException('cert error')), isTrue);
+    });
+
+    test('returns true for CertificateException', () {
+      expect(
+        isConnectivityFailure(const CertificateException('bad cert')),
+        isTrue,
+      );
+    });
   });
 }

--- a/test/beer_api_service_test.dart
+++ b/test/beer_api_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cambridge_beer_festival/services/services.dart';
 import 'package:cambridge_beer_festival/models/models.dart';
@@ -533,6 +534,47 @@ void main() {
           throwsA(isA<TimeoutException>()),
         );
       });
+    });
+  });
+
+  group('isConnectivityFailure', () {
+    // isConnectivityFailure is a top-level function; no service instantiation needed.
+
+    test('returns true for SocketException', () {
+      expect(isConnectivityFailure(const SocketException('no route')), isTrue);
+    });
+
+    test('returns true for HandshakeException', () {
+      expect(
+        isConnectivityFailure(const HandshakeException('handshake failed')),
+        isTrue,
+      );
+    });
+
+    test('returns true for HttpException', () {
+      expect(
+        isConnectivityFailure(const HttpException('connection refused')),
+        isTrue,
+      );
+    });
+
+    test('returns true for TimeoutException', () {
+      expect(isConnectivityFailure(TimeoutException('timed out')), isTrue);
+    });
+
+    test('returns true for http.ClientException', () {
+      expect(
+        isConnectivityFailure(http.ClientException('client error')),
+        isTrue,
+      );
+    });
+
+    test('returns false for generic Exception', () {
+      expect(isConnectivityFailure(Exception('random')), isFalse);
+    });
+
+    test('returns false for FormatException', () {
+      expect(isConnectivityFailure(const FormatException()), isFalse);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Replaces brittle `runtimeType.toString()` matching in `isConnectivityFailure` with a conditional import (`connectivity_io.dart` / `connectivity_web.dart`) that uses proper `is` type checks on native and returns `false` on web
- Removes dead `e is HandshakeException` check — `HandshakeException` is a `TlsException` subtype so it was already covered
- Replaces no-op `// ignore: avoid_unused_parameters` comment with a meaningful explanation
- Adds tests for `TlsException` and `CertificateException` (both correctly treated as connectivity failures via `is TlsException`)

Fixes #324

## Test plan

- [ ] `./bin/mise run test` passes
- [ ] New tests: `returns true for TlsException`, `returns true for CertificateException`
- [ ] Existing tests for `SocketException`, `HandshakeException`, `HttpException`, `TimeoutException`, `ClientException` all still pass