### PR TITLE
refactor(screens): extract DetailHeader widget, deduplicate sort label logic

### DIFF
--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -145,11 +146,7 @@ class BeerProvider extends ChangeNotifier {
 
   /// Get a festival by ID, or null if not found
   Festival? getFestivalById(String festivalId) {
-    try {
-      return _festivals.firstWhere((f) => f.id == festivalId);
-    } catch (e) {
-      return null;
-    }
+    return _festivals.firstWhereOrNull((f) => f.id == festivalId);
   }
 
   /// Check if drinks data is stale and should be refreshed
@@ -751,11 +748,7 @@ class BeerProvider extends ChangeNotifier {
 
   /// Get a drink by ID
   Drink? getDrinkById(String id) {
-    try {
-      return _allDrinks.firstWhere((d) => d.id == id);
-    } catch (e) {
-      return null;
-    }
+    return _allDrinks.firstWhereOrNull((d) => d.id == id);
   }
 
   @override

--- a/lib/screens/brewery_screen.dart
+++ b/lib/screens/brewery_screen.dart
@@ -71,7 +71,12 @@ class _BreweryScreenState extends State<BreweryScreen> {
       body: CustomScrollView(
         slivers: [
           // Header section
-          SliverToBoxAdapter(child: _buildHeader(context, producer, theme)),
+          SliverToBoxAdapter(
+            child: DetailHeader(
+              title: producer.name,
+              subtitle: producer.location.isNotEmpty ? producer.location : null,
+            ),
+          ),
           // Hero info card
           SliverToBoxAdapter(
             child: _buildHeroCard(
@@ -101,46 +106,6 @@ class _BreweryScreenState extends State<BreweryScreen> {
         color: Theme.of(context).colorScheme.onSurfaceVariant,
       ),
       overflow: TextOverflow.ellipsis,
-    );
-  }
-
-  /// Build clean white header with brewery name and location
-  Widget _buildHeader(
-    BuildContext context,
-    Producer producer,
-    ThemeData theme,
-  ) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(24.0),
-      color: theme.colorScheme.surface,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SelectableText(
-            producer.name,
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: theme.colorScheme.onSurface,
-            ),
-          ),
-          if (producer.location.isNotEmpty) ...[
-            const SizedBox(height: 8),
-            Row(
-              children: [
-                Expanded(
-                  child: SelectableText(
-                    producer.location,
-                    style: theme.textTheme.bodyLarge?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ],
-      ),
     );
   }
 

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -70,7 +70,15 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
             child: CustomScrollView(
               slivers: [
                 // Header section
-                SliverToBoxAdapter(child: _buildHeader(context, drink, theme)),
+                SliverToBoxAdapter(
+                  child: DetailHeader(
+                    title: drink.name,
+                    subtitle: drink.breweryLocation.isNotEmpty
+                        ? '${drink.breweryName} · ${drink.breweryLocation}'
+                        : drink.breweryName,
+                    padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0),
+                  ),
+                ),
                 // Hero info card
                 SliverToBoxAdapter(
                   child: _buildHeroCard(context, drink, theme),
@@ -110,40 +118,6 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen> {
         color: Theme.of(context).colorScheme.onSurfaceVariant,
       ),
       overflow: TextOverflow.ellipsis,
-    );
-  }
-
-  Widget _buildHeader(BuildContext context, Drink drink, ThemeData theme) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Drink name
-          SelectableText(
-            drink.name,
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          const SizedBox(height: 8),
-          // Brewery info
-          Row(
-            children: [
-              Expanded(
-                child: SelectableText(
-                  drink.breweryLocation.isNotEmpty
-                      ? '${drink.breweryName} · ${drink.breweryLocation}'
-                      : drink.breweryName,
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
     );
   }
 

--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -9,6 +9,23 @@ import '../providers/providers.dart';
 import '../utils/utils.dart';
 import '../widgets/widgets.dart';
 
+String _sortLabel(DrinkSort sort) {
+  switch (sort) {
+    case DrinkSort.nameAsc:
+      return 'Name (A-Z)';
+    case DrinkSort.nameDesc:
+      return 'Name (Z-A)';
+    case DrinkSort.abvHigh:
+      return 'ABV (High to Low)';
+    case DrinkSort.abvLow:
+      return 'ABV (Low to High)';
+    case DrinkSort.brewery:
+      return 'Brewery (A-Z)';
+    case DrinkSort.style:
+      return 'Style (A-Z)';
+  }
+}
+
 /// Main screen showing the list of drinks
 class DrinksScreen extends StatefulWidget {
   const DrinksScreen({required this.festivalId, super.key});
@@ -162,9 +179,9 @@ class _DrinksScreenState extends State<DrinksScreen> {
           const SizedBox(width: 6),
           Expanded(
             child: _FilterButton(
-              label: _getSortLabel(provider.currentSort),
+              label: _sortLabel(provider.currentSort),
               semanticLabel:
-                  'Sort drinks by ${_getSortLabel(provider.currentSort)}',
+                  'Sort drinks by ${_sortLabel(provider.currentSort)}',
               icon: Icons.sort,
               onPressed: () => _showSortOptions(context, provider),
               isActive: false,
@@ -619,23 +636,6 @@ class _DrinksScreenState extends State<DrinksScreen> {
       builder: (context) => const _VisibilityFilterSheet(),
     );
   }
-
-  String _getSortLabel(DrinkSort sort) {
-    switch (sort) {
-      case DrinkSort.nameAsc:
-        return 'Name (A-Z)';
-      case DrinkSort.nameDesc:
-        return 'Name (Z-A)';
-      case DrinkSort.abvHigh:
-        return 'ABV (High)';
-      case DrinkSort.abvLow:
-        return 'ABV (Low)';
-      case DrinkSort.brewery:
-        return 'Brewery';
-      case DrinkSort.style:
-        return 'Style';
-    }
-  }
 }
 
 class _FilterButton extends StatelessWidget {
@@ -927,7 +927,7 @@ class _SortOptionsSheet extends StatelessWidget {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: DrinkSort.values.map((sort) {
-                    final sortLabel = _getSortLabel(sort);
+                    final sortLabel = _sortLabel(sort);
                     return Semantics(
                       label: 'Sort by $sortLabel',
                       selected: provider.currentSort == sort,
@@ -950,23 +950,6 @@ class _SortOptionsSheet extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  String _getSortLabel(DrinkSort sort) {
-    switch (sort) {
-      case DrinkSort.nameAsc:
-        return 'Name (A-Z)';
-      case DrinkSort.nameDesc:
-        return 'Name (Z-A)';
-      case DrinkSort.abvHigh:
-        return 'ABV (High to Low)';
-      case DrinkSort.abvLow:
-        return 'ABV (Low to High)';
-      case DrinkSort.brewery:
-        return 'Brewery (A-Z)';
-      case DrinkSort.style:
-        return 'Style (A-Z)';
-    }
   }
 }
 

--- a/lib/screens/style_screen.dart
+++ b/lib/screens/style_screen.dart
@@ -65,7 +65,7 @@ class _StyleScreenState extends State<StyleScreen> {
       body: CustomScrollView(
         slivers: [
           // Header section
-          SliverToBoxAdapter(child: _buildHeader(context, theme, displayStyle)),
+          SliverToBoxAdapter(child: DetailHeader(title: displayStyle)),
           // Hero info card
           SliverToBoxAdapter(
             child: _buildHeroCard(context, styleDrinks, theme),
@@ -102,31 +102,6 @@ class _StyleScreenState extends State<StyleScreen> {
         color: Theme.of(context).colorScheme.onSurfaceVariant,
       ),
       overflow: TextOverflow.ellipsis,
-    );
-  }
-
-  /// Build clean white header with style name
-  Widget _buildHeader(
-    BuildContext context,
-    ThemeData theme,
-    String displayStyle,
-  ) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(24.0),
-      color: theme.colorScheme.surface,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SelectableText(
-            displayStyle,
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: theme.colorScheme.onSurface,
-            ),
-          ),
-        ],
-      ),
     );
   }
 

--- a/lib/widgets/detail_header.dart
+++ b/lib/widgets/detail_header.dart
@@ -34,17 +34,11 @@ class DetailHeader extends StatelessWidget {
           ),
           if (subtitle != null && subtitle!.isNotEmpty) ...[
             const SizedBox(height: 8),
-            Row(
-              children: [
-                Expanded(
-                  child: SelectableText(
-                    subtitle!,
-                    style: theme.textTheme.bodyLarge?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ),
-              ],
+            SelectableText(
+              subtitle!,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ],
         ],

--- a/lib/widgets/detail_header.dart
+++ b/lib/widgets/detail_header.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// A shared header widget used by detail screens (drink, brewery, style).
+///
+/// Renders a title with an optional subtitle on a surface-coloured background.
+class DetailHeader extends StatelessWidget {
+  const DetailHeader({
+    required this.title,
+    this.subtitle,
+    this.padding = const EdgeInsets.all(24.0),
+    super.key,
+  });
+
+  final String title;
+  final String? subtitle;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: padding,
+      color: theme.colorScheme.surface,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SelectableText(
+            title,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.onSurface,
+            ),
+          ),
+          if (subtitle != null && subtitle!.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: SelectableText(
+                    subtitle!,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,7 +1,7 @@
 export 'availability_badge.dart';
-export 'detail_header.dart';
 export 'bottom_action_bar.dart';
 export 'breadcrumb_bar.dart';
+export 'detail_header.dart';
 export 'drink_card.dart';
 export 'drink_list_section.dart';
 export 'environment_badge.dart';

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,4 +1,5 @@
 export 'availability_badge.dart';
+export 'detail_header.dart';
 export 'bottom_action_bar.dart';
 export 'breadcrumb_bar.dart';
 export 'drink_card.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "4.11.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   firebase_crashlytics: ^5.2.2
   firebase_analytics: ^12.4.1
   package_info_plus: ^9.0.1
+  collection: ^1.18.0
   go_router: ^17.2.3
   google_fonts: ^8.1.0
 


### PR DESCRIPTION
## Summary

- Extracts a shared `DetailHeader` widget used by `DrinkDetailScreen`, `BreweryScreen`, and `StyleScreen`, replacing three near-identical `_buildHeader` implementations
- Deduplicates `_getSortLabel` — two copies in `DrinksScreen` collapsed into a single file-scope `_sortLabel` function
- Switches `getFestivalById` and `getDrinkById` in `BeerProvider` to use `firstWhereOrNull` from the `collection` package, removing try/catch boilerplate
- Removes unnecessary `Row`/`Expanded` wrapper around the subtitle `SelectableText` in `DetailHeader`

Fixes #355

## Test plan

- [ ] `./bin/mise run test` passes
- [ ] `./bin/mise run analyze` clean
- [ ] Visually verify drink detail, brewery, and style screens render headers correctly (manual)