### PR TITLE
feat(claude): add ship-issues workflow commands and tighten agent docs

### DIFF
--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -1,9 +1,9 @@
-# Fix Review Findings
+# Address Review Findings
 
 Triage review comments on one or more PRs and spawn fixup agents for actionable findings.
 
-Usage: `/fix-review fix/270-partial-fetch-failures fix/324-connectivity-failure-detection`
-Or just: `/fix-review` to triage all open PRs being watched in this session.
+Usage: `/address-review fix/270-partial-fetch-failures fix/324-connectivity-failure-detection`
+Or just: `/address-review` to triage all open PRs being watched in this session.
 
 ---
 

--- a/.claude/commands/fix-review.md
+++ b/.claude/commands/fix-review.md
@@ -1,6 +1,6 @@
 # Fix Review Findings
 
-Triage Copilot/human review comments on one or more branches and spawn fixup agents for actionable findings.
+Triage review comments on one or more PRs and spawn fixup agents for actionable findings.
 
 Usage: `/fix-review fix/270-partial-fetch-failures fix/324-connectivity-failure-detection`
 Or just: `/fix-review` to triage all open PRs being watched in this session.
@@ -12,20 +12,22 @@ Or just: `/fix-review` to triage all open PRs being watched in this session.
 For each branch / PR:
 
 1. Fetch review comments via `mcp__github__pull_request_read` (method: `get_review_comments`).
-2. Triage each comment as one of:
-   - **Fix** — clear, correct, confined to the PR's allowed files
-   - **Skip** — wrong (verify against CI / Dart docs / code), out of scope, or style-only
-   - **Ask** — ambiguous or architecturally significant
-3. For each **Fix** item, spawn a haiku agent with `isolation: "worktree"` to apply the change, run `./bin/mise run check`, commit, and push.
-4. For each **Ask** item, surface it to the user with enough context to answer without scrolling.
-5. Skip items silently — do not post GitHub replies unless you need to correct a factually wrong review comment that could mislead other reviewers.
+2. Check current CI status (`get_check_runs`) before evaluating any comment.
+3. Triage each comment:
+   - **Fix** — correct finding, confined to the PR's allowed files, clear how to resolve
+   - **Skip** — contradicted by passing CI, factually wrong, out of scope, or pure style preference
+   - **Ask** — ambiguous interpretation or architecturally significant change
+4. Spawn one haiku agent per **Fix** item (or group related fixes on the same branch into one agent) with `isolation: "worktree"`.
+5. Surface **Ask** items to the user with enough context to answer without scrolling.
+6. Do not post GitHub replies to skip items unless the comment is factually wrong in a way that could mislead other reviewers.
 
-## Triage heuristics
+## Triage principles
 
-- If CI passes (test + analyze green), `const` constructor concerns from Copilot are likely wrong — `dart:io` exceptions have `const` constructors.
-- Conditional import stubs (`connectivity_io.dart` / `connectivity_web.dart`) should NOT be added to barrel exports — skip those suggestions.
-- Coverage warnings from Codecov are informational unless the `codecov/patch` check itself fails.
-- `CertificateException extends TlsException` in `dart:io` — Copilot sometimes gets this wrong.
+- **CI is ground truth.** If tests and analyzer pass, a "this won't compile" comment is wrong — skip it.
+- **Verify type hierarchy claims.** Automated reviewers sometimes get subtype relationships wrong; check the language/SDK docs before acting.
+- **Internal implementation files don't need barrel exports.** Files only meant to be imported via conditional imports or as private implementation details should not be added to public barrels.
+- **Coverage warnings are informational** unless the `codecov/patch` check itself fails (not just the comment).
+- **Pure refactors inherit prior coverage.** Moved code that was untested before is not a new gap.
 
 ## Fixup agent constraints
 

--- a/.claude/commands/fix-review.md
+++ b/.claude/commands/fix-review.md
@@ -1,0 +1,36 @@
+# Fix Review Findings
+
+Triage Copilot/human review comments on one or more branches and spawn fixup agents for actionable findings.
+
+Usage: `/fix-review fix/270-partial-fetch-failures fix/324-connectivity-failure-detection`
+Or just: `/fix-review` to triage all open PRs being watched in this session.
+
+---
+
+## Steps
+
+For each branch / PR:
+
+1. Fetch review comments via `mcp__github__pull_request_read` (method: `get_review_comments`).
+2. Triage each comment as one of:
+   - **Fix** — clear, correct, confined to the PR's allowed files
+   - **Skip** — wrong (verify against CI / Dart docs / code), out of scope, or style-only
+   - **Ask** — ambiguous or architecturally significant
+3. For each **Fix** item, spawn a haiku agent with `isolation: "worktree"` to apply the change, run `./bin/mise run check`, commit, and push.
+4. For each **Ask** item, surface it to the user with enough context to answer without scrolling.
+5. Skip items silently — do not post GitHub replies unless you need to correct a factually wrong review comment that could mislead other reviewers.
+
+## Triage heuristics
+
+- If CI passes (test + analyze green), `const` constructor concerns from Copilot are likely wrong — `dart:io` exceptions have `const` constructors.
+- Conditional import stubs (`connectivity_io.dart` / `connectivity_web.dart`) should NOT be added to barrel exports — skip those suggestions.
+- Coverage warnings from Codecov are informational unless the `codecov/patch` check itself fails.
+- `CertificateException extends TlsException` in `dart:io` — Copilot sometimes gets this wrong.
+
+## Fixup agent constraints
+
+Each agent must:
+- Work only on files within the branch's original allowed-file manifest
+- Run `./bin/mise run check` before committing
+- Use conventional commit format: `fix(<scope>): <subject>`
+- Push to the existing fix branch (not a new branch)

--- a/.claude/commands/plan-issues.md
+++ b/.claude/commands/plan-issues.md
@@ -12,7 +12,7 @@ For each issue number provided:
 2. Explore the affected files to understand the current code.
 3. Produce a plan in the exact contract format below.
 
-Spawn all planning agents **in parallel** (one per issue). Each agent should be `subagent_type: Explore` or `claude` depending on complexity. Use `model: haiku` for single-file mechanical fixes; `model: sonnet` for multi-file or architectural changes.
+Spawn all planning agents **in parallel** (one per issue, `subagent_type: claude`). Use `model: haiku` for single-file mechanical fixes; `model: sonnet` for multi-file or architectural changes. Each agent receives: the issue body, relevant file excerpts, and the planning contract below.
 
 ---
 

--- a/.claude/commands/plan-issues.md
+++ b/.claude/commands/plan-issues.md
@@ -1,0 +1,49 @@
+# Plan Issues
+
+Spawn parallel planning agents for one or more GitHub issue numbers.
+
+Usage: `/plan-issues #270 #324` or `/plan-issues 270 324 355`
+
+---
+
+For each issue number provided:
+
+1. Read the issue from GitHub (`mcp__github__issue_read`) to get the title, body, and any triage comments.
+2. Explore the affected files to understand the current code.
+3. Produce a plan in the exact contract format below.
+
+Spawn all planning agents **in parallel** (one per issue). Each agent should be `subagent_type: Explore` or `claude` depending on complexity. Use `model: haiku` for single-file mechanical fixes; `model: sonnet` for multi-file or architectural changes.
+
+---
+
+## Planning Agent Contract
+
+Every plan must output exactly these three sections — implementation agents receive them verbatim:
+
+```
+### Allowed files (HARD CONSTRAINT)
+- lib/path/to/file.dart
+- test/path/to/file_test.dart
+# Nothing outside this list may be touched.
+
+### Model recommendation
+haiku / sonnet — one-line rationale
+
+### Phase N — <short name>
+Files: (subset of allowed list)
+Changes: (exact description — line numbers where possible)
+Verification: (command to run)
+Done signal: (what "done" looks like)
+```
+
+## Model selection guide
+
+| Use haiku for | Use sonnet for |
+|---|---|
+| Single-file mechanical changes | Multi-file architectural changes |
+| Tests following an established pattern | Nullable/sentinel patterns, type system changes |
+| ≤2 files with a grep-based done signal | Cascading updates across 6+ files |
+
+---
+
+After all planning agents complete, present the plans to the user for approval before any implementation begins.

--- a/.claude/commands/ship-issues.md
+++ b/.claude/commands/ship-issues.md
@@ -23,7 +23,7 @@ Run all implementation agents **in parallel**.
 
 After all agents complete, verify each branch:
 ```bash
-git diff <base-commit>..<branch> --stat
+git diff $(git merge-base main fix/<issue>)..fix/<issue> --stat
 ```
 Confirm only planned files changed. ✋ Flag any drift before continuing.
 
@@ -31,13 +31,13 @@ Confirm only planned files changed. ✋ Flag any drift before continuing.
 Run `/fix-review` across all fix branches. Apply fixup commits for clear findings. ✋ Ask about ambiguous ones.
 
 ### Stage 4 — Push PRs
-Create one PR per fix branch targeting `main`. Subscribe to all PRs with `mcp__github__subscribe_pr_activity`.
+Create one PR per fix branch targeting `main`. PR body must include `Fixes #<issue-number>` to auto-close the issue on merge, plus a brief summary of changes. Subscribe to all PRs with `mcp__github__subscribe_pr_activity`.
 
 ### Stage 5 — Watch
 Monitor CI and review activity. For each event:
 - Green CI on all checks → nothing to do
 - Test/analyze failure → diagnose and push a fix commit
-- Copilot review comment → triage per `/fix-review` heuristics
+- Copilot/automated review comment → invoke `/fix-review` on that PR
 - Human review comment → surface to user if ambiguous, otherwise fix and push
 
 The session ends when all PRs are green and have no unresolved review threads.

--- a/.claude/commands/ship-issues.md
+++ b/.claude/commands/ship-issues.md
@@ -28,7 +28,7 @@ git diff $(git merge-base main fix/<issue>)..fix/<issue> --stat
 Confirm only planned files changed. ✋ Flag any drift before continuing.
 
 ### Stage 3 — Review
-Run `/fix-review` across all fix branches. Apply fixup commits for clear findings. ✋ Ask about ambiguous ones.
+Run `/address-review` across all fix branches. Apply fixup commits for clear findings. ✋ Ask about ambiguous ones.
 
 ### Stage 4 — Push PRs
 Create one PR per fix branch targeting `main`. PR body must include `Fixes #<issue-number>` to auto-close the issue on merge, plus a brief summary of changes. Subscribe to all PRs with `mcp__github__subscribe_pr_activity`.
@@ -37,7 +37,7 @@ Create one PR per fix branch targeting `main`. PR body must include `Fixes #<iss
 Monitor CI and review activity. For each event:
 - Green CI on all checks → nothing to do
 - Test/analyze failure → diagnose and push a fix commit
-- Copilot/automated review comment → invoke `/fix-review` on that PR
+- Copilot/automated review comment → invoke `/address-review` on that PR
 - Human review comment → surface to user if ambiguous, otherwise fix and push
 
 The session ends when all PRs are green and have no unresolved review threads.

--- a/.claude/commands/ship-issues.md
+++ b/.claude/commands/ship-issues.md
@@ -1,0 +1,51 @@
+# Ship Issues
+
+Full plan → implement → review → fix → PR → watch cycle for one or more GitHub issues.
+
+Usage: `/ship-issues #270 #324 #355`
+
+---
+
+## Workflow
+
+Work through these stages in order. Pause for user approval at each ✋ gate.
+
+### Stage 1 — Plan
+Invoke `/plan-issues` for all issue numbers. Present plans. ✋ Wait for approval.
+
+### Stage 2 — Implement
+For each approved plan, spawn an implementation agent with `isolation: "worktree"`:
+- Branch name: `fix/<issue-number>-<short-slug>` (created inside the worktree)
+- Pass: phase steps, allowed-file manifest as a hard constraint, explicit "do not modify files outside this list"
+- The agent must run `./bin/mise run check` before committing and push to its branch
+
+Run all implementation agents **in parallel**.
+
+After all agents complete, verify each branch:
+```bash
+git diff <base-commit>..<branch> --stat
+```
+Confirm only planned files changed. ✋ Flag any drift before continuing.
+
+### Stage 3 — Review
+Run `/fix-review` across all fix branches. Apply fixup commits for clear findings. ✋ Ask about ambiguous ones.
+
+### Stage 4 — Push PRs
+Create one PR per fix branch targeting `main`. Subscribe to all PRs with `mcp__github__subscribe_pr_activity`.
+
+### Stage 5 — Watch
+Monitor CI and review activity. For each event:
+- Green CI on all checks → nothing to do
+- Test/analyze failure → diagnose and push a fix commit
+- Copilot review comment → triage per `/fix-review` heuristics
+- Human review comment → surface to user if ambiguous, otherwise fix and push
+
+The session ends when all PRs are green and have no unresolved review threads.
+
+---
+
+## Notes
+
+- Implementation agents use `isolation: "worktree"` — this creates worktrees inside the repo at `.claude/worktrees/`, which is required for commit signing in the managed environment.
+- Fix branches target `main` directly. The session branch (`claude/session-*`) is for session-level changes (AGENTS.md updates, etc.).
+- Always run `./bin/mise run` commands, never raw `flutter` — see AGENTS.md for the full command reference.

--- a/.claude/commands/ship-issues.md
+++ b/.claude/commands/ship-issues.md
@@ -23,7 +23,7 @@ Run all implementation agents **in parallel**.
 
 After all agents complete, verify each branch:
 ```bash
-git diff $(git merge-base main fix/<issue>)..fix/<issue> --stat
+git diff $(git merge-base main fix/<issue-number>-<short-slug>)..fix/<issue-number>-<short-slug> --stat
 ```
 Confirm only planned files changed. ✋ Flag any drift before continuing.
 

--- a/.claude/commands/ship-issues.md
+++ b/.claude/commands/ship-issues.md
@@ -49,3 +49,4 @@ The session ends when all PRs are green and have no unresolved review threads.
 - Implementation agents use `isolation: "worktree"` — this creates worktrees inside the repo at `.claude/worktrees/`, which is required for commit signing in the managed environment.
 - Fix branches target `main` directly. The session branch (`claude/session-*`) is for session-level changes (AGENTS.md updates, etc.).
 - Always run `./bin/mise run` commands, never raw `flutter` — see AGENTS.md for the full command reference.
+- MCP tool parameters take plain strings — do not use `$(cat <<'EOF'...)` heredoc syntax in `body` fields; it will appear literally in the PR description.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code
+.claude/
+
 # Miscellaneous
 *.class
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# Claude Code
-.claude/
+# Claude Code — ephemeral and personal files only
+# .claude/commands/ and .claude/settings.json are committed (shared team config)
+.claude/worktrees/
+.claude/settings.local.json
 
 # Miscellaneous
 *.class

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -656,6 +656,17 @@ Done signal: (what "done" looks like — grep returns nothing, tests pass, etc.)
 
 ---
 
+## Dart / Flutter Type Facts
+
+Known facts to verify before acting on automated review comments:
+
+- **`dart:io` exceptions have `const` constructors** — `SocketException`, `HandshakeException`, `HttpException`, `TlsException`, `CertificateException` all accept `const`. A reviewer claiming otherwise is wrong if `flutter analyze` passes.
+- **`CertificateException extends TlsException`** — `e is TlsException` catches `CertificateException`. Both should be treated as connectivity failures.
+- **`HandshakeException extends TlsException`** — `e is TlsException` subsumes `e is HandshakeException`; the latter is dead code when both appear in the same predicate.
+- **Conditional import stubs** (`connectivity_io.dart` / `connectivity_web.dart`) must not be added to barrel exports (`services.dart`). They are only meaningful when imported together via the conditional import syntax in the file that uses them.
+
+---
+
 ## Engineering Standards
 
 ### Definition of Done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,9 +590,9 @@ chore: bump Flutter to 3.38.3
 
 ---
 
-## Parallel Work with Subagents and Worktrees
+## Parallel Work with Subagents
 
-For working on multiple issues in one session, use git worktrees + parallel subagents.
+For working on multiple issues in one session, use parallel subagents with agent isolation.
 
 ### Workflow
 
@@ -600,15 +600,15 @@ For working on multiple issues in one session, use git worktrees + parallel suba
 2. **Spawn planning agents in parallel** — one per issue. Each plan must include (see contract below): allowed file manifest, phases, model recommendation.
 3. **Review and iterate** on plans before any implementation starts.
 4. **User approves** plans.
-5. **Create worktrees** — one per issue:
-   ```bash
-   git worktree add /tmp/fix-NNN -b fix/NNN-short-description
-   git worktree list  # verify
-   ```
-6. **Spawn implementation agents** — one per phase, parallel where phases are independent. Each agent receives: its phase's steps only, the allowed file manifest as a hard constraint, and an explicit "do not modify files outside this list" instruction.
-7. **Verify each phase** before starting the next — diff against manifest, run the phase's verification command.
-8. **Run full suite** after all phases: `./bin/mise run test`.
-9. **Push, create PR against `main`, subscribe to activity** — worktree PRs target `main` directly, not the session branch. The session branch is for main-context changes (e.g. AGENTS.md updates) and may not exist on the remote.
+5. **Spawn implementation agents** with `isolation: "worktree"` — one per issue. Each agent:
+   - Creates its own branch inside its isolated worktree (`git checkout -b fix/NNN-short-description`)
+   - Receives its phase steps, the allowed file manifest as a hard constraint, and an explicit "do not modify files outside this list" instruction
+   - Commits and pushes from within the isolated worktree
+6. **Verify each agent's output** — diff the fix branch against the base commit to confirm only planned files changed: `git diff <base>..fix/NNN --stat`
+7. **Run full suite** in the main worktree after all agents complete: `./bin/mise run test`.
+8. **Push, create PR against `main`, subscribe to activity** — fix branches target `main` directly, not the session branch. The session branch is for main-context changes (e.g. AGENTS.md updates).
+
+> **Why `isolation: "worktree"`**: the managed environment's commit signing server only accepts commits made from paths within the repository directory. Agent isolation automatically creates worktrees inside the repo. Manual `/tmp/` worktrees bypass this and cause signing to fail.
 
 ### Planning Agent Contract
 
@@ -642,7 +642,7 @@ Done signal: (what "done" looks like — grep returns nothing, tests pass, etc.)
 
 **Scope creep** — the main failure mode. Hard file manifests + explicit "do not touch other files" instructions prevent it. Always diff against the base commit (`git diff <base>..HEAD --stat`) to confirm only planned files changed.
 
-**Stuck agents** — a long-running agent with no commits is likely in a test-fix loop. Check with `git -C /tmp/fix-NNN status` and `./bin/mise run test`. If tests pass, take over: commit and push manually.
+**Stuck agents** — a long-running agent with no commits is likely in a test-fix loop. If tests pass, the agent can commit and push from within its isolation worktree path (signing requires a path inside the repo directory — `/tmp/` paths will fail).
 
 **Format failures** — run `./bin/mise run --no-deps dart:format` before committing. Haiku agents doing substitutions sometimes produce formatting that CI rejects.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -592,7 +592,7 @@ chore: bump Flutter to 3.38.3
 
 ## Parallel Work with Subagents
 
-Use `/ship-issues` for the full plan → implement → review → fix → PR → watch workflow. Use `/plan-issues` to plan only. Use `/fix-review` to triage review comments on existing branches.
+Use `/ship-issues` for the full plan → implement → review → fix → PR → watch workflow. Use `/plan-issues` to plan only. Use `/address-review` to triage review comments on existing branches.
 
 ### Constraints (apply regardless of which command you use)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -592,57 +592,19 @@ chore: bump Flutter to 3.38.3
 
 ## Parallel Work with Subagents
 
-For working on multiple issues in one session, use parallel subagents with agent isolation.
+Use `/ship-issues` for the full plan → implement → review → fix → PR → watch workflow. Use `/plan-issues` to plan only. Use `/fix-review` to triage review comments on existing branches.
 
-### Workflow
+### Constraints (apply regardless of which command you use)
 
-1. **Pick issues** — choose independent issues with non-overlapping files where possible.
-2. **Spawn planning agents in parallel** — one per issue. Each plan must include (see contract below): allowed file manifest, phases, model recommendation.
-3. **Review and iterate** on plans before any implementation starts.
-4. **User approves** plans.
-5. **Spawn implementation agents** with `isolation: "worktree"` — one per issue. Each agent:
-   - Creates its own branch inside its isolated worktree (`git checkout -b fix/NNN-short-description`)
-   - Receives its phase steps, the allowed file manifest as a hard constraint, and an explicit "do not modify files outside this list" instruction
-   - Commits and pushes from within the isolated worktree
-6. **Verify each agent's output** — diff the fix branch against the base commit to confirm only planned files changed: `git diff <base>..fix/NNN --stat`
-7. **Run full suite** in the main worktree after all agents complete: `./bin/mise run test`.
-8. **Push, create PR against `main`, subscribe to activity** — fix branches target `main` directly, not the session branch. The session branch is for main-context changes (e.g. AGENTS.md updates).
+**Always use `isolation: "worktree"`** when spawning implementation agents. The managed environment's commit signing server only accepts commits from paths inside the repository directory — manual `/tmp/` worktrees cause signing to fail. Agent isolation creates worktrees at `.claude/worktrees/` automatically.
 
-> **Why `isolation: "worktree"`**: the managed environment's commit signing server only accepts commits made from paths within the repository directory. Agent isolation automatically creates worktrees inside the repo. Manual `/tmp/` worktrees bypass this and cause signing to fail.
+**Fix branches target `main` directly.** The session branch (`claude/session-*`) is for session-level changes only (AGENTS.md, commands, toolchain config).
 
-### Planning Agent Contract
+### Lessons Learned
 
-Every plan must output these three things — implementation agents receive them verbatim:
+**Scope creep** — the main failure mode. Hard file manifests + explicit "do not touch other files" instructions prevent it. Always diff against the base commit to confirm only planned files changed: `git diff $(git merge-base main fix/NNN)..fix/NNN --stat`
 
-```
-### Allowed files (HARD CONSTRAINT)
-- lib/path/to/file.dart
-- test/path/to/file_test.dart
-# Nothing outside this list may be touched.
-
-### Model recommendation
-haiku / sonnet — one-line rationale
-
-### Phase N — <short name>
-Files: (subset of allowed list)
-Changes: (exact description — line numbers where possible)
-Verification: (command to run)
-Done signal: (what "done" looks like — grep returns nothing, tests pass, etc.)
-```
-
-### Model Selection
-
-| Use haiku for | Use sonnet for |
-|---|---|
-| Single-file mechanical changes (rename, replace, reformat) | Multi-file architectural changes |
-| Tests following an established pattern | Nullable/sentinel patterns, type system changes |
-| Phases with ≤2 files and a grep-based done signal | Cascading test updates across 6+ files |
-
-### Rules and Lessons Learned
-
-**Scope creep** — the main failure mode. Hard file manifests + explicit "do not touch other files" instructions prevent it. Always diff against the base commit (`git diff <base>..HEAD --stat`) to confirm only planned files changed.
-
-**Stuck agents** — a long-running agent with no commits is likely in a test-fix loop. If tests pass, the agent can commit and push from within its isolation worktree path (signing requires a path inside the repo directory — `/tmp/` paths will fail).
+**Stuck agents** — a long-running agent with no commits is likely in a test-fix loop. If tests pass, the agent can commit and push; signing requires a path inside the repo directory.
 
 **Format failures** — run `./bin/mise run --no-deps dart:format` before committing. Haiku agents doing substitutions sometimes produce formatting that CI rejects.
 


### PR DESCRIPTION
Introduces reusable Claude Code slash commands that encode the plan → implement → review → fix → PR → watch workflow, and tightens AGENTS.md now that the workflow detail lives in the commands.

## Changes

**New commands** (`.claude/commands/`)
- `/plan-issues` — spawn parallel planning agents per issue; outputs allowed-file manifest, phases, model recommendation; stops for approval
- `/address-review` — fetch PR review comments, triage as fix/skip/ask, spawn fixup agents for actionable findings
- `/ship-issues` — full end-to-end orchestrator: plan → implement → review → PR → watch, with approval gates

**AGENTS.md**
- Updated `.gitignore` to selectively ignore `.claude/` — ephemeral worktrees and `settings.local.json` excluded; `commands/` and `settings.json` tracked
- Replaced manual `/tmp/` worktree guidance with `isolation: "worktree"` (commit signing server requires paths inside the repo)
- Trimmed the parallel work section (workflow, contract template, model selection table) now maintained in the commands; kept constraints and lessons learned
- Added "Dart / Flutter Type Facts" section with known type hierarchy facts to verify before acting on automated review comments

## Why

The parallel work workflow was documented in AGENTS.md as a wall of text. Extracting it into named commands makes it discoverable, reusable across sessions, and gives other contributors (human or AI) a consistent entry point. AGENTS.md now focuses on constraints and context; commands own procedure.