### PR TITLE
fix(models): add == and hashCode to Drink, Product, and Producer

### DIFF
--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -52,10 +52,13 @@ class Producer {
   }
 
   @override
-  bool operator ==(Object other) => other is Producer && other.id == id;
+  bool operator ==(Object other) {
+    if (id.isEmpty) return identical(this, other);
+    return other is Producer && other.id == id;
+  }
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode => id.isEmpty ? identityHashCode(this) : id.hashCode;
 }
 
 /// Represents a beverage product (beer, cider, mead, etc.)
@@ -208,10 +211,13 @@ class Product {
       allergens.isEmpty || allergens.values.every((v) => v == 0);
 
   @override
-  bool operator ==(Object other) => other is Product && other.id == id;
+  bool operator ==(Object other) {
+    if (id.isEmpty) return identical(this, other);
+    return other is Product && other.id == id;
+  }
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode => id.isEmpty ? identityHashCode(this) : id.hashCode;
 }
 
 /// Availability status for a product, ordered from most to least available.

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -285,10 +285,7 @@ class Drink {
   bool get isAllergenFree => product.isAllergenFree;
   String get producerId => producer.id;
 
-  bool isSameBrewery(Drink other) {
-    if (producer.id.isEmpty) return identical(producer, other.producer);
-    return producer.id == other.producer.id;
-  }
+  bool isSameBrewery(Drink other) => producer == other.producer;
 
   @override
   bool operator ==(Object other) {

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -288,13 +288,17 @@ class Drink {
   bool isSameBrewery(Drink other) => producer.id == other.producer.id;
 
   @override
-  bool operator ==(Object other) =>
-      other is Drink &&
-      other.product.id == product.id &&
-      other.festivalId == festivalId;
+  bool operator ==(Object other) {
+    if (product.id.isEmpty) return identical(this, other);
+    return other is Drink &&
+        other.product.id == product.id &&
+        other.festivalId == festivalId;
+  }
 
   @override
-  int get hashCode => Object.hash(product.id, festivalId);
+  int get hashCode => product.id.isEmpty
+      ? identityHashCode(this)
+      : Object.hash(product.id, festivalId);
 
   /// Generate a share message for this drink.
   ///

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -285,7 +285,10 @@ class Drink {
   bool get isAllergenFree => product.isAllergenFree;
   String get producerId => producer.id;
 
-  bool isSameBrewery(Drink other) => producer.id == other.producer.id;
+  bool isSameBrewery(Drink other) {
+    if (producer.id.isEmpty) return identical(producer, other.producer);
+    return producer.id == other.producer.id;
+  }
 
   @override
   bool operator ==(Object other) {

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -50,6 +50,12 @@ class Producer {
       'products': products.map((p) => p.toJson()).toList(),
     };
   }
+
+  @override
+  bool operator ==(Object other) => other is Producer && other.id == id;
+
+  @override
+  int get hashCode => id.hashCode;
 }
 
 /// Represents a beverage product (beer, cider, mead, etc.)
@@ -200,6 +206,12 @@ class Product {
   /// Returns true if the product has no declared allergens
   bool get isAllergenFree =>
       allergens.isEmpty || allergens.values.every((v) => v == 0);
+
+  @override
+  bool operator ==(Object other) => other is Product && other.id == id;
+
+  @override
+  int get hashCode => id.hashCode;
 }
 
 /// Availability status for a product, ordered from most to least available.
@@ -268,6 +280,15 @@ class Drink {
   String get producerId => producer.id;
 
   bool isSameBrewery(Drink other) => producer.id == other.producer.id;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Drink &&
+      other.product.id == product.id &&
+      other.festivalId == festivalId;
+
+  @override
+  int get hashCode => Object.hash(product.id, festivalId);
 
   /// Generate a share message for this drink.
   ///

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1205,31 +1205,34 @@ void main() {
         expect(drink1.isSameBrewery(drink2), isFalse);
       });
 
-      test('isSameBrewery returns false for two drinks with empty producer ids', () {
-        final emptyProducer1 = Producer.fromJson({
-          'id': null,
-          'name': 'A',
-          'location': 'X',
-          'products': [],
-        });
-        final emptyProducer2 = Producer.fromJson({
-          'id': null,
-          'name': 'B',
-          'location': 'Y',
-          'products': [],
-        });
-        final drink1 = Drink(
-          product: testProduct,
-          producer: emptyProducer1,
-          festivalId: 'cbf2025',
-        );
-        final drink2 = Drink(
-          product: testProduct,
-          producer: emptyProducer2,
-          festivalId: 'cbf2025',
-        );
-        expect(drink1.isSameBrewery(drink2), isFalse);
-      });
+      test(
+        'isSameBrewery returns false for two drinks with empty producer ids',
+        () {
+          final emptyProducer1 = Producer.fromJson({
+            'id': null,
+            'name': 'A',
+            'location': 'X',
+            'products': [],
+          });
+          final emptyProducer2 = Producer.fromJson({
+            'id': null,
+            'name': 'B',
+            'location': 'Y',
+            'products': [],
+          });
+          final drink1 = Drink(
+            product: testProduct,
+            producer: emptyProducer1,
+            festivalId: 'cbf2025',
+          );
+          final drink2 = Drink(
+            product: testProduct,
+            producer: emptyProducer2,
+            festivalId: 'cbf2025',
+          );
+          expect(drink1.isSameBrewery(drink2), isFalse);
+        },
+      );
     });
 
     group('equality', () {

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1281,6 +1281,8 @@ void main() {
           festivalId: 'cbf2025',
         );
         expect(d1, isNot(equals(d2)));
+        // Verify hashCode is also distinct (exercises the identityHashCode path)
+        expect({d1, d2}.length, 2);
       });
     });
   });

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1204,6 +1204,32 @@ void main() {
 
         expect(drink1.isSameBrewery(drink2), isFalse);
       });
+
+      test('isSameBrewery returns false for two drinks with empty producer ids', () {
+        final emptyProducer1 = Producer.fromJson({
+          'id': null,
+          'name': 'A',
+          'location': 'X',
+          'products': [],
+        });
+        final emptyProducer2 = Producer.fromJson({
+          'id': null,
+          'name': 'B',
+          'location': 'Y',
+          'products': [],
+        });
+        final drink1 = Drink(
+          product: testProduct,
+          producer: emptyProducer1,
+          festivalId: 'cbf2025',
+        );
+        final drink2 = Drink(
+          product: testProduct,
+          producer: emptyProducer2,
+          festivalId: 'cbf2025',
+        );
+        expect(drink1.isSameBrewery(drink2), isFalse);
+      });
     });
 
     group('equality', () {

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1255,6 +1255,33 @@ void main() {
         );
         expect({d1, d2}.length, 1);
       });
+      test('drinks with empty product id are not equal (object identity)', () {
+        final emptyProduct1 = Product.fromJson({
+          'id': null,
+          'name': 'a',
+          'category': 'beer',
+          'dispense': 'cask',
+          'abv': '4.0',
+        });
+        final emptyProduct2 = Product.fromJson({
+          'id': null,
+          'name': 'a',
+          'category': 'beer',
+          'dispense': 'cask',
+          'abv': '4.0',
+        });
+        final d1 = Drink(
+          product: emptyProduct1,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+        );
+        final d2 = Drink(
+          product: emptyProduct2,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+        );
+        expect(d1, isNot(equals(d2)));
+      });
     });
   });
 

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -649,6 +649,23 @@ void main() {
         });
         expect({a, b}.length, 1);
       });
+      test('two products with empty id are not equal (object identity)', () {
+        final a = Product.fromJson({
+          'id': null,
+          'name': 'a',
+          'category': 'beer',
+          'dispense': 'cask',
+          'abv': '4.0',
+        });
+        final b = Product.fromJson({
+          'id': null,
+          'name': 'a',
+          'category': 'beer',
+          'dispense': 'cask',
+          'abv': '4.0',
+        });
+        expect(a, isNot(equals(b)));
+      });
     });
   });
 
@@ -813,6 +830,24 @@ void main() {
 
         expect(json.containsKey('year_founded'), isFalse);
         expect(json.containsKey('notes'), isFalse);
+      });
+
+      group('equality', () {
+        test('two producers with empty id are not equal (object identity)', () {
+          final a = Producer.fromJson({
+            'id': null,
+            'name': 'A',
+            'location': 'X',
+            'products': [],
+          });
+          final b = Producer.fromJson({
+            'id': null,
+            'name': 'A',
+            'location': 'X',
+            'products': [],
+          });
+          expect(a, isNot(equals(b)));
+        });
       });
     });
 

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -595,6 +595,61 @@ void main() {
         expect(product.isAllergenFree, isFalse);
       });
     });
+
+    group('equality', () {
+      test('two products with the same id are equal', () {
+        final a = Product.fromJson({
+          'id': 'p1',
+          'name': 'A',
+          'category': 'beer',
+          'dispense': 'cask',
+          'abv': '4.0',
+        });
+        final b = Product.fromJson({
+          'id': 'p1',
+          'name': 'B',
+          'category': 'cider',
+          'dispense': 'keg',
+          'abv': '5.0',
+        });
+        expect(a, equals(b));
+        expect(a.hashCode, b.hashCode);
+      });
+      test('products with different ids are not equal', () {
+        final a = Product.fromJson({
+          'id': 'p1',
+          'name': 'A',
+          'category': 'beer',
+          'dispense': 'cask',
+          'abv': '4.0',
+        });
+        final b = Product.fromJson({
+          'id': 'p2',
+          'name': 'A',
+          'category': 'beer',
+          'dispense': 'cask',
+          'abv': '4.0',
+        });
+        expect(a, isNot(equals(b)));
+      });
+      test('product is usable in a Set', () {
+        final a = Product.fromJson({
+          'id': 'p1',
+          'name': 'A',
+          'category': 'beer',
+          'dispense': 'cask',
+          'abv': '4.0',
+        });
+        final b = Product.fromJson({
+          'id': 'p1',
+          'name': 'B',
+          'category': 'cider',
+          'dispense': 'keg',
+          'abv': '5.0',
+        });
+        expect({a, b}.length, 1);
+      });
+    });
   });
 
   group('Producer', () {
@@ -758,6 +813,55 @@ void main() {
 
         expect(json.containsKey('year_founded'), isFalse);
         expect(json.containsKey('notes'), isFalse);
+      });
+    });
+
+    group('equality', () {
+      test('two producers with the same id are equal', () {
+        final a = Producer.fromJson({
+          'id': 'b1',
+          'name': 'A',
+          'location': 'X',
+          'products': [],
+        });
+        final b = Producer.fromJson({
+          'id': 'b1',
+          'name': 'B',
+          'location': 'Y',
+          'products': [],
+        });
+        expect(a, equals(b));
+        expect(a.hashCode, b.hashCode);
+      });
+      test('producers with different ids are not equal', () {
+        final a = Producer.fromJson({
+          'id': 'b1',
+          'name': 'A',
+          'location': 'X',
+          'products': [],
+        });
+        final b = Producer.fromJson({
+          'id': 'b2',
+          'name': 'A',
+          'location': 'X',
+          'products': [],
+        });
+        expect(a, isNot(equals(b)));
+      });
+      test('producer is usable in a Set', () {
+        final a = Producer.fromJson({
+          'id': 'b1',
+          'name': 'A',
+          'location': 'X',
+          'products': [],
+        });
+        final b = Producer.fromJson({
+          'id': 'b1',
+          'name': 'B',
+          'location': 'Y',
+          'products': [],
+        });
+        expect({a, b}.length, 1);
       });
     });
   });
@@ -1064,6 +1168,57 @@ void main() {
         );
 
         expect(drink1.isSameBrewery(drink2), isFalse);
+      });
+    });
+
+    group('equality', () {
+      test(
+        'drinks with same product id and festival id are equal regardless of mutable state',
+        () {
+          final d1 = Drink(
+            product: testProduct,
+            producer: testProducer,
+            festivalId: 'cbf2025',
+            isFavorite: true,
+          );
+          final d2 = Drink(
+            product: testProduct,
+            producer: testProducer,
+            festivalId: 'cbf2025',
+            isFavorite: false,
+          );
+          expect(d1, equals(d2));
+          expect(d1.hashCode, d2.hashCode);
+        },
+      );
+      test(
+        'drinks with same product id but different festival id are not equal',
+        () {
+          final d1 = Drink(
+            product: testProduct,
+            producer: testProducer,
+            festivalId: 'cbf2025',
+          );
+          final d2 = Drink(
+            product: testProduct,
+            producer: testProducer,
+            festivalId: 'cbf2026',
+          );
+          expect(d1, isNot(equals(d2)));
+        },
+      );
+      test('drink is usable in a Set', () {
+        final d1 = Drink(
+          product: testProduct,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+        );
+        final d2 = Drink(
+          product: testProduct,
+          producer: testProducer,
+          festivalId: 'cbf2025',
+        );
+        expect({d1, d2}.length, 1);
       });
     });
   });

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1310,7 +1310,7 @@ void main() {
           festivalId: 'cbf2025',
         );
         expect(d1, isNot(equals(d2)));
-        // Verify hashCode is also distinct (exercises the identityHashCode path)
+        // Set insertion exercises both == and hashCode; length 2 confirms they are distinct
         expect({d1, d2}.length, 2);
       });
     });


### PR DESCRIPTION
## Summary

- Adds `==` and `hashCode` to `Producer` (keyed on `id`)
- Adds `==` and `hashCode` to `Product` (keyed on `id`)
- Adds `==` and `hashCode` to `Drink` (keyed on `product.id + festivalId`) — intentionally excludes mutable UI state fields (`isFavorite`, `rating`, `isTasted`) so the hash is stable across `copyWith` mutations
- Adds equality test groups for all three classes covering: same-id equality, different-id inequality, and `Set` membership

## Test plan

- [ ] `./bin/mise run check` passes (generate → analyze → test)
- [ ] Two `Drink` objects with the same product ID and festival ID compare equal even when `isFavorite` differs
- [ ] `Set<Drink>` deduplicates correctly on identity fields

Fixes #323

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRmoRgJPpz9v9XqPufEMxC)_