### PR TITLE
fix(provider): don't update lastDrinksRefresh when festival has no types

### DIFF
--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -454,10 +454,13 @@ class BeerProvider extends ChangeNotifier {
       _refreshNotice = null;
       // Only mark drinks as freshly fetched when the festival had types to
       // request. If availableBeverageTypes is empty, Future.wait([]) succeeds
-      // trivially with no network contact, so updating the timestamp would
-      // suppress retries for an hour with no user-visible error.
+      // trivially with no network contact; reset the timestamp so that
+      // isDrinksDataStale stays true and refreshIfStale can retry once the
+      // rate-limit window passes (e.g. after switching from a loaded festival).
       if (festival.availableBeverageTypes.isNotEmpty) {
         _lastDrinksRefresh = DateTime.now();
+      } else {
+        _lastDrinksRefresh = null;
       }
     } catch (e, stackTrace) {
       if (token != _drinksLoadToken) return;

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -452,7 +452,13 @@ class BeerProvider extends ChangeNotifier {
       _filter.setSource(_allDrinks);
       _error = null;
       _refreshNotice = null;
-      _lastDrinksRefresh = DateTime.now();
+      // Only mark drinks as freshly fetched when the festival had types to
+      // request. If availableBeverageTypes is empty, Future.wait([]) succeeds
+      // trivially with no network contact, so updating the timestamp would
+      // suppress retries for an hour with no user-visible error.
+      if (festival.availableBeverageTypes.isNotEmpty) {
+        _lastDrinksRefresh = DateTime.now();
+      }
     } catch (e, stackTrace) {
       if (token != _drinksLoadToken) return;
       final haveData = _allDrinks.isNotEmpty;

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -2342,6 +2342,34 @@ void main() {
       );
 
       test(
+        'resets lastDrinksRefresh when switching to a festival with no types',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+
+          when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
+
+          // Load a normal festival first to set _lastDrinksRefresh.
+          await provider.loadDrinks();
+          expect(provider.lastDrinksRefresh, isNotNull);
+
+          // Switch to a festival with no types — timestamp must be cleared.
+          final emptyFestival = createSampleFestival(
+            id: 'cbf-empty',
+            availableBeverageTypes: [],
+          );
+          await provider.setFestival(emptyFestival, persist: false);
+
+          expect(provider.lastDrinksRefresh, isNull);
+          expect(provider.isDrinksDataStale, isTrue);
+        },
+      );
+
+      test(
         'updates lastDrinksRefresh when festival has beverage types',
         () async {
           provider = BeerProvider(

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -2317,6 +2317,47 @@ void main() {
           verify(mockDrinkRepository.getDrinks(any)).called(1);
         },
       );
+
+      test(
+        'does not update lastDrinksRefresh when festival has no beverage types',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+
+          when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
+
+          final emptyFestival = createSampleFestival(
+            id: 'cbf-empty',
+            availableBeverageTypes: [],
+          );
+          await provider.setFestival(emptyFestival, persist: false);
+
+          expect(provider.isDrinksDataStale, isTrue);
+          expect(provider.lastDrinksRefresh, isNull);
+        },
+      );
+
+      test(
+        'updates lastDrinksRefresh when festival has beverage types',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+
+          when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
+          await provider.loadDrinks();
+
+          expect(provider.lastDrinksRefresh, isNotNull);
+          expect(provider.isDrinksDataStale, isFalse);
+        },
+      );
     });
 
     group('tasted, refresh and favourite filtering', () {


### PR DESCRIPTION
## Summary

When `festival.availableBeverageTypes` is `[]`, `Future.wait([])` resolves immediately with both `drinksByType` and `failedTypes` empty. `FestivalDrinksResult.isCompleteFailure` is `false` (requires `failedTypes.isNotEmpty`), so `throwIfCompleteFailure` no-ops and `getDrinks` returns with no error. `BeerProvider` then set `_lastDrinksRefresh = DateTime.now()`, making `isDrinksDataStale` false for an hour — locking users to stale cached data with no error signal and suppressing `refreshIfStale` retries.

**Fix:** In `BeerProvider._refreshDrinksFromNetwork`, only update `_lastDrinksRefresh` when the festival had types to fetch. If `availableBeverageTypes` is empty, `Future.wait([])` made no network contact, so the timestamp should not advance.

## Test plan

- [ ] `./bin/mise run check` passes (generate → analyze → test)
- [ ] After `setFestival` with a festival that has `availableBeverageTypes: []`, `isDrinksDataStale` remains `true` and `lastDrinksRefresh` stays `null`
- [ ] Normal festival load still sets `lastDrinksRefresh` and returns `isDrinksDataStale == false`

Fixes #308

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRmoRgJPpz9v9XqPufEMxC)_