### PR TITLE
chore(analysis): add code complexity lint rules and promote to CI warnings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,12 +1,28 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  language:
+    strict-casts: true
+  errors:
+    dead_code: error
+    unused_element: warning
+    unused_local_variable: warning
+    cascade_invocations: warning
+    unnecessary_lambdas: warning
+    avoid_positional_boolean_parameters: warning
+    always_declare_return_types: warning
+    require_trailing_commas: warning
+
 linter:
   rules:
     prefer_const_constructors: true
     prefer_const_declarations: true
     prefer_final_fields: true
     prefer_final_locals: true
-    avoid_print: true
     prefer_single_quotes: true
-    sort_child_properties_last: true
-    use_key_in_widget_constructors: true
+    # Code structure
+    always_declare_return_types: true
+    avoid_positional_boolean_parameters: true
+    cascade_invocations: true
+    require_trailing_commas: true
+    unnecessary_lambdas: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,12 +1,23 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  language:
+    strict-casts: true
+  errors:
+    dead_code: error
+    unused_element: warning
+    unused_local_variable: warning
+
 linter:
   rules:
     prefer_const_constructors: true
     prefer_const_declarations: true
     prefer_final_fields: true
     prefer_final_locals: true
-    avoid_print: true
     prefer_single_quotes: true
-    sort_child_properties_last: true
-    use_key_in_widget_constructors: true
+    # Code structure
+    always_declare_return_types: true
+    avoid_positional_boolean_parameters: true
+    cascade_invocations: true
+    require_trailing_commas: true
+    unnecessary_lambdas: true

--- a/lib/domain/controllers/drink_filter_controller.dart
+++ b/lib/domain/controllers/drink_filter_controller.dart
@@ -57,9 +57,7 @@ class DrinkFilterController {
 
   /// Unique categories present in the source drinks, sorted.
   List<String> get availableCategories {
-    final categories = _source.map((d) => d.category).toSet().toList();
-    categories.sort();
-    return categories;
+    return _source.map((d) => d.category).toSet().toList()..sort();
   }
 
   /// Unique styles in the source drinks, narrowed to the selected category when
@@ -68,13 +66,12 @@ class DrinkFilterController {
   /// human-friendly way regardless of capitalisation. Presentation consumes
   /// this directly — no sorting in the UI.
   List<String> get availableStyles {
-    final styles = _categoryScopedSource()
+    return _categoryScopedSource()
         .where((d) => d.style != null && d.style!.isNotEmpty)
         .map((d) => d.style!)
         .toSet()
-        .toList();
-    styles.sort(StringComparisonHelper.compareLocaleAware);
-    return styles;
+        .toList()
+      ..sort(StringComparisonHelper.compareLocaleAware);
   }
 
   /// Drink count per category across the full source.
@@ -171,13 +168,16 @@ class DrinkFilterController {
   }
 
   /// Toggle the favourites-only filter.
-  void setShowFavoritesOnly(bool value) {
+  void setShowFavoritesOnly({required bool value}) {
     _showFavoritesOnly = value;
     recompute();
   }
 
   /// Turn a visibility filter on or off.
-  void setVisibilityFilter(DrinkVisibilityFilter filter, bool active) {
+  void setVisibilityFilter(
+    DrinkVisibilityFilter filter, {
+    required bool active,
+  }) {
     if (active) {
       _visibilityFilters = Set.from(_visibilityFilters)..add(filter);
     } else {
@@ -193,7 +193,7 @@ class DrinkFilterController {
   }
 
   /// Turn a per-allergen exclusion on or off.
-  void setAllergenFilter(String allergen, bool active) {
+  void setAllergenFilter(String allergen, {required bool active}) {
     if (active) {
       _excludedAllergens = Set.from(_excludedAllergens)..add(allergen);
     } else {

--- a/lib/domain/services/drink_filter_service.dart
+++ b/lib/domain/services/drink_filter_service.dart
@@ -29,9 +29,9 @@ class DrinkFilterService {
   /// Returns all drinks if [favoritesOnly] is false
   /// Uses lazy evaluation - call .toList() to materialize
   Iterable<Drink> filterByFavorites(
-    Iterable<Drink> drinks,
-    bool favoritesOnly,
-  ) {
+    Iterable<Drink> drinks, {
+    required bool favoritesOnly,
+  }) {
     if (!favoritesOnly) return drinks;
     return drinks.where((d) => d.isFavorite);
   }
@@ -42,9 +42,9 @@ class DrinkFilterService {
   /// Returns all drinks if [hideUnavailable] is false
   /// Uses lazy evaluation - call .toList() to materialize
   Iterable<Drink> filterByAvailability(
-    Iterable<Drink> drinks,
-    bool hideUnavailable,
-  ) {
+    Iterable<Drink> drinks, {
+    required bool hideUnavailable,
+  }) {
     if (!hideUnavailable) return drinks;
     return drinks.where((d) => d.availabilityStatus != AvailabilityStatus.out);
   }
@@ -54,9 +54,9 @@ class DrinkFilterService {
   /// Returns all drinks if [notTastedOnly] is false
   /// Uses lazy evaluation - call .toList() to materialize
   Iterable<Drink> filterByNotTasted(
-    Iterable<Drink> drinks,
-    bool notTastedOnly,
-  ) {
+    Iterable<Drink> drinks, {
+    required bool notTastedOnly,
+  }) {
     if (!notTastedOnly) return drinks;
     return drinks.where((d) => !d.isTasted);
   }
@@ -67,7 +67,10 @@ class DrinkFilterService {
   /// Drinks with null (unknown) vegan status are excluded.
   /// Returns all drinks if [veganOnly] is false
   /// Uses lazy evaluation - call .toList() to materialize
-  Iterable<Drink> filterByVegan(Iterable<Drink> drinks, bool veganOnly) {
+  Iterable<Drink> filterByVegan(
+    Iterable<Drink> drinks, {
+    required bool veganOnly,
+  }) {
     if (!veganOnly) return drinks;
     return drinks.where((d) => d.isVegan == true);
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -170,8 +170,7 @@ class _ProviderInitializerState extends State<ProviderInitializer>
 
     // When app resumes to foreground, refresh data if stale
     if (state == AppLifecycleState.resumed) {
-      final provider = context.read<BeerProvider>();
-      provider.refreshIfStale();
+      context.read<BeerProvider>().refreshIfStale();
     }
   }
 

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -109,13 +109,15 @@ class Product {
     final allergens = <String, int>{};
     if (allergensRaw is Map) {
       for (final entry in allergensRaw.entries) {
+        if (entry.key is! String) continue;
+        final key = entry.key as String;
         final value = entry.value;
         if (value is int) {
-          allergens[entry.key] = value;
+          allergens[key] = value;
         } else if (value is bool) {
-          allergens[entry.key] = value ? 1 : 0;
+          allergens[key] = value ? 1 : 0;
         } else if (value is num) {
-          allergens[entry.key] = value.toInt();
+          allergens[key] = value.toInt();
         }
         // Other types (String, null, etc.) are skipped as invalid allergen flags
       }
@@ -317,8 +319,8 @@ class Drink {
   /// - With rating: "Drinking {name} from {brewery} at {hashtag} - {n} stars"
   /// - With url: above + "\n{url}"
   String getShareMessage(String hashtag, {String? url}) {
-    final buffer = StringBuffer();
-    buffer.write('Drinking $name from $breweryName at $hashtag');
+    final buffer = StringBuffer()
+      ..write('Drinking $name from $breweryName at $hashtag');
     if (rating != null) {
       buffer.write(' - $rating stars');
     }

--- a/lib/models/drink.dart
+++ b/lib/models/drink.dart
@@ -109,13 +109,15 @@ class Product {
     final allergens = <String, int>{};
     if (allergensRaw is Map) {
       for (final entry in allergensRaw.entries) {
+        if (entry.key is! String) continue;
+        final key = entry.key as String;
         final value = entry.value;
         if (value is int) {
-          allergens[entry.key] = value;
+          allergens[key] = value;
         } else if (value is bool) {
-          allergens[entry.key] = value ? 1 : 0;
+          allergens[key] = value ? 1 : 0;
         } else if (value is num) {
-          allergens[entry.key] = value.toInt();
+          allergens[key] = value.toInt();
         }
         // Other types (String, null, etc.) are skipped as invalid allergen flags
       }

--- a/lib/models/festival.dart
+++ b/lib/models/festival.dart
@@ -186,9 +186,7 @@ class Festival {
   /// then past (most recent first)
   static List<Festival> sortByDate(List<Festival> festivals, [DateTime? now]) {
     final currentDate = now ?? DateTime.now();
-    final sorted = List<Festival>.from(festivals);
-
-    sorted.sort((a, b) {
+    return List<Festival>.from(festivals)..sort((a, b) {
       final statusA = a.getBasicStatus(currentDate);
       final statusB = b.getBasicStatus(currentDate);
 
@@ -231,8 +229,6 @@ class Festival {
 
       return 0;
     });
-
-    return sorted;
   }
 
   /// Get the status of a festival in the context of a sorted list

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -616,23 +616,23 @@ class BeerProvider extends ChangeNotifier {
   }
 
   /// Toggle showing favorites only
-  void setShowFavoritesOnly(bool value) {
-    _filter.setShowFavoritesOnly(value);
+  void setShowFavoritesOnly({required bool value}) {
+    _filter.setShowFavoritesOnly(value: value);
     notifyListeners();
   }
 
   /// Toggle hiding unavailable drinks and persist preference
   ///
   /// Convenience wrapper around [setVisibilityFilter] for backward compatibility.
-  Future<void> setHideUnavailable(bool value) =>
-      setVisibilityFilter(DrinkVisibilityFilter.availableOnly, value);
+  Future<void> setHideUnavailable({required bool value}) =>
+      setVisibilityFilter(DrinkVisibilityFilter.availableOnly, active: value);
 
   /// Set a visibility filter on or off and persist the preference
   Future<void> setVisibilityFilter(
-    DrinkVisibilityFilter filter,
-    bool active,
-  ) async {
-    _filter.setVisibilityFilter(filter, active);
+    DrinkVisibilityFilter filter, {
+    required bool active,
+  }) async {
+    _filter.setVisibilityFilter(filter, active: active);
     notifyListeners();
     await _persistVisibilityFilters();
   }
@@ -645,8 +645,11 @@ class BeerProvider extends ChangeNotifier {
   }
 
   /// Toggle a per-allergen exclusion filter and persist
-  Future<void> setAllergenFilter(String allergen, bool active) async {
-    _filter.setAllergenFilter(allergen, active);
+  Future<void> setAllergenFilter(
+    String allergen, {
+    required bool active,
+  }) async {
+    _filter.setAllergenFilter(allergen, active: active);
     notifyListeners();
     await _persistExcludedAllergens();
   }

--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -46,7 +46,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
         children: [
           Expanded(
             child: RefreshIndicator(
-              onRefresh: () => provider.loadDrinks(),
+              onRefresh: provider.loadDrinks,
               child: CustomScrollView(
                 slivers: [
                   SliverAppBar(
@@ -297,7 +297,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
                 button: true,
                 excludeSemantics: true,
                 child: ElevatedButton(
-                  onPressed: () => provider.loadDrinks(),
+                  onPressed: provider.loadDrinks,
                   child: const Text('Retry'),
                 ),
               ),

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -44,7 +44,10 @@ class AnalyticsService {
 
   /// Log app launch event
   Future<void> logAppLaunch() async {
-    await _logIfEnabled(() => analytics.logAppOpen(), showDebug: true);
+    await _logIfEnabled(
+      () => analytics.logAppOpen(),
+      showDebug: true,
+    ); // ignore: unnecessary_lambdas
   }
 
   /// Log festival selection

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -45,9 +45,9 @@ class AnalyticsService {
   /// Log app launch event
   Future<void> logAppLaunch() async {
     await _logIfEnabled(
-      () => analytics.logAppOpen(),
+      () => analytics.logAppOpen(), // ignore: unnecessary_lambdas
       showDebug: true,
-    ); // ignore: unnecessary_lambdas
+    );
   }
 
   /// Log festival selection

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -19,15 +19,13 @@ class FavoritesService {
 
   /// Add a drink to favorites
   Future<void> addFavorite(String festivalId, String drinkId) async {
-    final favorites = getFavorites(festivalId);
-    favorites.add(drinkId);
+    final favorites = getFavorites(festivalId)..add(drinkId);
     await _saveFavorites(festivalId, favorites);
   }
 
   /// Remove a drink from favorites
   Future<void> removeFavorite(String festivalId, String drinkId) async {
-    final favorites = getFavorites(festivalId);
-    favorites.remove(drinkId);
+    final favorites = getFavorites(festivalId)..remove(drinkId);
     await _saveFavorites(festivalId, favorites);
   }
 

--- a/lib/widgets/drink_card.dart
+++ b/lib/widgets/drink_card.dart
@@ -152,9 +152,9 @@ class DrinkCard extends StatelessWidget {
   }
 
   String _buildCardSemanticLabel() {
-    final buffer = StringBuffer();
-    buffer.write(drink.name);
-    buffer.write(', ${drink.abv.toStringAsFixed(1)} percent ABV');
+    final buffer = StringBuffer()
+      ..write(drink.name)
+      ..write(', ${drink.abv.toStringAsFixed(1)} percent ABV');
     if (drink.style != null) {
       buffer.write(', ${drink.style}');
     }

--- a/lib/widgets/drink_filter_sheets.dart
+++ b/lib/widgets/drink_filter_sheets.dart
@@ -393,7 +393,7 @@ class VisibilityFilterSheet extends StatelessWidget {
                         ),
                         onChanged: (value) => beerProvider.setVisibilityFilter(
                           DrinkVisibilityFilter.availableOnly,
-                          value ?? false,
+                          active: value ?? false,
                         ),
                       ),
                       VisibilityFilterTile(
@@ -405,7 +405,7 @@ class VisibilityFilterSheet extends StatelessWidget {
                         ),
                         onChanged: (value) => beerProvider.setVisibilityFilter(
                           DrinkVisibilityFilter.notTasted,
-                          value ?? false,
+                          active: value ?? false,
                         ),
                       ),
                       VisibilityFilterTile(
@@ -417,7 +417,7 @@ class VisibilityFilterSheet extends StatelessWidget {
                         ),
                         onChanged: (value) => beerProvider.setVisibilityFilter(
                           DrinkVisibilityFilter.veganOnly,
-                          value ?? false,
+                          active: value ?? false,
                         ),
                       ),
                       if (beerProvider.availableAllergens.isNotEmpty) ...[
@@ -447,8 +447,11 @@ class VisibilityFilterSheet extends StatelessWidget {
                             isChecked: beerProvider.excludedAllergens.contains(
                               allergen,
                             ),
-                            onChanged: (value) => beerProvider
-                                .setAllergenFilter(allergen, value ?? false),
+                            onChanged: (value) =>
+                                beerProvider.setAllergenFilter(
+                                  allergen,
+                                  active: value ?? false,
+                                ),
                           ),
                       ],
                     ],

--- a/lib/widgets/festival_menu_sheets.dart
+++ b/lib/widgets/festival_menu_sheets.dart
@@ -141,7 +141,7 @@ class FestivalSelectorSheet extends StatelessWidget {
                               hint: 'Double tap to reload festival list',
                               button: true,
                               child: FilledButton.icon(
-                                onPressed: () => provider.loadFestivals(),
+                                onPressed: provider.loadFestivals,
                                 icon: const Icon(Icons.refresh),
                                 label: const Text('Retry'),
                               ),
@@ -172,7 +172,7 @@ class FestivalSelectorSheet extends StatelessWidget {
                               hint: 'Double tap to reload festival list',
                               button: true,
                               child: FilledButton.icon(
-                                onPressed: () => provider.loadFestivals(),
+                                onPressed: provider.loadFestivals,
                                 icon: const Icon(Icons.refresh),
                                 label: const Text('Refresh'),
                               ),

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -354,8 +354,9 @@ void main() {
         ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
-        provider.toggleStyle('IPA');
-        provider.toggleStyle('IPA');
+        provider
+          ..toggleStyle('IPA')
+          ..toggleStyle('IPA');
 
         expect(provider.selectedStyles, isEmpty);
         expect(provider.drinks.length, 4);
@@ -375,8 +376,9 @@ void main() {
         ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
-        provider.toggleStyle('IPA');
-        provider.toggleStyle('Bitter');
+        provider
+          ..toggleStyle('IPA')
+          ..toggleStyle('Bitter');
 
         expect(provider.selectedStyles.length, 2);
         expect(provider.drinks.length, 2);
@@ -396,9 +398,10 @@ void main() {
         ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
-        provider.toggleStyle('IPA');
-        provider.toggleStyle('Bitter');
-        provider.clearStyles();
+        provider
+          ..toggleStyle('IPA')
+          ..toggleStyle('Bitter')
+          ..clearStyles();
 
         expect(provider.selectedStyles, isEmpty);
         expect(provider.drinks.length, 4);
@@ -710,7 +713,7 @@ void main() {
         await provider.toggleFavorite(provider.allDrinks[0]);
         await provider.toggleFavorite(provider.allDrinks[2]);
 
-        provider.setShowFavoritesOnly(true);
+        provider.setShowFavoritesOnly(value: true);
 
         expect(provider.drinks.length, 2);
         expect(provider.drinks.every((d) => d.isFavorite), isTrue);
@@ -821,7 +824,7 @@ void main() {
         expect(provider.drinks.length, 3);
 
         // Enable hide unavailable
-        await provider.setHideUnavailable(true);
+        await provider.setHideUnavailable(value: true);
 
         // Sold out drink should be filtered out
         expect(provider.drinks.length, 2);
@@ -885,7 +888,7 @@ void main() {
 
           expect(provider.drinks.length, 2);
 
-          await provider.setHideUnavailable(true);
+          await provider.setHideUnavailable(value: true);
 
           // 'Not yet available' resolves to unknown, so both drinks remain.
           expect(provider.drinks.length, 2);
@@ -912,7 +915,7 @@ void main() {
         await provider.loadDrinks();
 
         // Set hide unavailable via convenience wrapper
-        await provider.setHideUnavailable(true);
+        await provider.setHideUnavailable(value: true);
         expect(provider.hideUnavailable, isTrue);
         expect(
           provider.visibilityFilters.contains(
@@ -930,7 +933,7 @@ void main() {
         expect(prefs.getBool('hideUnavailable'), isNull);
 
         // Disable it
-        await provider.setHideUnavailable(false);
+        await provider.setHideUnavailable(value: false);
         expect(provider.hideUnavailable, isFalse);
         expect(
           prefs.getStringList('visibilityFilters'),
@@ -992,11 +995,11 @@ void main() {
 
           await provider.setVisibilityFilter(
             DrinkVisibilityFilter.veganOnly,
-            true,
+            active: true,
           );
           await provider.setVisibilityFilter(
             DrinkVisibilityFilter.notTasted,
-            true,
+            active: true,
           );
 
           expect(
@@ -1012,7 +1015,7 @@ void main() {
           // Turn off vegan only, notTasted should remain
           await provider.setVisibilityFilter(
             DrinkVisibilityFilter.veganOnly,
-            false,
+            active: false,
           );
           expect(
             provider.visibilityFilters,
@@ -1044,7 +1047,7 @@ void main() {
 
         await provider.setVisibilityFilter(
           DrinkVisibilityFilter.notTasted,
-          true,
+          active: true,
         );
 
         expect(provider.drinks.any((d) => d.isTasted), isFalse);
@@ -1068,7 +1071,7 @@ void main() {
 
           await provider.setVisibilityFilter(
             DrinkVisibilityFilter.notTasted,
-            true,
+            active: true,
           );
           expect(provider.drinks.length, sampleDrinks.length);
 
@@ -1136,7 +1139,7 @@ void main() {
 
         await provider.setVisibilityFilter(
           DrinkVisibilityFilter.veganOnly,
-          true,
+          active: true,
         );
 
         expect(provider.drinks.length, 1);
@@ -1226,7 +1229,7 @@ void main() {
           await provider.loadDrinks();
 
           expect(provider.drinks.length, 3);
-          await provider.setAllergenFilter('gluten', true);
+          await provider.setAllergenFilter('gluten', active: true);
 
           expect(provider.drinks.length, 2);
           expect(
@@ -1242,8 +1245,8 @@ void main() {
         ).thenAnswer((_) async => [glutenDrink, sulphiteDrink, cleanDrink]);
         await provider.loadDrinks();
 
-        await provider.setAllergenFilter('gluten', true);
-        await provider.setAllergenFilter('sulphites', true);
+        await provider.setAllergenFilter('gluten', active: true);
+        await provider.setAllergenFilter('sulphites', active: true);
 
         expect(provider.drinks.length, 1);
         expect(provider.drinks[0].name, equals('Clean Ale'));
@@ -1255,7 +1258,7 @@ void main() {
         ).thenAnswer((_) async => [glutenDrink, cleanDrink]);
         await provider.loadDrinks();
 
-        await provider.setAllergenFilter('gluten', true);
+        await provider.setAllergenFilter('gluten', active: true);
         expect(provider.drinks.length, 1);
 
         await provider.clearAllergenFilters();
@@ -1271,10 +1274,10 @@ void main() {
           ).thenAnswer((_) async => [glutenDrink, cleanDrink]);
           await provider.loadDrinks();
 
-          await provider.setAllergenFilter('gluten', true);
+          await provider.setAllergenFilter('gluten', active: true);
           expect(provider.drinks.length, 1);
 
-          await provider.setAllergenFilter('gluten', false);
+          await provider.setAllergenFilter('gluten', active: false);
           expect(provider.drinks.length, 2);
           expect(provider.excludedAllergens, isEmpty);
         },
@@ -1283,11 +1286,11 @@ void main() {
       test('clearVisibilityFilters removes all visibility filters', () async {
         await provider.setVisibilityFilter(
           DrinkVisibilityFilter.availableOnly,
-          true,
+          active: true,
         );
         await provider.setVisibilityFilter(
           DrinkVisibilityFilter.notTasted,
-          true,
+          active: true,
         );
         expect(provider.visibilityFilters.length, 2);
 
@@ -1302,8 +1305,8 @@ void main() {
       test(
         'excludedAllergens persisted and restored on initialization',
         () async {
-          await provider.setAllergenFilter('gluten', true);
-          await provider.setAllergenFilter('sulphites', true);
+          await provider.setAllergenFilter('gluten', active: true);
+          await provider.setAllergenFilter('sulphites', active: true);
 
           final prefs = await SharedPreferences.getInstance();
           expect(
@@ -1582,8 +1585,9 @@ void main() {
         ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
-        provider.setCategory('beer');
-        provider.toggleStyle('IPA');
+        provider
+          ..setCategory('beer')
+          ..toggleStyle('IPA');
 
         expect(provider.drinks.length, 1);
         expect(provider.drinks.first.name, 'Alpha Ale');
@@ -1603,8 +1607,9 @@ void main() {
         ).thenAnswer((_) async => sampleDrinks);
         await provider.loadDrinks();
 
-        provider.setCategory('beer');
-        provider.setSearchQuery('alpha');
+        provider
+          ..setCategory('beer')
+          ..setSearchQuery('alpha');
 
         expect(provider.drinks.length, 1);
         expect(provider.drinks.first.name, 'Alpha Ale');
@@ -2223,12 +2228,13 @@ void main() {
             mockFestivalRepository.getCachedFestivals(),
           ).thenAnswer((_) async => null);
 
-          // Simulate a stale attempt by backdating the timestamp.
-          provider.lastFestivalsRefreshAttempt = DateTime.now().subtract(
-            const Duration(minutes: 2),
-          );
-          // Suppress drinks retry so loadDrinks() doesn't re-trigger loadFestivals().
-          provider.lastDrinksRefreshAttempt = DateTime.now();
+          provider
+            // Simulate a stale attempt by backdating the timestamp.
+            ..lastFestivalsRefreshAttempt = DateTime.now().subtract(
+              const Duration(minutes: 2),
+            )
+            // Suppress drinks retry so loadDrinks() doesn't re-trigger loadFestivals().
+            ..lastDrinksRefreshAttempt = DateTime.now();
 
           expect(provider.isFestivalsDataStale, isTrue);
 
@@ -2562,7 +2568,7 @@ void main() {
           ).thenAnswer((_) async => createSampleDrinks());
           await provider.loadDrinks();
 
-          provider.setShowFavoritesOnly(true);
+          provider.setShowFavoritesOnly(value: true);
           expect(provider.showFavoritesOnly, isTrue);
           expect(provider.drinks, isEmpty);
 

--- a/test/domain/controllers/drink_filter_controller_test.dart
+++ b/test/domain/controllers/drink_filter_controller_test.dart
@@ -103,16 +103,18 @@ void main() {
       });
 
       test('empty source yields empty filtered list', () {
-        controller.setSource(_sampleDrinks());
-        controller.setSource([]);
+        controller
+          ..setSource(_sampleDrinks())
+          ..setSource([]);
         expect(controller.filteredDrinks, isEmpty);
       });
     });
 
     group('category filter', () {
       test('narrows filtered drinks to the selected category', () {
-        controller.setSource(_sampleDrinks());
-        controller.setCategory('cider');
+        controller
+          ..setSource(_sampleDrinks())
+          ..setCategory('cider');
         expect(controller.filteredDrinks.map((d) => d.name), [
           'Crisp Cider',
           'Zesty Zider',
@@ -120,9 +122,10 @@ void main() {
       });
 
       test('setting category clears any active style filter', () {
-        controller.setSource(_sampleDrinks());
-        controller.setCategory('beer');
-        controller.toggleStyle('IPA');
+        controller
+          ..setSource(_sampleDrinks())
+          ..setCategory('beer')
+          ..toggleStyle('IPA');
         expect(controller.selectedStyles, {'IPA'});
 
         controller.setCategory('cider');
@@ -130,17 +133,19 @@ void main() {
       });
 
       test('null category shows all categories again', () {
-        controller.setSource(_sampleDrinks());
-        controller.setCategory('beer');
-        controller.setCategory(null);
+        controller
+          ..setSource(_sampleDrinks())
+          ..setCategory('beer')
+          ..setCategory(null);
         expect(controller.filteredDrinks, hasLength(4));
       });
     });
 
     group('style filter', () {
       test('toggleStyle adds then removes a style', () {
-        controller.setSource(_sampleDrinks());
-        controller.toggleStyle('IPA');
+        controller
+          ..setSource(_sampleDrinks())
+          ..toggleStyle('IPA');
         expect(controller.selectedStyles, {'IPA'});
         expect(controller.filteredDrinks.map((d) => d.name), ['Alpha Ale']);
 
@@ -150,9 +155,10 @@ void main() {
       });
 
       test('multiple styles use OR logic', () {
-        controller.setSource(_sampleDrinks());
-        controller.toggleStyle('IPA');
-        controller.toggleStyle('Dry');
+        controller
+          ..setSource(_sampleDrinks())
+          ..toggleStyle('IPA')
+          ..toggleStyle('Dry');
         expect(controller.selectedStyles, {'IPA', 'Dry'});
         expect(controller.filteredDrinks.map((d) => d.name), [
           'Alpha Ale',
@@ -161,9 +167,10 @@ void main() {
       });
 
       test('clearStyles removes all style filters', () {
-        controller.setSource(_sampleDrinks());
-        controller.toggleStyle('IPA');
-        controller.clearStyles();
+        controller
+          ..setSource(_sampleDrinks())
+          ..toggleStyle('IPA')
+          ..clearStyles();
         expect(controller.selectedStyles, isEmpty);
         expect(controller.filteredDrinks, hasLength(4));
       });
@@ -171,8 +178,9 @@ void main() {
 
     group('search filter', () {
       test('matches name and is stored lower-cased', () {
-        controller.setSource(_sampleDrinks());
-        controller.setSearchQuery('CIDER');
+        controller
+          ..setSource(_sampleDrinks())
+          ..setSearchQuery('CIDER');
         expect(controller.searchQuery, 'cider');
         expect(controller.filteredDrinks.map((d) => d.name), ['Crisp Cider']);
       });
@@ -182,12 +190,12 @@ void main() {
       test('shows only favourites when enabled', () {
         final drinks = _sampleDrinks();
         drinks[0] = drinks[0].copyWith(isFavorite: true);
-        controller.setSource(drinks);
-
-        controller.setShowFavoritesOnly(true);
+        controller
+          ..setSource(drinks)
+          ..setShowFavoritesOnly(value: true);
         expect(controller.filteredDrinks.map((d) => d.name), ['Alpha Ale']);
 
-        controller.setShowFavoritesOnly(false);
+        controller.setShowFavoritesOnly(value: false);
         expect(controller.filteredDrinks, hasLength(4));
       });
     });
@@ -196,7 +204,7 @@ void main() {
       test('setVisibilityFilter toggles membership and hideUnavailable', () {
         controller.setVisibilityFilter(
           DrinkVisibilityFilter.availableOnly,
-          true,
+          active: true,
         );
         expect(
           controller.visibilityFilters,
@@ -206,24 +214,26 @@ void main() {
 
         controller.setVisibilityFilter(
           DrinkVisibilityFilter.availableOnly,
-          false,
+          active: false,
         );
         expect(controller.visibilityFilters, isEmpty);
         expect(controller.hideUnavailable, isFalse);
       });
 
       test('clearVisibilityFilters removes all', () {
-        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
-        controller.setVisibilityFilter(DrinkVisibilityFilter.veganOnly, true);
-        controller.clearVisibilityFilters();
+        controller
+          ..setVisibilityFilter(DrinkVisibilityFilter.notTasted, active: true)
+          ..setVisibilityFilter(DrinkVisibilityFilter.veganOnly, active: true)
+          ..clearVisibilityFilters();
         expect(controller.visibilityFilters, isEmpty);
       });
 
       test('notTasted filter hides tasted drinks', () {
         final drinks = _sampleDrinks();
         drinks[0] = drinks[0].copyWith(isTasted: true);
-        controller.setSource(drinks);
-        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
+        controller
+          ..setSource(drinks)
+          ..setVisibilityFilter(DrinkVisibilityFilter.notTasted, active: true);
         expect(
           controller.filteredDrinks.map((d) => d.name),
           isNot(contains('Alpha Ale')),
@@ -232,7 +242,10 @@ void main() {
       });
 
       test('visibilityFilters getter is unmodifiable', () {
-        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
+        controller.setVisibilityFilter(
+          DrinkVisibilityFilter.notTasted,
+          active: true,
+        );
         expect(
           () =>
               controller.visibilityFilters.add(DrinkVisibilityFilter.veganOnly),
@@ -243,31 +256,33 @@ void main() {
 
     group('allergen filters', () {
       test('excludes drinks containing an excluded allergen', () {
-        controller.setSource([
-          _drink(
-            id: 'a',
-            name: 'Gluten Beer',
-            category: 'beer',
-            allergens: {'gluten': 1},
-          ),
-          _drink(id: 'b', name: 'Clean Beer', category: 'beer'),
-        ]);
-        controller.setAllergenFilter('gluten', true);
+        controller
+          ..setSource([
+            _drink(
+              id: 'a',
+              name: 'Gluten Beer',
+              category: 'beer',
+              allergens: {'gluten': 1},
+            ),
+            _drink(id: 'b', name: 'Clean Beer', category: 'beer'),
+          ])
+          ..setAllergenFilter('gluten', active: true);
         expect(controller.filteredDrinks.map((d) => d.name), ['Clean Beer']);
 
-        controller.setAllergenFilter('gluten', false);
+        controller.setAllergenFilter('gluten', active: false);
         expect(controller.filteredDrinks, hasLength(2));
       });
 
       test('clearAllergenFilters removes all exclusions', () {
-        controller.setAllergenFilter('gluten', true);
-        controller.setAllergenFilter('nuts', true);
-        controller.clearAllergenFilters();
+        controller
+          ..setAllergenFilter('gluten', active: true)
+          ..setAllergenFilter('nuts', active: true)
+          ..clearAllergenFilters();
         expect(controller.excludedAllergens, isEmpty);
       });
 
       test('excludedAllergens getter is unmodifiable', () {
-        controller.setAllergenFilter('gluten', true);
+        controller.setAllergenFilter('gluten', active: true);
         expect(
           () => controller.excludedAllergens.add('nuts'),
           throwsUnsupportedError,
@@ -277,8 +292,9 @@ void main() {
 
     group('sort', () {
       test('setSort reorders the filtered list', () {
-        controller.setSource(_sampleDrinks());
-        controller.setSort(DrinkSort.nameDesc);
+        controller
+          ..setSource(_sampleDrinks())
+          ..setSort(DrinkSort.nameDesc);
         expect(controller.currentSort, DrinkSort.nameDesc);
         expect(controller.filteredDrinks.first.name, 'Zesty Zider');
       });
@@ -301,8 +317,9 @@ void main() {
       });
 
       test('availableStyles narrows to the selected category', () {
-        controller.setSource(_sampleDrinks());
-        controller.setCategory('cider');
+        controller
+          ..setSource(_sampleDrinks())
+          ..setCategory('cider');
         expect(controller.availableStyles, ['Dry', 'Sweet']);
       });
 
@@ -320,8 +337,9 @@ void main() {
       });
 
       test('styleCountsMap narrows to the selected category', () {
-        controller.setSource(_sampleDrinks());
-        controller.setCategory('beer');
+        controller
+          ..setSource(_sampleDrinks())
+          ..setCategory('beer');
         expect(controller.styleCountsMap, {'IPA': 1, 'Bitter': 1});
       });
 
@@ -344,8 +362,9 @@ void main() {
         'reflects favourite change via list replacement when favourites-only',
         () {
           final drinks = _sampleDrinks();
-          controller.setSource(drinks);
-          controller.setShowFavoritesOnly(true);
+          controller
+            ..setSource(drinks)
+            ..setShowFavoritesOnly(value: true);
           expect(controller.filteredDrinks, isEmpty);
 
           // Simulate BeerProvider replacing a list element via copyWith, then
@@ -359,14 +378,14 @@ void main() {
 
     group('clearCategoryStyleSearch', () {
       test('resets category, styles and search but keeps sort/visibility', () {
-        controller.setSource(_sampleDrinks());
-        controller.setCategory('beer');
-        controller.toggleStyle('IPA');
-        controller.setSearchQuery('alpha');
-        controller.setSort(DrinkSort.nameDesc);
-        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
-
-        controller.clearCategoryStyleSearch();
+        controller
+          ..setSource(_sampleDrinks())
+          ..setCategory('beer')
+          ..toggleStyle('IPA')
+          ..setSearchQuery('alpha')
+          ..setSort(DrinkSort.nameDesc)
+          ..setVisibilityFilter(DrinkVisibilityFilter.notTasted, active: true)
+          ..clearCategoryStyleSearch();
 
         expect(controller.selectedCategory, isNull);
         expect(controller.selectedStyles, isEmpty);
@@ -395,22 +414,24 @@ void main() {
       });
 
       test('applies once a source is set', () {
-        controller.hydrate(excludedAllergens: {'gluten'});
-        controller.setSource([
-          _drink(
-            id: 'a',
-            name: 'Gluten',
-            category: 'beer',
-            allergens: {'gluten': 1},
-          ),
-          _drink(id: 'b', name: 'Clean', category: 'beer'),
-        ]);
+        controller
+          ..hydrate(excludedAllergens: {'gluten'})
+          ..setSource([
+            _drink(
+              id: 'a',
+              name: 'Gluten',
+              category: 'beer',
+              allergens: {'gluten': 1},
+            ),
+            _drink(id: 'b', name: 'Clean', category: 'beer'),
+          ]);
         expect(controller.filteredDrinks.map((d) => d.name), ['Clean']);
       });
 
       test('null arguments leave existing state unchanged', () {
-        controller.setVisibilityFilter(DrinkVisibilityFilter.notTasted, true);
-        controller.hydrate();
+        controller
+          ..setVisibilityFilter(DrinkVisibilityFilter.notTasted, active: true)
+          ..hydrate();
         expect(controller.visibilityFilters, {DrinkVisibilityFilter.notTasted});
       });
     });

--- a/test/domain/services/drink_filter_service_test.dart
+++ b/test/domain/services/drink_filter_service_test.dart
@@ -140,7 +140,9 @@ void main() {
         testDrinks[0] = testDrinks[0].copyWith(isFavorite: true);
         testDrinks[2] = testDrinks[2].copyWith(isFavorite: true);
 
-        final result = service.filterByFavorites(testDrinks, true).toList();
+        final result = service
+            .filterByFavorites(testDrinks, favoritesOnly: true)
+            .toList();
         expect(result, hasLength(2));
         expect(result.every((d) => d.isFavorite), isTrue);
       });
@@ -148,12 +150,16 @@ void main() {
       test('returns all drinks when favoritesOnly is false', () {
         testDrinks[0] = testDrinks[0].copyWith(isFavorite: true);
 
-        final result = service.filterByFavorites(testDrinks, false).toList();
+        final result = service
+            .filterByFavorites(testDrinks, favoritesOnly: false)
+            .toList();
         expect(result, hasLength(5));
       });
 
       test('returns empty list when no favorites exist', () {
-        final result = service.filterByFavorites(testDrinks, true).toList();
+        final result = service
+            .filterByFavorites(testDrinks, favoritesOnly: true)
+            .toList();
         expect(result, isEmpty);
       });
     });
@@ -162,7 +168,9 @@ void main() {
       test('hides drinks with status "out"', () {
         // Only AvailabilityStatus.out is hidden; unknown status texts resolve
         // to AvailabilityStatus.unknown and are not filtered out.
-        final result = service.filterByAvailability(testDrinks, true).toList();
+        final result = service
+            .filterByAvailability(testDrinks, hideUnavailable: true)
+            .toList();
         expect(result, hasLength(4));
         expect(
           result.every((d) => d.availabilityStatus != AvailabilityStatus.out),
@@ -174,7 +182,9 @@ void main() {
         // notYetAvailable was a dead enum value — no real festival data used it.
         // "not yet available" is not in the known vocabulary, so it resolves to
         // AvailabilityStatus.unknown and is not filtered out.
-        final result = service.filterByAvailability(testDrinks, true).toList();
+        final result = service
+            .filterByAvailability(testDrinks, hideUnavailable: true)
+            .toList();
         expect(result, hasLength(4));
         expect(
           result.every((d) => d.availabilityStatus != AvailabilityStatus.out),
@@ -183,7 +193,9 @@ void main() {
       });
 
       test('returns all drinks when hideUnavailable is false', () {
-        final result = service.filterByAvailability(testDrinks, false).toList();
+        final result = service
+            .filterByAvailability(testDrinks, hideUnavailable: false)
+            .toList();
         expect(result, hasLength(5));
       });
     });
@@ -193,7 +205,9 @@ void main() {
         testDrinks[0] = testDrinks[0].copyWith(isTasted: true);
         testDrinks[1] = testDrinks[1].copyWith(isTasted: true);
 
-        final result = service.filterByNotTasted(testDrinks, true).toList();
+        final result = service
+            .filterByNotTasted(testDrinks, notTastedOnly: true)
+            .toList();
         expect(result, hasLength(3));
         expect(result.every((d) => !d.isTasted), isTrue);
       });
@@ -201,7 +215,9 @@ void main() {
       test('returns all drinks when notTastedOnly is false', () {
         testDrinks[0] = testDrinks[0].copyWith(isTasted: true);
 
-        final result = service.filterByNotTasted(testDrinks, false).toList();
+        final result = service
+            .filterByNotTasted(testDrinks, notTastedOnly: false)
+            .toList();
         expect(result, hasLength(5));
       });
     });
@@ -209,13 +225,17 @@ void main() {
     group('filterByVegan', () {
       test('shows only vegan drinks', () {
         // product4 has is_vegan: true
-        final result = service.filterByVegan(testDrinks, true).toList();
+        final result = service
+            .filterByVegan(testDrinks, veganOnly: true)
+            .toList();
         expect(result, hasLength(1));
         expect(result[0].isVegan, isTrue);
       });
 
       test('returns all drinks when veganOnly is false', () {
-        final result = service.filterByVegan(testDrinks, false).toList();
+        final result = service
+            .filterByVegan(testDrinks, veganOnly: false)
+            .toList();
         expect(result, hasLength(5));
       });
     });

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -341,12 +341,11 @@ void main() {
       // Reset counter after initial load, then force stale state so that the
       // next refreshIfStale() call actually triggers a network reload.
       getDrinksCalls = 0;
-      provider.lastDrinksRefresh = DateTime.now().subtract(
-        const Duration(hours: 2),
-      );
-      provider.lastDrinksRefreshAttempt = DateTime.now().subtract(
-        const Duration(minutes: 5),
-      );
+      provider
+        ..lastDrinksRefresh = DateTime.now().subtract(const Duration(hours: 2))
+        ..lastDrinksRefreshAttempt = DateTime.now().subtract(
+          const Duration(minutes: 5),
+        );
 
       // Simulate app resuming from background
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);

--- a/test/screens_test.dart
+++ b/test/screens_test.dart
@@ -81,10 +81,10 @@ void main() {
     late BeerProvider provider;
 
     setUp(() async {
-      mockUrlLauncher = MockUrlLauncherPlatform();
-      // Explicitly reset mock state to ensure test isolation
-      mockUrlLauncher.canLaunchResult = true;
-      mockUrlLauncher.shouldThrowOnLaunch = false;
+      mockUrlLauncher = MockUrlLauncherPlatform()
+        // Explicitly reset mock state to ensure test isolation
+        ..canLaunchResult = true
+        ..shouldThrowOnLaunch = false;
       UrlLauncherPlatform.instance = mockUrlLauncher;
 
       testFestival = Festival(
@@ -328,9 +328,9 @@ void main() {
     late BeerProvider provider;
 
     setUp(() {
-      mockUrlLauncher = MockUrlLauncherPlatform();
-      mockUrlLauncher.canLaunchResult = true;
-      mockUrlLauncher.shouldThrowOnLaunch = false;
+      mockUrlLauncher = MockUrlLauncherPlatform()
+        ..canLaunchResult = true
+        ..shouldThrowOnLaunch = false;
       UrlLauncherPlatform.instance = mockUrlLauncher;
 
       // Set up PackageInfo with test values
@@ -599,9 +599,9 @@ void main() {
     late BeerProvider provider;
 
     setUp(() async {
-      mockUrlLauncher = MockUrlLauncherPlatform();
-      mockUrlLauncher.canLaunchResult = true;
-      mockUrlLauncher.shouldThrowOnLaunch = false;
+      mockUrlLauncher = MockUrlLauncherPlatform()
+        ..canLaunchResult = true
+        ..shouldThrowOnLaunch = false;
       UrlLauncherPlatform.instance = mockUrlLauncher;
 
       mockDrinkRepository = MockDrinkRepository();

--- a/test/string_comparison_helper_test.dart
+++ b/test/string_comparison_helper_test.dart
@@ -5,8 +5,8 @@ void main() {
   group('StringComparisonHelper', () {
     test('sorts case-insensitively', () {
       final unsorted = ['ipa', 'IPA', 'bitter', 'BITTER', 'Stout', 'STOUT'];
-      final sorted = List<String>.from(unsorted);
-      sorted.sort(StringComparisonHelper.compareLocaleAware);
+      final sorted = List<String>.from(unsorted)
+        ..sort(StringComparisonHelper.compareLocaleAware);
 
       // All case variations of the same word should be grouped together
       expect(sorted[0].toLowerCase(), 'bitter');
@@ -21,8 +21,8 @@ void main() {
       // With case-insensitive comparison, accented versions should come
       // after their non-accented counterparts in most cases
       final unsorted = ['Rosé', 'Rose', 'Café', 'Cafe'];
-      final sorted = List<String>.from(unsorted);
-      sorted.sort(StringComparisonHelper.compareLocaleAware);
+      final sorted = List<String>.from(unsorted)
+        ..sort(StringComparisonHelper.compareLocaleAware);
 
       // Verify Cafe comes before Café, and Rose comes before Rosé
       final cafeIndex = sorted.indexWhere((s) => s == 'Cafe');
@@ -53,8 +53,8 @@ void main() {
         'Pilsner',
         'Stout',
       ];
-      final sorted = List<String>.from(unsorted);
-      sorted.sort(StringComparisonHelper.compareLocaleAware);
+      final sorted = List<String>.from(unsorted)
+        ..sort(StringComparisonHelper.compareLocaleAware);
 
       // Verify basic alphabetical order (B < C < I < P < R < S)
       final bIndex = sorted.indexWhere((s) => s.toLowerCase().startsWith('b'));
@@ -81,8 +81,8 @@ void main() {
         'Niño', // Spanish ñ
         'Nino',
       ];
-      final sorted = List<String>.from(unsorted);
-      sorted.sort(StringComparisonHelper.compareLocaleAware);
+      final sorted = List<String>.from(unsorted)
+        ..sort(StringComparisonHelper.compareLocaleAware);
 
       // Verify basic alphabetical grouping works
       // All K's should come before M's, M's before N's
@@ -161,8 +161,8 @@ void main() {
         'Porter',
       ];
 
-      final sorted = List<String>.from(styles);
-      sorted.sort(StringComparisonHelper.compareLocaleAware);
+      final sorted = List<String>.from(styles)
+        ..sort(StringComparisonHelper.compareLocaleAware);
 
       // Verify it's in a reasonable alphabetical order
       // B comes before I, I before K, K before M, etc.
@@ -179,9 +179,8 @@ void main() {
     test('accented characters display correctly (not garbled)', () {
       // This test verifies that the strings with accented characters
       // maintain their correct form after comparison
-      final styles = ['Rosé', 'Café', 'Märzen'];
-
-      styles.sort(StringComparisonHelper.compareLocaleAware);
+      final styles = ['Rosé', 'Café', 'Märzen']
+        ..sort(StringComparisonHelper.compareLocaleAware);
 
       // Verify the accented characters are preserved correctly
       expect(

--- a/test/url_launcher_helper_test.dart
+++ b/test/url_launcher_helper_test.dart
@@ -68,10 +68,10 @@ void main() {
     late MockUrlLauncherPlatform mockUrlLauncher;
 
     setUp(() {
-      mockUrlLauncher = MockUrlLauncherPlatform();
-      mockUrlLauncher.canLaunchResult = true;
-      mockUrlLauncher.shouldThrowOnCanLaunch = false;
-      mockUrlLauncher.shouldThrowOnLaunch = false;
+      mockUrlLauncher = MockUrlLauncherPlatform()
+        ..canLaunchResult = true
+        ..shouldThrowOnCanLaunch = false
+        ..shouldThrowOnLaunch = false;
       UrlLauncherPlatform.instance = mockUrlLauncher;
     });
 

--- a/test/widgets/drink_filter_sheets_test.dart
+++ b/test/widgets/drink_filter_sheets_test.dart
@@ -282,7 +282,7 @@ void main() {
       ) async {
         await provider.setVisibilityFilter(
           DrinkVisibilityFilter.availableOnly,
-          true,
+          active: true,
         );
         await tester.pumpWidget(launcherHost());
         await tester.tap(find.text('open-visibility'));


### PR DESCRIPTION
## Summary

- Adds `strict-casts` to the analyzer, which immediately surfaced a real type-safety bug: allergen JSON keys were `dynamic` being silently coerced into a `Map` — now guarded with `if (entry.key is! String) continue` before casting
- Adds five new linter rules targeting code structure: `cascade_invocations`, `avoid_positional_boolean_parameters`, `unnecessary_lambdas`, `always_declare_return_types`, `require_trailing_commas`
- Fixes all 79 existing violations of those rules across `lib/` and `test/`
- Promotes all five rules to `warning` severity in the `errors:` block so CI catches future regressions (previously the rules only showed as `info`, invisible to `flutter analyze --no-fatal-infos`)
- Removes three explicit rules that were already covered by `flutter_lints` defaults (`avoid_print`, `sort_child_properties_last`, `use_key_in_widget_constructors`)

One intentional `// ignore: unnecessary_lambdas` on `logAppLaunch` in `analytics_service.dart` — the lambda is semantically necessary to defer the `analytics` lazy getter past the enabled-check; a tearoff would evaluate `FirebaseAnalytics.instance` eagerly and crash in tests.

## Test plan

- [ ] CI analyze step passes with zero warnings
- [ ] All 934 tests pass
- [ ] `flutter analyze` locally shows only `info`-level items (two `use_null_aware_elements` in test files), zero warnings or errors
- [ ] Introduce a new positional `bool` parameter or omit a cascade — verify CI catches it as a warning