### PR TITLE
feat(favourites): query favourites from the personal-state store, independent of the catalogue

### DIFF
--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -198,6 +198,10 @@ class ApiDrinkRepository implements DrinkRepository {
         .toList();
   }
 
+  @override
+  Map<String, UserDrinkState> getPersonalEntries(String festivalId) =>
+      _userDataStore.readAll(festivalId);
+
   void dispose() {
     _apiService.dispose();
   }

--- a/lib/domain/repositories/drink_repository.dart
+++ b/lib/domain/repositories/drink_repository.dart
@@ -44,4 +44,16 @@ abstract class DrinkRepository {
 
   /// Get list of tasted drink IDs for a festival
   Future<List<String>> getTastedDrinks(String festivalId);
+
+  /// Returns all personal-state entries for a festival keyed by drink ID,
+  /// WITHOUT requiring the catalogue to be loaded.
+  ///
+  /// This is the catalogue-independent query path introduced in #390: the
+  /// caller can enumerate a user's favourites, ratings, and tasting history
+  /// purely from the personal-data store, before (or without) the drink
+  /// catalogue being fetched.
+  ///
+  /// A future cross-festival variant (omitting [festivalId]) is deferred to
+  /// #315 (My Festival view).
+  Map<String, UserDrinkState> getPersonalEntries(String festivalId);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -534,7 +534,7 @@ class FavoritesScreen extends StatelessWidget {
                 // Catalogue not yet loaded — render an accessible placeholder
                 // row so the user can see their saved drinks without full data.
                 return Semantics(
-                  label: 'Favourite drink, details loading',
+                  label: 'Favourite drink ${entry.drinkId}, details loading',
                   child: ListTile(
                     title: Text(entry.drinkId),
                     subtitle: const Text('Loading details…'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -466,7 +466,7 @@ class FavoritesScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<BeerProvider>();
-    final favorites = provider.favoriteDrinks;
+    final entries = provider.favouriteEntries;
     final theme = Theme.of(context);
 
     return Scaffold(
@@ -479,17 +479,17 @@ class FavoritesScreen extends StatelessWidget {
               style: theme.textTheme.titleMedium,
             ),
             Text(
-              '${favorites.length} favorites',
+              '${entries.length} favourites',
               style: theme.textTheme.bodySmall,
             ),
           ],
         ),
         actions: [buildOverflowMenu(context)],
       ),
-      body: favorites.isEmpty
+      body: entries.isEmpty
           ? Semantics(
               label:
-                  'No favorites yet. Tap the heart icon on drinks you want to try.',
+                  'No favourites yet. Tap the heart icon on drinks you want to try.',
               child: Center(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -500,7 +500,10 @@ class FavoritesScreen extends StatelessWidget {
                       color: Colors.grey,
                     ),
                     const SizedBox(height: 16),
-                    Text('No favorites yet', style: theme.textTheme.titleLarge),
+                    Text(
+                      'No favourites yet',
+                      style: theme.textTheme.titleLarge,
+                    ),
                     const SizedBox(height: 8),
                     const Text('Tap the ♡ on drinks you want to try'),
                   ],
@@ -509,17 +512,33 @@ class FavoritesScreen extends StatelessWidget {
             )
           : ListView.builder(
               padding: const EdgeInsets.only(bottom: 16),
-              itemCount: favorites.length,
+              itemCount: entries.length,
               itemBuilder: (context, index) {
-                final drink = favorites[index];
-                return DrinkCard(
-                  key: ValueKey(drink.id),
-                  drink: drink,
-                  onTap: () => navigateToRoute(
-                    context,
-                    buildDrinkDetailPath(festivalId, drink.category, drink.id),
+                final entry = entries[index];
+                if (entry.drink != null) {
+                  final drink = entry.drink!;
+                  return DrinkCard(
+                    key: ValueKey(drink.id),
+                    drink: drink,
+                    onTap: () => navigateToRoute(
+                      context,
+                      buildDrinkDetailPath(
+                        festivalId,
+                        drink.category,
+                        drink.id,
+                      ),
+                    ),
+                    onFavoriteTap: () => provider.toggleFavorite(drink),
+                  );
+                }
+                // Catalogue not yet loaded — render an accessible placeholder
+                // row so the user can see their saved drinks without full data.
+                return Semantics(
+                  label: 'Favourite drink, details loading',
+                  child: ListTile(
+                    title: Text(entry.drinkId),
+                    subtitle: const Text('Loading details…'),
                   ),
-                  onFavoriteTap: () => provider.toggleFavorite(drink),
                 );
               },
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -466,7 +466,7 @@ class FavoritesScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<BeerProvider>();
-    final entries = provider.favouriteEntries;
+    final entries = provider.favoriteEntries;
     final theme = Theme.of(context);
 
     return Scaffold(

--- a/lib/models/favorite_drink_entry.dart
+++ b/lib/models/favorite_drink_entry.dart
@@ -10,7 +10,7 @@ import 'drink.dart';
 /// is a valid personal-state record that can be displayed as a placeholder;
 /// once the catalogue loads, [drink] will be populated and the full card can
 /// be rendered.
-class FavouriteDrinkEntry {
+class FavoriteDrinkEntry {
   /// The drink's identifier within the festival.
   final String drinkId;
 
@@ -25,7 +25,7 @@ class FavouriteDrinkEntry {
   /// loaded.
   final Drink? drink;
 
-  const FavouriteDrinkEntry({
+  const FavoriteDrinkEntry({
     required this.drinkId,
     required this.festivalId,
     required this.state,

--- a/lib/models/favourite_drink_entry.dart
+++ b/lib/models/favourite_drink_entry.dart
@@ -1,0 +1,40 @@
+import 'user_drink_state.dart';
+import 'drink.dart';
+
+/// A queryable, catalogue-independent entry combining a drink's personal state
+/// with its optional hydrated catalogue record.
+///
+/// This view-model lets the Favourites screen (and, in future, a cross-festival
+/// "My Festival" view — see #315) enumerate user-marked drinks regardless of
+/// whether the catalogue has finished loading. When [drink] is null the entry
+/// is a valid personal-state record that can be displayed as a placeholder;
+/// once the catalogue loads, [drink] will be populated and the full card can
+/// be rendered.
+class FavouriteDrinkEntry {
+  /// The drink's identifier within the festival.
+  final String drinkId;
+
+  /// The festival this entry belongs to.
+  final String festivalId;
+
+  /// The user's full personal state for this drink (favourite status, rating,
+  /// tasting log, etc.).
+  final UserDrinkState state;
+
+  /// The hydrated catalogue record, or null when the catalogue is not yet
+  /// loaded.
+  final Drink? drink;
+
+  const FavouriteDrinkEntry({
+    required this.drinkId,
+    required this.festivalId,
+    required this.state,
+    required this.drink,
+  });
+
+  /// True when the catalogue has been loaded and [drink] is populated.
+  bool get isCatalogueLoaded => drink != null;
+
+  /// True when the user has marked this drink as a favourite (want to try).
+  bool get isFavorite => state.wantToTry;
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,5 +1,5 @@
 export 'beverage_categories.dart';
 export 'drink.dart';
-export 'favourite_drink_entry.dart';
+export 'favorite_drink_entry.dart';
 export 'festival.dart';
 export 'user_drink_state.dart';

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,4 +1,5 @@
 export 'beverage_categories.dart';
 export 'drink.dart';
+export 'favourite_drink_entry.dart';
 export 'festival.dart';
 export 'user_drink_state.dart';

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -196,11 +196,15 @@ class BeerProvider extends ChangeNotifier {
       return byName != 0 ? byName : a.drinkId.compareTo(b.drinkId);
     });
 
-    _favouriteEntriesCache = result;
+    // Cache an unmodifiable view: the same instance is handed to every consumer
+    // on a cache hit, so a stray mutation would corrupt the cache and break
+    // invalidation.
+    final cached = List<FavouriteDrinkEntry>.unmodifiable(result);
+    _favouriteEntriesCache = cached;
     _favouriteEntriesCacheRevision = _personalStateRevision;
     _favouriteEntriesCacheFestivalId = festivalId;
     _favouriteEntriesCacheDrinksRef = _allDrinks;
-    return result;
+    return cached;
   }
 
   /// Check if a festival ID is valid (exists in the registry)

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -25,6 +25,19 @@ class BeerProvider extends ChangeNotifier {
   ApiFestivalRepository? _ownedFestivalRepository;
 
   List<Drink> _allDrinks = [];
+
+  // Memoised backing for [favouriteEntries]. The personal-data store iterates
+  // an unordered key set and re-decodes JSON on every read, so the result is
+  // both sorted and cached. Invalidation is keyed on a revision counter bumped
+  // by [_replaceDrink] (the sole personal-state write path), the current
+  // festival id, and the identity of [_allDrinks] (reassigned whenever the
+  // catalogue (re)loads) — so the cache can never go stale.
+  List<FavouriteDrinkEntry>? _favouriteEntriesCache;
+  int _personalStateRevision = 0;
+  int _favouriteEntriesCacheRevision = -1;
+  String? _favouriteEntriesCacheFestivalId;
+  List<Drink>? _favouriteEntriesCacheDrinksRef;
+
   List<Festival> _festivals = [];
   Festival? _currentFestival;
   bool _isLoading = false;
@@ -144,14 +157,26 @@ class BeerProvider extends ChangeNotifier {
   /// even before (or without) the catalogue being loaded — the [#310] scope
   /// fix — matching on both drink ID and festival ID to avoid cross-festival
   /// collisions.
+  ///
+  /// Entries are sorted by hydrated drink name (falling back to drink ID for
+  /// not-yet-loaded placeholders, with ID as a deterministic tiebreak) so the
+  /// list order is stable — the store iterates an unordered key set. The
+  /// computed list is memoised; see the cache fields above for invalidation.
   List<FavouriteDrinkEntry> get favouriteEntries {
     if (_drinkRepository == null) return const [];
-    final entries = _drinkRepository!.getPersonalEntries(currentFestival.id);
+    final festivalId = currentFestival.id;
+    if (_favouriteEntriesCache != null &&
+        _favouriteEntriesCacheRevision == _personalStateRevision &&
+        _favouriteEntriesCacheFestivalId == festivalId &&
+        identical(_favouriteEntriesCacheDrinksRef, _allDrinks)) {
+      return _favouriteEntriesCache!;
+    }
+
+    final entries = _drinkRepository!.getPersonalEntries(festivalId);
     final result = <FavouriteDrinkEntry>[];
     for (final entry in entries.entries) {
       if (!entry.value.wantToTry) continue;
       final drinkId = entry.key;
-      final festivalId = currentFestival.id;
       final found = _allDrinks.firstWhereOrNull(
         (d) => d.id == drinkId && d.festivalId == festivalId,
       );
@@ -164,6 +189,17 @@ class BeerProvider extends ChangeNotifier {
         ),
       );
     }
+    result.sort((a, b) {
+      final byName = (a.drink?.name ?? a.drinkId).toLowerCase().compareTo(
+        (b.drink?.name ?? b.drinkId).toLowerCase(),
+      );
+      return byName != 0 ? byName : a.drinkId.compareTo(b.drinkId);
+    });
+
+    _favouriteEntriesCache = result;
+    _favouriteEntriesCacheRevision = _personalStateRevision;
+    _favouriteEntriesCacheFestivalId = festivalId;
+    _favouriteEntriesCacheDrinksRef = _allDrinks;
     return result;
   }
 
@@ -727,6 +763,8 @@ class BeerProvider extends ChangeNotifier {
     if (idx != -1) {
       _allDrinks[idx] = updated;
     }
+    // Personal state changed — invalidate the memoised favourites list.
+    _personalStateRevision++;
     _filter.recompute();
     return updated;
   }

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -26,17 +26,17 @@ class BeerProvider extends ChangeNotifier {
 
   List<Drink> _allDrinks = [];
 
-  // Memoised backing for [favouriteEntries]. The personal-data store iterates
+  // Memoised backing for [favoriteEntries]. The personal-data store iterates
   // an unordered key set and re-decodes JSON on every read, so the result is
   // both sorted and cached. Invalidation is keyed on a revision counter bumped
   // by [_replaceDrink] (the sole personal-state write path), the current
   // festival id, and the identity of [_allDrinks] (reassigned whenever the
   // catalogue (re)loads) — so the cache can never go stale.
-  List<FavouriteDrinkEntry>? _favouriteEntriesCache;
+  List<FavoriteDrinkEntry>? _favoriteEntriesCache;
   int _personalStateRevision = 0;
-  int _favouriteEntriesCacheRevision = -1;
-  String? _favouriteEntriesCacheFestivalId;
-  List<Drink>? _favouriteEntriesCacheDrinksRef;
+  int _favoriteEntriesCacheRevision = -1;
+  String? _favoriteEntriesCacheFestivalId;
+  List<Drink>? _favoriteEntriesCacheDrinksRef;
 
   List<Festival> _festivals = [];
   Festival? _currentFestival;
@@ -162,18 +162,18 @@ class BeerProvider extends ChangeNotifier {
   /// not-yet-loaded placeholders, with ID as a deterministic tiebreak) so the
   /// list order is stable — the store iterates an unordered key set. The
   /// computed list is memoised; see the cache fields above for invalidation.
-  List<FavouriteDrinkEntry> get favouriteEntries {
+  List<FavoriteDrinkEntry> get favoriteEntries {
     if (_drinkRepository == null) return const [];
     final festivalId = currentFestival.id;
-    if (_favouriteEntriesCache != null &&
-        _favouriteEntriesCacheRevision == _personalStateRevision &&
-        _favouriteEntriesCacheFestivalId == festivalId &&
-        identical(_favouriteEntriesCacheDrinksRef, _allDrinks)) {
-      return _favouriteEntriesCache!;
+    if (_favoriteEntriesCache != null &&
+        _favoriteEntriesCacheRevision == _personalStateRevision &&
+        _favoriteEntriesCacheFestivalId == festivalId &&
+        identical(_favoriteEntriesCacheDrinksRef, _allDrinks)) {
+      return _favoriteEntriesCache!;
     }
 
     final entries = _drinkRepository!.getPersonalEntries(festivalId);
-    final result = <FavouriteDrinkEntry>[];
+    final result = <FavoriteDrinkEntry>[];
     for (final entry in entries.entries) {
       if (!entry.value.wantToTry) continue;
       final drinkId = entry.key;
@@ -181,7 +181,7 @@ class BeerProvider extends ChangeNotifier {
         (d) => d.id == drinkId && d.festivalId == festivalId,
       );
       result.add(
-        FavouriteDrinkEntry(
+        FavoriteDrinkEntry(
           drinkId: drinkId,
           festivalId: festivalId,
           state: entry.value,
@@ -199,11 +199,11 @@ class BeerProvider extends ChangeNotifier {
     // Cache an unmodifiable view: the same instance is handed to every consumer
     // on a cache hit, so a stray mutation would corrupt the cache and break
     // invalidation.
-    final cached = List<FavouriteDrinkEntry>.unmodifiable(result);
-    _favouriteEntriesCache = cached;
-    _favouriteEntriesCacheRevision = _personalStateRevision;
-    _favouriteEntriesCacheFestivalId = festivalId;
-    _favouriteEntriesCacheDrinksRef = _allDrinks;
+    final cached = List<FavoriteDrinkEntry>.unmodifiable(result);
+    _favoriteEntriesCache = cached;
+    _favoriteEntriesCacheRevision = _personalStateRevision;
+    _favoriteEntriesCacheFestivalId = festivalId;
+    _favoriteEntriesCacheDrinksRef = _allDrinks;
     return cached;
   }
 

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -134,9 +134,38 @@ class BeerProvider extends ChangeNotifier {
   /// Get drink count by style
   Map<String, int> get styleCountsMap => _filter.styleCountsMap;
 
-  /// Get favorite drinks
-  List<Drink> get favoriteDrinks =>
-      _allDrinks.where((d) => d.isFavorite).toList();
+  /// Returns all personal-state entries for the current festival where the
+  /// user has marked the drink as a favourite, paired with the hydrated
+  /// catalogue record when available.
+  ///
+  /// Ownership of the favourites query now lives in the personal-data store
+  /// ([DrinkRepository.getPersonalEntries]) rather than in the in-memory
+  /// catalogue list. This means the Favourites screen can enumerate entries
+  /// even before (or without) the catalogue being loaded — the [#310] scope
+  /// fix — matching on both drink ID and festival ID to avoid cross-festival
+  /// collisions.
+  List<FavouriteDrinkEntry> get favouriteEntries {
+    if (_drinkRepository == null) return const [];
+    final entries = _drinkRepository!.getPersonalEntries(currentFestival.id);
+    final result = <FavouriteDrinkEntry>[];
+    for (final entry in entries.entries) {
+      if (!entry.value.wantToTry) continue;
+      final drinkId = entry.key;
+      final festivalId = currentFestival.id;
+      final found = _allDrinks.firstWhereOrNull(
+        (d) => d.id == drinkId && d.festivalId == festivalId,
+      );
+      result.add(
+        FavouriteDrinkEntry(
+          drinkId: drinkId,
+          festivalId: festivalId,
+          state: entry.value,
+          drink: found,
+        ),
+      );
+    }
+    return result;
+  }
 
   /// Check if a festival ID is valid (exists in the registry)
   bool isValidFestivalId(String? festivalId) {

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -719,42 +719,82 @@ void main() {
         expect(provider.drinks.every((d) => d.isFavorite), isTrue);
       });
 
-      test('favoriteDrinks getter returns only favorites', () async {
-        provider = BeerProvider(
-          drinkRepository: mockDrinkRepository,
-          festivalRepository: mockFestivalRepository,
-          analyticsService: mockAnalyticsService,
-        );
-        await provider.initialize();
+      test(
+        'favouriteEntries returns hydrated entries when catalogue is loaded',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
 
-        final sampleDrinks = createSampleDrinks();
+          final sampleDrinks = createSampleDrinks();
 
-        when(
-          mockDrinkRepository.getDrinks(any),
-        ).thenAnswer((_) async => sampleDrinks);
-        await provider.loadDrinks();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => sampleDrinks);
+          await provider.loadDrinks();
 
-        // Mock toggleFavorite to properly toggle state
-        final favorites = <String>{};
-        when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer((
-          invocation,
-        ) async {
-          final drinkId = invocation.positionalArguments[1] as String;
-          if (favorites.contains(drinkId)) {
-            favorites.remove(drinkId);
-            return false;
-          } else {
-            favorites.add(drinkId);
-            return true;
-          }
-        });
+          // Stub getPersonalEntries to return a wantToTry record for drink-1
+          final now = DateTime.now();
+          final state = UserDrinkState(
+            wantToTry: true,
+            createdAt: now,
+            updatedAt: now,
+          );
+          when(
+            mockDrinkRepository.getPersonalEntries(any),
+          ).thenReturn({'drink-1': state});
 
-        // Toggle favorite after loading
-        await provider.toggleFavorite(provider.allDrinks[0]);
+          final entries = provider.favouriteEntries;
 
-        expect(provider.favoriteDrinks.length, 1);
-        expect(provider.favoriteDrinks.first.name, 'Alpha Ale');
-      });
+          expect(entries.length, 1);
+          // Catalogue is loaded — drink must be hydrated
+          expect(entries.first.isCatalogueLoaded, isTrue);
+          expect(entries.first.drink, isNotNull);
+          expect(entries.first.drink!.name, 'Alpha Ale');
+          expect(entries.first.drinkId, 'drink-1');
+        },
+      );
+
+      test(
+        'favouriteEntries returns placeholder entries when catalogue not loaded'
+        ' but store has favourite',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+
+          // Catalogue is NOT loaded — getDrinks returns empty list
+          when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
+          await provider.loadDrinks();
+
+          // Store has a wantToTry record for drink-1
+          final now = DateTime.now();
+          final state = UserDrinkState(
+            wantToTry: true,
+            createdAt: now,
+            updatedAt: now,
+          );
+          when(
+            mockDrinkRepository.getPersonalEntries(any),
+          ).thenReturn({'drink-1': state});
+
+          final entries = provider.favouriteEntries;
+
+          // Entry is present even without the catalogue — this is the #390/#310
+          // fix: personal-state query is catalogue-independent.
+          expect(entries.length, 1);
+          expect(entries.first.drinkId, 'drink-1');
+          // Catalogue not loaded — drink is null
+          expect(entries.first.isCatalogueLoaded, isFalse);
+          expect(entries.first.drink, isNull);
+        },
+      );
     });
 
     group('hide unavailable filter', () {

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -720,7 +720,7 @@ void main() {
       });
 
       test(
-        'favouriteEntries returns hydrated entries when catalogue is loaded',
+        'favoriteEntries returns hydrated entries when catalogue is loaded',
         () async {
           provider = BeerProvider(
             drinkRepository: mockDrinkRepository,
@@ -747,7 +747,7 @@ void main() {
             mockDrinkRepository.getPersonalEntries(any),
           ).thenReturn({'drink-1': state});
 
-          final entries = provider.favouriteEntries;
+          final entries = provider.favoriteEntries;
 
           expect(entries.length, 1);
           // Catalogue is loaded — drink must be hydrated
@@ -759,7 +759,7 @@ void main() {
       );
 
       test(
-        'favouriteEntries returns placeholder entries when catalogue not loaded'
+        'favoriteEntries returns placeholder entries when catalogue not loaded'
         ' but store has favourite',
         () async {
           provider = BeerProvider(
@@ -784,7 +784,7 @@ void main() {
             mockDrinkRepository.getPersonalEntries(any),
           ).thenReturn({'drink-1': state});
 
-          final entries = provider.favouriteEntries;
+          final entries = provider.favoriteEntries;
 
           // Entry is present even without the catalogue — this is the #390/#310
           // fix: personal-state query is catalogue-independent.
@@ -796,7 +796,7 @@ void main() {
         },
       );
 
-      test('favouriteEntries are returned in a stable, sorted order', () async {
+      test('favoriteEntries are returned in a stable, sorted order', () async {
         provider = BeerProvider(
           drinkRepository: mockDrinkRepository,
           festivalRepository: mockFestivalRepository,
@@ -810,17 +810,17 @@ void main() {
         UserDrinkState fav() =>
             UserDrinkState(wantToTry: true, createdAt: now, updatedAt: now);
         // Insertion order is deliberately unsorted; the store iterates an
-        // unordered key set, so favouriteEntries must impose a stable order.
+        // unordered key set, so favoriteEntries must impose a stable order.
         when(
           mockDrinkRepository.getPersonalEntries(any),
         ).thenReturn({'zulu': fav(), 'alpha': fav(), 'mike': fav()});
 
-        final ids = provider.favouriteEntries.map((e) => e.drinkId).toList();
+        final ids = provider.favoriteEntries.map((e) => e.drinkId).toList();
         expect(ids, ['alpha', 'mike', 'zulu']);
       });
 
       test(
-        'favouriteEntries memoises and recomputes only when invalidated',
+        'favoriteEntries memoises and recomputes only when invalidated',
         () async {
           provider = BeerProvider(
             drinkRepository: mockDrinkRepository,
@@ -841,13 +841,13 @@ void main() {
           });
 
           // First read computes; second read must reuse the cached instance.
-          final firstRead = provider.favouriteEntries;
-          final secondRead = provider.favouriteEntries;
+          final firstRead = provider.favoriteEntries;
+          final secondRead = provider.favoriteEntries;
           expect(identical(firstRead, secondRead), isTrue);
 
           // Reloading the catalogue reassigns _allDrinks → cache invalidated.
           await provider.loadDrinks();
-          final afterReload = provider.favouriteEntries;
+          final afterReload = provider.favoriteEntries;
           expect(identical(secondRead, afterReload), isFalse);
 
           // Three reads, but only two computes: the cached middle read did not

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -840,13 +840,15 @@ void main() {
             ),
           });
 
-          // First read computes; second read must hit the cache (no re-query).
-          provider.favouriteEntries;
-          provider.favouriteEntries;
+          // First read computes; second read must reuse the cached instance.
+          final firstRead = provider.favouriteEntries;
+          final secondRead = provider.favouriteEntries;
+          expect(identical(firstRead, secondRead), isTrue);
 
           // Reloading the catalogue reassigns _allDrinks → cache invalidated.
           await provider.loadDrinks();
-          provider.favouriteEntries;
+          final afterReload = provider.favouriteEntries;
+          expect(identical(secondRead, afterReload), isFalse);
 
           // Three reads, but only two computes: the cached middle read did not
           // re-query the store, and the post-reload read recomputed. A total of

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -795,6 +795,65 @@ void main() {
           expect(entries.first.drink, isNull);
         },
       );
+
+      test('favouriteEntries are returned in a stable, sorted order', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+        when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
+        await provider.loadDrinks();
+
+        final now = DateTime.now();
+        UserDrinkState fav() =>
+            UserDrinkState(wantToTry: true, createdAt: now, updatedAt: now);
+        // Insertion order is deliberately unsorted; the store iterates an
+        // unordered key set, so favouriteEntries must impose a stable order.
+        when(
+          mockDrinkRepository.getPersonalEntries(any),
+        ).thenReturn({'zulu': fav(), 'alpha': fav(), 'mike': fav()});
+
+        final ids = provider.favouriteEntries.map((e) => e.drinkId).toList();
+        expect(ids, ['alpha', 'mike', 'zulu']);
+      });
+
+      test(
+        'favouriteEntries memoises and recomputes only when invalidated',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
+          await provider.loadDrinks();
+
+          final now = DateTime.now();
+          when(mockDrinkRepository.getPersonalEntries(any)).thenReturn({
+            'drink-1': UserDrinkState(
+              wantToTry: true,
+              createdAt: now,
+              updatedAt: now,
+            ),
+          });
+
+          // First read computes; second read must hit the cache (no re-query).
+          provider.favouriteEntries;
+          provider.favouriteEntries;
+
+          // Reloading the catalogue reassigns _allDrinks → cache invalidated.
+          await provider.loadDrinks();
+          provider.favouriteEntries;
+
+          // Three reads, but only two computes: the cached middle read did not
+          // re-query the store, and the post-reload read recomputed. A total of
+          // 1 would mean the cache never invalidated; 3 would mean no caching.
+          verify(mockDrinkRepository.getPersonalEntries(any)).called(2);
+        },
+      );
     });
 
     group('hide unavailable filter', () {

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -409,6 +409,10 @@ void main() {
       when(
         mockDrinkRepository.getFavorites(any),
       ).thenAnswer((_) async => ['drink1']);
+      // Stub getPersonalEntries so favouriteEntries returns the loaded drink.
+      when(mockDrinkRepository.getPersonalEntries(any)).thenReturn({
+        'drink1': UserDrinkState.initial().copyWith(wantToTry: true),
+      });
 
       provider = BeerProvider(
         drinkRepository: mockDrinkRepository,
@@ -456,6 +460,72 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Drink Detail'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'shows placeholder row when catalogue not loaded but store has favourite',
+      (WidgetTester tester) async {
+        // Use a fresh MockDrinkRepository so setUp stubs don't interfere.
+        final emptyMockRepo = MockDrinkRepository();
+        final emptyMockFestivalRepo = MockFestivalRepository();
+        final emptyMockAnalytics = MockAnalyticsService();
+
+        when(emptyMockFestivalRepo.getFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: [
+              const Festival(
+                id: 'cbf2025',
+                name: 'Cambridge Beer Festival 2025',
+                dataBaseUrl: 'https://example.com',
+              ),
+            ],
+            defaultFestivalId: 'cbf2025',
+            version: '1.0',
+            baseUrl: 'https://example.com',
+          ),
+        );
+        when(
+          emptyMockFestivalRepo.getSelectedFestivalId(),
+        ).thenAnswer((_) async => null);
+        // Catalogue returns nothing — simulates pre-load state
+        when(emptyMockRepo.getDrinks(any)).thenAnswer((_) async => []);
+        // Store has a wantToTry record for drink1
+        when(emptyMockRepo.getPersonalEntries(any)).thenReturn({
+          'drink1': UserDrinkState.initial().copyWith(wantToTry: true),
+        });
+
+        final emptyProvider = BeerProvider(
+          drinkRepository: emptyMockRepo,
+          festivalRepository: emptyMockFestivalRepo,
+          analyticsService: emptyMockAnalytics,
+        );
+        addTearDown(emptyProvider.dispose);
+
+        await emptyProvider.initialize();
+        await emptyProvider.loadDrinks();
+
+        final router = GoRouter(
+          initialLocation: '/favorites',
+          routes: [
+            GoRoute(
+              path: '/favorites',
+              builder: (context, state) =>
+                  ChangeNotifierProvider<BeerProvider>.value(
+                    value: emptyProvider,
+                    child: const FavoritesScreen(festivalId: 'cbf2025'),
+                  ),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+        await tester.pumpAndSettle();
+
+        // Placeholder text is shown because the catalogue is not loaded
+        expect(find.text('Loading details…'), findsOneWidget);
+        // The real drink name is NOT shown
+        expect(find.text('Favourite Ale'), findsNothing);
       },
     );
   });

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -409,7 +409,7 @@ void main() {
       when(
         mockDrinkRepository.getFavorites(any),
       ).thenAnswer((_) async => ['drink1']);
-      // Stub getPersonalEntries so favouriteEntries returns the loaded drink.
+      // Stub getPersonalEntries so favoriteEntries returns the loaded drink.
       when(mockDrinkRepository.getPersonalEntries(any)).thenReturn({
         'drink1': UserDrinkState.initial().copyWith(wantToTry: true),
       });

--- a/test/provider_test.mocks.dart
+++ b/test/provider_test.mocks.dart
@@ -152,6 +152,15 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
             ),
           )
           as _i6.Future<List<String>>);
+
+  @override
+  Map<String, _i7.UserDrinkState> getPersonalEntries(String? festivalId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getPersonalEntries, [festivalId]),
+            returnValue: <String, _i7.UserDrinkState>{},
+            returnValueForMissingStub: <String, _i7.UserDrinkState>{},
+          )
+          as Map<String, _i7.UserDrinkState>);
 }
 
 /// A class which mocks [FestivalRepository].

--- a/test/widgets/festival_menu_sheets_test.mocks.dart
+++ b/test/widgets/festival_menu_sheets_test.mocks.dart
@@ -152,6 +152,15 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
             ),
           )
           as _i6.Future<List<String>>);
+
+  @override
+  Map<String, _i7.UserDrinkState> getPersonalEntries(String? festivalId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getPersonalEntries, [festivalId]),
+            returnValue: <String, _i7.UserDrinkState>{},
+            returnValueForMissingStub: <String, _i7.UserDrinkState>{},
+          )
+          as Map<String, _i7.UserDrinkState>);
 }
 
 /// A class which mocks [FestivalRepository].


### PR DESCRIPTION
Builds on the unified `UserDataStore` (#395) to make personal data queryable
**without** the drink catalogue being loaded — the foundational read/query flip
for "My Festival" (#315).

## Problem

Favourites were derived from the in-memory catalogue: `favoriteDrinks =
_allDrinks.where((d) => d.isFavorite)`. That only reflected the **current**
festival, and only **after** the network/cache load completed — the direct
cause of the transient-wrong-festival bug (#310). There was no way to enumerate
"my drinks" before (or without) the catalogue being fetched.

## Change

Ownership flips: the personal-data store is the source of truth, and catalogue
`Drink`s are hydrated onto it on demand.

- **`DrinkRepository.getPersonalEntries(festivalId)`** — returns
  `Map<String, UserDrinkState>` straight from `UserDataStore.readAll()`, no
  catalogue required. (`ApiDrinkRepository` implements it as a thin delegate.)
- **`FavoriteDrinkEntry`** — a small transient view-model: `drinkId`,
  `festivalId`, `state`, and a nullable hydrated `drink`.
- **`BeerProvider.favoriteEntries`** replaces `favoriteDrinks` (return type
  changes `List<Drink>` → `List<FavoriteDrinkEntry>`, so every call site opts
  in). It reads from the store, then hydrates from `_allDrinks` matching on
  **both `id` and `festivalId`** — the #310 collision fix.
- **`FavoritesScreen`** renders a normal `DrinkCard` when hydrated, and an
  accessible placeholder row (`Semantics`-labelled per entry) when the
  catalogue isn't loaded yet.

## Review fixes (post code-review)

- **Stable ordering** — `favoriteEntries` sorts by hydrated drink name
  (placeholder fallback to drink ID, ID as tiebreak). The store iterates an
  unordered key set, so without this the list order was arbitrary and could
  reshuffle between launches.
- **Memoised (unmodifiable)** — the computed list is cached and returned as an
  unmodifiable view, invalidated only by a revision counter bumped on every
  personal-state write (`_replaceDrink`), the current festival id, and
  `_allDrinks` identity. Avoids re-scanning SharedPreferences and re-decoding
  every personal record on each `FavoritesScreen` rebuild.
- **American spelling** — new identifiers (`FavoriteDrinkEntry`,
  `favoriteEntries`, `favorite_drink_entry.dart`) match the rest of the feature
  area. UI strings stay British per project convention.

## Testing

`./bin/mise run check` green — analyzer clean, **976 tests** pass. New coverage:
hydrated vs catalogue-absent (placeholder) entries, the FavoritesScreen
placeholder row, deterministic ordering, and cache memoisation/invalidation
(cache-instance identity on a hit; recompute after a catalogue reload).

## Scope / follow-ups (deferred)

- **#397** — residual one-frame deep-link case: `FavoritesScreen` still reads
  `currentFestival` rather than the route `festivalId`, so a cross-festival deep
  link shows the previous festival's favourites for the first frame. Pre-existing
  and out of this PR's core (the steady-state collision is fixed here), tracked
  separately.
- Cross-festival aggregation and the full My Festival UI → #315.
- Extracting this into a `UserDrinkStateController` (rebuild-scope) → #392.
- Placeholder rows aren't yet tappable/removable (need catalogue loaded) — minor
  UX gap, deferred with the My Festival UI.

Closes #390
Refs #310 (residual first-frame case tracked in #397)

https://claude.ai/code/session_01LYmzRmVZrcRnJQw98PaEex