### PR TITLE
feat(domain): extract personal-state management into UserDrinkStateController

### DIFF
--- a/lib/domain/controllers/controllers.dart
+++ b/lib/domain/controllers/controllers.dart
@@ -1,2 +1,3 @@
 // Domain controllers - stateful application logic independent of UI and data layers
 export 'drink_filter_controller.dart';
+export 'user_drink_state_controller.dart';

--- a/lib/domain/controllers/user_drink_state_controller.dart
+++ b/lib/domain/controllers/user_drink_state_controller.dart
@@ -1,0 +1,113 @@
+import '../../models/models.dart';
+
+/// Owns in-memory personal state (want-to-try, rating, tasting) keyed by
+/// drink ID and provides the mutation helpers used by [BeerProvider].
+///
+/// Pure application logic: no Flutter, persistence, async, or analytics
+/// dependencies, so it can be unit-tested in isolation. [BeerProvider] composes
+/// this controller, feeds it the loaded drinks via [setSource], and handles the
+/// cross-cutting concerns (persistence, analytics, change notification) around
+/// it.
+///
+/// All mutators are synchronous and side-effect free; callers are responsible
+/// for persisting and broadcasting changes.
+class UserDrinkStateController {
+  final Map<String, UserDrinkState> _states = {};
+
+  /// Replace the internal state map with the personal state from [drinks].
+  /// Drinks with null [Drink.userState] are ignored; their entries are absent
+  /// from the map (semantically: no user signal recorded).
+  void setSource(List<Drink> drinks) {
+    _states.clear();
+    for (final drink in drinks) {
+      if (drink.userState != null) {
+        _states[drink.id] = drink.userState!;
+      }
+    }
+  }
+
+  /// Remove all tracked state (called when the user switches festivals or the
+  /// catalogue is cleared).
+  void clear() => _states.clear();
+
+  // --- Read access ---
+
+  /// Returns the current [UserDrinkState] for [drinkId], or null if there is
+  /// no user signal for it.
+  UserDrinkState? stateFor(String drinkId) => _states[drinkId];
+
+  /// Whether the drink is flagged as "want to try". Returns false for unknown
+  /// IDs.
+  bool isFavorite(String drinkId) => _states[drinkId]?.wantToTry ?? false;
+
+  /// The user's 1–5 rating, or null when unrated or for unknown IDs.
+  int? ratingFor(String drinkId) => _states[drinkId]?.rating;
+
+  /// Whether the user has at least one tasting event. Returns false for
+  /// unknown IDs.
+  bool isTasted(String drinkId) => _states[drinkId]?.isTasted ?? false;
+
+  /// Number of tasting events. Returns 0 for unknown IDs.
+  int tastingCountFor(String drinkId) => _states[drinkId]?.tastingCount ?? 0;
+
+  // --- Mutators ---
+
+  /// Apply a want-to-try toggle to [drinkId]. Creates a fresh record if none
+  /// exists. Returns the updated [UserDrinkState], or null when the state
+  /// became empty (all fields cleared) and was pruned.
+  UserDrinkState? applyWantToTry(
+    String drinkId, {
+    required bool value,
+    DateTime? now,
+  }) {
+    final timestamp = now ?? DateTime.now();
+    final base = _states[drinkId] ?? UserDrinkState.initial(now: timestamp);
+    return _apply(
+      drinkId,
+      base.copyWith(wantToTry: value, updatedAt: timestamp),
+    );
+  }
+
+  /// Apply a rating change (1–5) or clear it (null) for [drinkId]. Creates a
+  /// fresh record if none exists. Returns the updated [UserDrinkState], or
+  /// null when the state became empty and was pruned.
+  UserDrinkState? applyRating(String drinkId, int? rating, {DateTime? now}) {
+    final timestamp = now ?? DateTime.now();
+    final base = _states[drinkId] ?? UserDrinkState.initial(now: timestamp);
+    return _apply(drinkId, base.copyWith(rating: rating, updatedAt: timestamp));
+  }
+
+  /// Record or clear a tasting event for [drinkId]. When [tasted] is true,
+  /// sets the tasting list to `[now]` (binary toggle — replaces any previous
+  /// list rather than appending). When false, clears tasting events entirely.
+  /// Returns the updated [UserDrinkState], or null when the state became empty
+  /// and was pruned.
+  UserDrinkState? applyTasted(
+    String drinkId, {
+    required bool tasted,
+    DateTime? now,
+  }) {
+    final timestamp = now ?? DateTime.now();
+    final base = _states[drinkId] ?? UserDrinkState.initial(now: timestamp);
+    return _apply(
+      drinkId,
+      base.copyWith(
+        tastingEvents: tasted ? [timestamp] : const [],
+        updatedAt: timestamp,
+      ),
+    );
+  }
+
+  // --- Internal helpers ---
+
+  /// Stores [next] under [drinkId] when non-empty; removes the entry when
+  /// empty (prune). Returns [next] or null when pruned.
+  UserDrinkState? _apply(String drinkId, UserDrinkState next) {
+    if (next.isEmpty) {
+      _states.remove(drinkId);
+      return null;
+    }
+    _states[drinkId] = next;
+    return next;
+  }
+}

--- a/lib/domain/controllers/user_drink_state_controller.dart
+++ b/lib/domain/controllers/user_drink_state_controller.dart
@@ -71,7 +71,11 @@ class UserDrinkStateController {
   /// Apply a rating change (1–5) or clear it (null) for [drinkId]. Creates a
   /// fresh record if none exists. Returns the updated [UserDrinkState], or
   /// null when the state became empty and was pruned.
-  UserDrinkState? applyRating(String drinkId, int? rating, {DateTime? now}) {
+  UserDrinkState? applyRating(
+    String drinkId, {
+    required int? rating,
+    DateTime? now,
+  }) {
     final timestamp = now ?? DateTime.now();
     final base = _states[drinkId] ?? UserDrinkState.initial(now: timestamp);
     return _apply(drinkId, base.copyWith(rating: rating, updatedAt: timestamp));

--- a/lib/domain/controllers/user_drink_state_controller.dart
+++ b/lib/domain/controllers/user_drink_state_controller.dart
@@ -60,8 +60,7 @@ class UserDrinkStateController {
     required bool value,
     DateTime? now,
   }) {
-    final timestamp = now ?? DateTime.now();
-    final base = _states[drinkId] ?? UserDrinkState.initial(now: timestamp);
+    final (timestamp, base) = _baseFor(drinkId, now);
     return _apply(
       drinkId,
       base.copyWith(wantToTry: value, updatedAt: timestamp),
@@ -76,8 +75,7 @@ class UserDrinkStateController {
     required int? rating,
     DateTime? now,
   }) {
-    final timestamp = now ?? DateTime.now();
-    final base = _states[drinkId] ?? UserDrinkState.initial(now: timestamp);
+    final (timestamp, base) = _baseFor(drinkId, now);
     return _apply(drinkId, base.copyWith(rating: rating, updatedAt: timestamp));
   }
 
@@ -91,8 +89,7 @@ class UserDrinkStateController {
     required bool tasted,
     DateTime? now,
   }) {
-    final timestamp = now ?? DateTime.now();
-    final base = _states[drinkId] ?? UserDrinkState.initial(now: timestamp);
+    final (timestamp, base) = _baseFor(drinkId, now);
     return _apply(
       drinkId,
       base.copyWith(
@@ -103,6 +100,16 @@ class UserDrinkStateController {
   }
 
   // --- Internal helpers ---
+
+  /// Resolves the effective timestamp and base state for a mutation. Creates a
+  /// fresh [UserDrinkState] when no record exists yet for [drinkId].
+  (DateTime, UserDrinkState) _baseFor(String drinkId, DateTime? now) {
+    final timestamp = now ?? DateTime.now();
+    return (
+      timestamp,
+      _states[drinkId] ?? UserDrinkState.initial(now: timestamp),
+    );
+  }
 
   /// Stores [next] under [drinkId] when non-empty; removes the entry when
   /// empty (prune). Returns [next] or null when pruned.

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -445,9 +445,7 @@ class BeerProvider extends ChangeNotifier {
       final cached = await _drinkRepository!.getCachedDrinks(festival);
       if (token != _drinksLoadToken) return;
       if (cached != null) {
-        _allDrinks = cached;
-        _filter.setSource(_allDrinks);
-        _personalState.setSource(_allDrinks);
+        _setAllDrinks(cached);
         _error = null;
         _isLoading = false;
       } else {
@@ -481,9 +479,7 @@ class BeerProvider extends ChangeNotifier {
     // Clear existing drinks and signal the switch immediately so the UI rebuilds
     // against the new festival id; the new festival's cached drinks (if any)
     // replace them below, otherwise the spinner stays up.
-    _allDrinks = [];
-    _filter.setSource(_allDrinks);
-    _personalState.setSource(_allDrinks);
+    _setAllDrinks([]);
     _error = null;
     _refreshNotice = null;
     _isLoading = true;
@@ -494,9 +490,7 @@ class BeerProvider extends ChangeNotifier {
     final cached = await _drinkRepository?.getCachedDrinks(festival);
     if (token != _drinksLoadToken) return;
     if (cached != null) {
-      _allDrinks = cached;
-      _filter.setSource(_allDrinks);
-      _personalState.setSource(_allDrinks);
+      _setAllDrinks(cached);
       _isLoading = false;
       notifyListeners();
     }
@@ -524,9 +518,7 @@ class BeerProvider extends ChangeNotifier {
       // Repository returns drinks with favorites and ratings already populated.
       final drinks = await _drinkRepository!.getDrinks(festival);
       if (token != _drinksLoadToken) return;
-      _allDrinks = drinks;
-      _filter.setSource(_allDrinks);
-      _personalState.setSource(_allDrinks);
+      _setAllDrinks(drinks);
       _error = null;
       _refreshNotice = null;
       // Only mark drinks as freshly fetched when the festival had types to
@@ -548,9 +540,7 @@ class BeerProvider extends ChangeNotifier {
         _error = null;
       } else {
         _error = _getUserFriendlyErrorMessage(e);
-        _allDrinks = [];
-        _filter.setSource(_allDrinks);
-        _personalState.setSource(_allDrinks);
+        _setAllDrinks([]);
       }
       // Log to Crashlytics unless this is an expected offline failure that we
       // already covered with cached data. Always log when fully blocked, and
@@ -765,6 +755,16 @@ class BeerProvider extends ChangeNotifier {
     // Persist the preference
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(PreferenceKeys.themeMode, mode.index);
+  }
+
+  /// Assign [drinks] as the active catalogue and propagate to both controllers.
+  ///
+  /// Single call site ensures [_allDrinks], [_filter], and [_personalState]
+  /// are never updated independently.
+  void _setAllDrinks(List<Drink> drinks) {
+    _allDrinks = drinks;
+    _filter.setSource(drinks);
+    _personalState.setSource(drinks);
   }
 
   /// Replace a drink in [_allDrinks] with [updated] and recompute filters.

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -815,7 +815,7 @@ class BeerProvider extends ChangeNotifier {
       // Log analytics event for rating (fire and forget)
       unawaited(_analyticsService.logRatingGiven(drink, rating));
     }
-    final newState = _personalState.applyRating(drink.id, rating);
+    final newState = _personalState.applyRating(drink.id, rating: rating);
     _replaceDrink(drink, drink.copyWith(userState: newState));
     notifyListeners();
   }

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -19,6 +19,11 @@ class BeerProvider extends ChangeNotifier {
   /// provider feeds it the loaded drinks and handles persistence, analytics,
   /// and change notification around it.
   final DrinkFilterController _filter;
+
+  /// Owns in-memory personal state (want-to-try, rating, tasting) keyed by
+  /// drink ID. This provider feeds it the loaded drinks and handles
+  /// persistence, analytics, and change notification around it.
+  final UserDrinkStateController _personalState = UserDrinkStateController();
   DrinkRepository? _drinkRepository;
   FestivalRepository? _festivalRepository;
   ApiDrinkRepository? _ownedDrinkRepository;
@@ -442,6 +447,7 @@ class BeerProvider extends ChangeNotifier {
       if (cached != null) {
         _allDrinks = cached;
         _filter.setSource(_allDrinks);
+        _personalState.setSource(_allDrinks);
         _error = null;
         _isLoading = false;
       } else {
@@ -477,6 +483,7 @@ class BeerProvider extends ChangeNotifier {
     // replace them below, otherwise the spinner stays up.
     _allDrinks = [];
     _filter.setSource(_allDrinks);
+    _personalState.setSource(_allDrinks);
     _error = null;
     _refreshNotice = null;
     _isLoading = true;
@@ -489,6 +496,7 @@ class BeerProvider extends ChangeNotifier {
     if (cached != null) {
       _allDrinks = cached;
       _filter.setSource(_allDrinks);
+      _personalState.setSource(_allDrinks);
       _isLoading = false;
       notifyListeners();
     }
@@ -518,6 +526,7 @@ class BeerProvider extends ChangeNotifier {
       if (token != _drinksLoadToken) return;
       _allDrinks = drinks;
       _filter.setSource(_allDrinks);
+      _personalState.setSource(_allDrinks);
       _error = null;
       _refreshNotice = null;
       // Only mark drinks as freshly fetched when the festival had types to
@@ -541,6 +550,7 @@ class BeerProvider extends ChangeNotifier {
         _error = _getUserFriendlyErrorMessage(e);
         _allDrinks = [];
         _filter.setSource(_allDrinks);
+        _personalState.setSource(_allDrinks);
       }
       // Log to Crashlytics unless this is an expected offline failure that we
       // already covered with cached data. Always log when fully blocked, and
@@ -781,12 +791,8 @@ class BeerProvider extends ChangeNotifier {
       currentFestival.id,
       drink.id,
     );
-    final base = drink.userState ?? UserDrinkState.initial();
-    final nextState = base.copyWith(wantToTry: newStatus);
-    _replaceDrink(
-      drink,
-      drink.copyWith(userState: nextState.isEmpty ? null : nextState),
-    );
+    final newState = _personalState.applyWantToTry(drink.id, value: newStatus);
+    _replaceDrink(drink, drink.copyWith(userState: newState));
 
     notifyListeners();
 
@@ -809,12 +815,8 @@ class BeerProvider extends ChangeNotifier {
       // Log analytics event for rating (fire and forget)
       unawaited(_analyticsService.logRatingGiven(drink, rating));
     }
-    final base = drink.userState ?? UserDrinkState.initial();
-    final nextState = base.copyWith(rating: rating);
-    _replaceDrink(
-      drink,
-      drink.copyWith(userState: nextState.isEmpty ? null : nextState),
-    );
+    final newState = _personalState.applyRating(drink.id, rating);
+    _replaceDrink(drink, drink.copyWith(userState: newState));
     notifyListeners();
   }
 
@@ -828,14 +830,8 @@ class BeerProvider extends ChangeNotifier {
     );
     // Binary toggle mirrors the repository: a single event when tasted, none
     // when cleared. (Multiple-tasting support is feature work in #315.)
-    final base = drink.userState ?? UserDrinkState.initial();
-    final nextState = base.copyWith(
-      tastingEvents: newStatus ? [DateTime.now()] : const [],
-    );
-    _replaceDrink(
-      drink,
-      drink.copyWith(userState: nextState.isEmpty ? null : nextState),
-    );
+    final newState = _personalState.applyTasted(drink.id, tasted: newStatus);
+    _replaceDrink(drink, drink.copyWith(userState: newState));
 
     notifyListeners();
 

--- a/test/domain/controllers/user_drink_state_controller_test.dart
+++ b/test/domain/controllers/user_drink_state_controller_test.dart
@@ -2,6 +2,24 @@ import 'package:cambridge_beer_festival/domain/controllers/controllers.dart';
 import 'package:cambridge_beer_festival/models/models.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+final _kNow = DateTime(2026, 6, 7);
+
+UserDrinkState _sampleState({
+  bool wantToTry = false,
+  int? rating,
+  List<DateTime>? tastingEvents,
+  DateTime? createdAt,
+  DateTime? updatedAt,
+}) {
+  return UserDrinkState(
+    wantToTry: wantToTry,
+    rating: rating,
+    tastingEvents: tastingEvents,
+    createdAt: createdAt ?? _kNow,
+    updatedAt: updatedAt ?? _kNow,
+  );
+}
+
 Drink _drink({required String id, UserDrinkState? userState}) {
   final producer = Producer.fromJson({
     'id': 'brewery-1',
@@ -36,13 +54,10 @@ void main() {
 
     group('setSource / clear', () {
       test('setSource populates state from drinks with non-null userState', () {
-        final now = DateTime(2026, 6, 7);
-        final stateWithData = UserDrinkState(
-          wantToTry: true,
-          createdAt: now,
-          updatedAt: now,
+        final drinkWithState = _drink(
+          id: 'd1',
+          userState: _sampleState(wantToTry: true),
         );
-        final drinkWithState = _drink(id: 'd1', userState: stateWithData);
         final drinkWithoutState = _drink(id: 'd2');
 
         controller.setSource([drinkWithState, drinkWithoutState]);
@@ -59,32 +74,23 @@ void main() {
       });
 
       test('setSource replaces previous state on re-call', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(
-          wantToTry: true,
-          createdAt: now,
-          updatedAt: now,
-        );
-        final drinkA = _drink(id: 'a', userState: state);
-        controller.setSource([drinkA]);
-
-        // Second call with a different list
-        final drinkB = _drink(id: 'b', userState: state);
-        controller.setSource([drinkB]);
+        controller
+          ..setSource([
+            _drink(id: 'a', userState: _sampleState(wantToTry: true)),
+          ])
+          ..setSource([
+            _drink(id: 'b', userState: _sampleState(wantToTry: true)),
+          ]);
 
         expect(controller.stateFor('a'), isNull);
         expect(controller.stateFor('b'), isNotNull);
       });
 
       test('clear removes all state', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(
-          wantToTry: true,
-          createdAt: now,
-          updatedAt: now,
-        );
         controller
-          ..setSource([_drink(id: 'd1', userState: state)])
+          ..setSource([
+            _drink(id: 'd1', userState: _sampleState(wantToTry: true)),
+          ])
           ..clear();
 
         expect(controller.stateFor('d1'), isNull);
@@ -99,13 +105,9 @@ void main() {
       });
 
       test('isFavorite returns true when wantToTry is set', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(
-          wantToTry: true,
-          createdAt: now,
-          updatedAt: now,
-        );
-        controller.setSource([_drink(id: 'd1', userState: state)]);
+        controller.setSource([
+          _drink(id: 'd1', userState: _sampleState(wantToTry: true)),
+        ]);
 
         expect(controller.isFavorite('d1'), isTrue);
       });
@@ -115,9 +117,9 @@ void main() {
       });
 
       test('ratingFor returns value when rating is set', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(rating: 4, createdAt: now, updatedAt: now);
-        controller.setSource([_drink(id: 'd1', userState: state)]);
+        controller.setSource([
+          _drink(id: 'd1', userState: _sampleState(rating: 4)),
+        ]);
 
         expect(controller.ratingFor('d1'), equals(4));
       });
@@ -127,13 +129,12 @@ void main() {
       });
 
       test('isTasted returns true when tastingEvents non-empty', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(
-          tastingEvents: [now],
-          createdAt: now,
-          updatedAt: now,
-        );
-        controller.setSource([_drink(id: 'd1', userState: state)]);
+        controller.setSource([
+          _drink(
+            id: 'd1',
+            userState: _sampleState(tastingEvents: [_kNow]),
+          ),
+        ]);
 
         expect(controller.isTasted('d1'), isTrue);
       });
@@ -143,13 +144,14 @@ void main() {
       });
 
       test('tastingCountFor returns count of tasting events', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(
-          tastingEvents: [now, now.add(const Duration(hours: 1))],
-          createdAt: now,
-          updatedAt: now,
-        );
-        controller.setSource([_drink(id: 'd1', userState: state)]);
+        controller.setSource([
+          _drink(
+            id: 'd1',
+            userState: _sampleState(
+              tastingEvents: [_kNow, _kNow.add(const Duration(hours: 1))],
+            ),
+          ),
+        ]);
 
         expect(controller.tastingCountFor('d1'), equals(2));
       });
@@ -174,14 +176,9 @@ void main() {
       });
 
       test('clears wantToTry but retains rating when other state present', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(
-          wantToTry: true,
-          rating: 3,
-          createdAt: now,
-          updatedAt: now,
-        );
-        controller.setSource([_drink(id: 'd1', userState: state)]);
+        controller.setSource([
+          _drink(id: 'd1', userState: _sampleState(wantToTry: true, rating: 3)),
+        ]);
 
         final result = controller.applyWantToTry('d1', value: false);
 
@@ -209,14 +206,9 @@ void main() {
       });
 
       test('clears rating but retains wantToTry when other state present', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(
-          wantToTry: true,
-          rating: 3,
-          createdAt: now,
-          updatedAt: now,
-        );
-        controller.setSource([_drink(id: 'd1', userState: state)]);
+        controller.setSource([
+          _drink(id: 'd1', userState: _sampleState(wantToTry: true, rating: 3)),
+        ]);
 
         final result = controller.applyRating('d1', rating: null);
 
@@ -274,10 +266,8 @@ void main() {
 
     group('cross-field preservation', () {
       test('applyWantToTry preserves existing rating', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(rating: 4, createdAt: now, updatedAt: now);
         controller
-          ..setSource([_drink(id: 'd1', userState: state)])
+          ..setSource([_drink(id: 'd1', userState: _sampleState(rating: 4))])
           ..applyWantToTry('d1', value: true);
 
         expect(controller.ratingFor('d1'), equals(4));
@@ -285,14 +275,10 @@ void main() {
       });
 
       test('applyRating preserves existing wantToTry', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(
-          wantToTry: true,
-          createdAt: now,
-          updatedAt: now,
-        );
         controller
-          ..setSource([_drink(id: 'd1', userState: state)])
+          ..setSource([
+            _drink(id: 'd1', userState: _sampleState(wantToTry: true)),
+          ])
           ..applyRating('d1', rating: 5);
 
         expect(controller.isFavorite('d1'), isTrue);
@@ -300,11 +286,9 @@ void main() {
       });
 
       test('applyTasted preserves existing rating', () {
-        final now = DateTime(2026, 6, 7);
-        final state = UserDrinkState(rating: 3, createdAt: now, updatedAt: now);
         controller
-          ..setSource([_drink(id: 'd1', userState: state)])
-          ..applyTasted('d1', tasted: true, now: now);
+          ..setSource([_drink(id: 'd1', userState: _sampleState(rating: 3))])
+          ..applyTasted('d1', tasted: true, now: _kNow);
 
         expect(controller.ratingFor('d1'), equals(3));
         expect(controller.isTasted('d1'), isTrue);

--- a/test/domain/controllers/user_drink_state_controller_test.dart
+++ b/test/domain/controllers/user_drink_state_controller_test.dart
@@ -1,0 +1,314 @@
+import 'package:cambridge_beer_festival/domain/controllers/controllers.dart';
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Drink _drink({required String id, UserDrinkState? userState}) {
+  final producer = Producer.fromJson({
+    'id': 'brewery-1',
+    'name': 'Test Brewery',
+    'location': 'Cambridge',
+    'products': const [],
+  });
+  final product = Product.fromJson({
+    'id': id,
+    'name': 'Test Drink $id',
+    'category': 'beer',
+    'dispense': 'cask',
+    'abv': '5.0',
+  });
+  return Drink(
+    product: product,
+    producer: producer,
+    festivalId: 'cbf2025',
+    userState: userState,
+  );
+}
+
+void main() {
+  group('UserDrinkStateController', () {
+    late UserDrinkStateController controller;
+
+    setUp(() {
+      controller = UserDrinkStateController();
+    });
+
+    // --- setSource / clear ---
+
+    group('setSource / clear', () {
+      test('setSource populates state from drinks with non-null userState', () {
+        final now = DateTime(2026, 6, 7);
+        final stateWithData = UserDrinkState(
+          wantToTry: true,
+          createdAt: now,
+          updatedAt: now,
+        );
+        final drinkWithState = _drink(id: 'd1', userState: stateWithData);
+        final drinkWithoutState = _drink(id: 'd2');
+
+        controller.setSource([drinkWithState, drinkWithoutState]);
+
+        expect(controller.stateFor('d1'), isNotNull);
+        expect(controller.stateFor('d2'), isNull);
+      });
+
+      test('setSource ignores drinks with null userState', () {
+        final drinkWithoutState = _drink(id: 'd1');
+        controller.setSource([drinkWithoutState]);
+
+        expect(controller.stateFor('d1'), isNull);
+      });
+
+      test('setSource replaces previous state on re-call', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(
+          wantToTry: true,
+          createdAt: now,
+          updatedAt: now,
+        );
+        final drinkA = _drink(id: 'a', userState: state);
+        controller.setSource([drinkA]);
+
+        // Second call with a different list
+        final drinkB = _drink(id: 'b', userState: state);
+        controller.setSource([drinkB]);
+
+        expect(controller.stateFor('a'), isNull);
+        expect(controller.stateFor('b'), isNotNull);
+      });
+
+      test('clear removes all state', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(
+          wantToTry: true,
+          createdAt: now,
+          updatedAt: now,
+        );
+        controller
+          ..setSource([_drink(id: 'd1', userState: state)])
+          ..clear();
+
+        expect(controller.stateFor('d1'), isNull);
+      });
+    });
+
+    // --- read access ---
+
+    group('read access', () {
+      test('isFavorite returns false for unknown id', () {
+        expect(controller.isFavorite('unknown'), isFalse);
+      });
+
+      test('isFavorite returns true when wantToTry is set', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(
+          wantToTry: true,
+          createdAt: now,
+          updatedAt: now,
+        );
+        controller.setSource([_drink(id: 'd1', userState: state)]);
+
+        expect(controller.isFavorite('d1'), isTrue);
+      });
+
+      test('ratingFor returns null for unknown id', () {
+        expect(controller.ratingFor('unknown'), isNull);
+      });
+
+      test('ratingFor returns value when rating is set', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(rating: 4, createdAt: now, updatedAt: now);
+        controller.setSource([_drink(id: 'd1', userState: state)]);
+
+        expect(controller.ratingFor('d1'), equals(4));
+      });
+
+      test('isTasted returns false for unknown id', () {
+        expect(controller.isTasted('unknown'), isFalse);
+      });
+
+      test('isTasted returns true when tastingEvents non-empty', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(
+          tastingEvents: [now],
+          createdAt: now,
+          updatedAt: now,
+        );
+        controller.setSource([_drink(id: 'd1', userState: state)]);
+
+        expect(controller.isTasted('d1'), isTrue);
+      });
+
+      test('tastingCountFor returns 0 for unknown id', () {
+        expect(controller.tastingCountFor('unknown'), equals(0));
+      });
+
+      test('tastingCountFor returns count of tasting events', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(
+          tastingEvents: [now, now.add(const Duration(hours: 1))],
+          createdAt: now,
+          updatedAt: now,
+        );
+        controller.setSource([_drink(id: 'd1', userState: state)]);
+
+        expect(controller.tastingCountFor('d1'), equals(2));
+      });
+    });
+
+    // --- applyWantToTry ---
+
+    group('applyWantToTry', () {
+      test('sets wantToTry on drink with no prior state', () {
+        final result = controller.applyWantToTry('d1', value: true);
+
+        expect(result, isNotNull);
+        expect(controller.isFavorite('d1'), isTrue);
+      });
+
+      test('returns null and prunes when clearing sole field', () {
+        controller.applyWantToTry('d1', value: true);
+        final result = controller.applyWantToTry('d1', value: false);
+
+        expect(result, isNull);
+        expect(controller.stateFor('d1'), isNull);
+      });
+
+      test('clears wantToTry but retains rating when other state present', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(
+          wantToTry: true,
+          rating: 3,
+          createdAt: now,
+          updatedAt: now,
+        );
+        controller.setSource([_drink(id: 'd1', userState: state)]);
+
+        final result = controller.applyWantToTry('d1', value: false);
+
+        expect(result, isNotNull);
+        expect(controller.ratingFor('d1'), equals(3));
+      });
+    });
+
+    // --- applyRating ---
+
+    group('applyRating', () {
+      test('sets rating on drink with no prior state', () {
+        final result = controller.applyRating('d1', 5);
+
+        expect(result, isNotNull);
+        expect(controller.ratingFor('d1'), equals(5));
+      });
+
+      test('clears rating (null) and prunes when no other state', () {
+        controller.applyRating('d1', 3);
+        final result = controller.applyRating('d1', null);
+
+        expect(result, isNull);
+        expect(controller.stateFor('d1'), isNull);
+      });
+
+      test('clears rating but retains wantToTry when other state present', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(
+          wantToTry: true,
+          rating: 3,
+          createdAt: now,
+          updatedAt: now,
+        );
+        controller.setSource([_drink(id: 'd1', userState: state)]);
+
+        final result = controller.applyRating('d1', null);
+
+        expect(result, isNotNull);
+        expect(controller.isFavorite('d1'), isTrue);
+      });
+    });
+
+    // --- applyTasted ---
+
+    group('applyTasted', () {
+      test('records a single tasting event when tasted=true', () {
+        final result = controller.applyTasted(
+          'd1',
+          tasted: true,
+          now: DateTime(2026, 6, 7),
+        );
+
+        expect(result, isNotNull);
+        expect(controller.isTasted('d1'), isTrue);
+        expect(controller.tastingCountFor('d1'), equals(1));
+      });
+
+      test('uses injected timestamp', () {
+        final ts = DateTime(2026, 6, 7);
+        controller.applyTasted('d1', tasted: true, now: ts);
+
+        expect(controller.stateFor('d1')!.tastingEvents.first, equals(ts));
+      });
+
+      test('clears tasting events when tasted=false', () {
+        controller.applyTasted('d1', tasted: true, now: DateTime(2026, 6, 7));
+        final result = controller.applyTasted('d1', tasted: false);
+
+        expect(controller.isTasted('d1'), isFalse);
+        expect(result, isNull);
+      });
+
+      test(
+        'binary toggle: calling applyTasted(true) twice still yields count=1',
+        () {
+          final ts1 = DateTime(2026, 6, 7, 10);
+          final ts2 = DateTime(2026, 6, 7, 11);
+          controller
+            ..applyTasted('d1', tasted: true, now: ts1)
+            ..applyTasted('d1', tasted: true, now: ts2);
+
+          expect(controller.tastingCountFor('d1'), equals(1));
+          expect(controller.stateFor('d1')!.tastingEvents.first, equals(ts2));
+        },
+      );
+    });
+
+    // --- cross-field preservation ---
+
+    group('cross-field preservation', () {
+      test('applyWantToTry preserves existing rating', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(rating: 4, createdAt: now, updatedAt: now);
+        controller
+          ..setSource([_drink(id: 'd1', userState: state)])
+          ..applyWantToTry('d1', value: true);
+
+        expect(controller.ratingFor('d1'), equals(4));
+        expect(controller.isFavorite('d1'), isTrue);
+      });
+
+      test('applyRating preserves existing wantToTry', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(
+          wantToTry: true,
+          createdAt: now,
+          updatedAt: now,
+        );
+        controller
+          ..setSource([_drink(id: 'd1', userState: state)])
+          ..applyRating('d1', 5);
+
+        expect(controller.isFavorite('d1'), isTrue);
+        expect(controller.ratingFor('d1'), equals(5));
+      });
+
+      test('applyTasted preserves existing rating', () {
+        final now = DateTime(2026, 6, 7);
+        final state = UserDrinkState(rating: 3, createdAt: now, updatedAt: now);
+        controller
+          ..setSource([_drink(id: 'd1', userState: state)])
+          ..applyTasted('d1', tasted: true, now: now);
+
+        expect(controller.ratingFor('d1'), equals(3));
+        expect(controller.isTasted('d1'), isTrue);
+      });
+    });
+  });
+}

--- a/test/domain/controllers/user_drink_state_controller_test.dart
+++ b/test/domain/controllers/user_drink_state_controller_test.dart
@@ -194,15 +194,15 @@ void main() {
 
     group('applyRating', () {
       test('sets rating on drink with no prior state', () {
-        final result = controller.applyRating('d1', 5);
+        final result = controller.applyRating('d1', rating: 5);
 
         expect(result, isNotNull);
         expect(controller.ratingFor('d1'), equals(5));
       });
 
       test('clears rating (null) and prunes when no other state', () {
-        controller.applyRating('d1', 3);
-        final result = controller.applyRating('d1', null);
+        controller.applyRating('d1', rating: 3);
+        final result = controller.applyRating('d1', rating: null);
 
         expect(result, isNull);
         expect(controller.stateFor('d1'), isNull);
@@ -218,7 +218,7 @@ void main() {
         );
         controller.setSource([_drink(id: 'd1', userState: state)]);
 
-        final result = controller.applyRating('d1', null);
+        final result = controller.applyRating('d1', rating: null);
 
         expect(result, isNotNull);
         expect(controller.isFavorite('d1'), isTrue);
@@ -293,7 +293,7 @@ void main() {
         );
         controller
           ..setSource([_drink(id: 'd1', userState: state)])
-          ..applyRating('d1', 5);
+          ..applyRating('d1', rating: 5);
 
         expect(controller.isFavorite('d1'), isTrue);
         expect(controller.ratingFor('d1'), equals(5));


### PR DESCRIPTION
## Summary

- Adds `UserDrinkStateController` — a pure-Dart controller (no Flutter/async/analytics) that owns the in-memory personal-state map, mirroring the `DrinkFilterController` pattern introduced when filtering was extracted.
- Wires it into `BeerProvider`: `setSource` is co-called alongside `_filter.setSource` at all 5 load/refresh/clear sites; `toggleFavorite`, `setRating`, and `toggleTasted` delegate their `copyWith` mutation logic to the controller's `applyWantToTry`, `applyRating`, and `applyTasted` methods.
- Adds 25 unit tests for the controller following red/green/refactor TDD: tests were written first (red), controller implemented to make them pass (green).

## What changed

| File | Change |
|---|---|
| `lib/domain/controllers/user_drink_state_controller.dart` | New controller |
| `lib/domain/controllers/controllers.dart` | Export new controller |
| `lib/providers/beer_provider.dart` | Compose controller; delegate mutation logic |
| `test/domain/controllers/user_drink_state_controller_test.dart` | 25 unit tests |

## Test plan

- All 1001 existing tests continue to pass (`./bin/mise run check` green)
- New controller tests cover: `setSource`/`clear` lifecycle, all read-access getters, `applyWantToTry`/`applyRating`/`applyTasted` mutations including empty-record pruning and cross-field preservation, binary-toggle semantics for tasting events, and injected-timestamp testability

Fixes #392