### PR TITLE
refactor: simplify controllers and eliminate parallel switch and boilerplate

### DIFF
--- a/lib/constants/preference_keys.dart
+++ b/lib/constants/preference_keys.dart
@@ -57,7 +57,10 @@ class PreferenceKeys {
   /// Flag set to `true` after the one-time migration of pre-#391 personal-state
   /// keys into the unified [userStatePrefix] format. When present and true the
   /// migration is skipped on startup, avoiding a full key-scan every launch.
-  static const legacyMigrationComplete = 'user_state_migration_v1';
+  ///
+  /// Intentionally does NOT share the `user_state_` prefix so it cannot
+  /// collide with a per-drink record key (`user_state_{festivalId}_{drinkId}`).
+  static const legacyMigrationComplete = 'personal_state_migration_v1';
 
   // --- FestivalStorageService ---
 

--- a/lib/constants/preference_keys.dart
+++ b/lib/constants/preference_keys.dart
@@ -54,6 +54,11 @@ class PreferenceKeys {
   /// Never written.
   static const tastingLogLegacyPrefix = 'tasting_log_';
 
+  /// Flag set to `true` after the one-time migration of pre-#391 personal-state
+  /// keys into the unified [userStatePrefix] format. When present and true the
+  /// migration is skipped on startup, avoiding a full key-scan every launch.
+  static const legacyMigrationComplete = 'user_state_migration_v1';
+
   // --- FestivalStorageService ---
 
   /// The last selected festival ID. Stored with `setString`.

--- a/lib/domain/controllers/user_drink_state_controller.dart
+++ b/lib/domain/controllers/user_drink_state_controller.dart
@@ -59,13 +59,11 @@ class UserDrinkStateController {
     String drinkId, {
     required bool value,
     DateTime? now,
-  }) {
-    final (timestamp, base) = _baseFor(drinkId, now);
-    return _apply(
-      drinkId,
-      base.copyWith(wantToTry: value, updatedAt: timestamp),
-    );
-  }
+  }) => _mutate(
+    drinkId,
+    (base, ts) => base.copyWith(wantToTry: value, updatedAt: ts),
+    now,
+  );
 
   /// Apply a rating change (1–5) or clear it (null) for [drinkId]. Creates a
   /// fresh record if none exists. Returns the updated [UserDrinkState], or
@@ -74,10 +72,11 @@ class UserDrinkStateController {
     String drinkId, {
     required int? rating,
     DateTime? now,
-  }) {
-    final (timestamp, base) = _baseFor(drinkId, now);
-    return _apply(drinkId, base.copyWith(rating: rating, updatedAt: timestamp));
-  }
+  }) => _mutate(
+    drinkId,
+    (base, ts) => base.copyWith(rating: rating, updatedAt: ts),
+    now,
+  );
 
   /// Record or clear a tasting event for [drinkId]. When [tasted] is true,
   /// sets the tasting list to `[now]` (binary toggle — replaces any previous
@@ -88,18 +87,26 @@ class UserDrinkStateController {
     String drinkId, {
     required bool tasted,
     DateTime? now,
-  }) {
-    final (timestamp, base) = _baseFor(drinkId, now);
-    return _apply(
-      drinkId,
-      base.copyWith(
-        tastingEvents: tasted ? [timestamp] : const [],
-        updatedAt: timestamp,
-      ),
-    );
-  }
+  }) => _mutate(
+    drinkId,
+    (base, ts) =>
+        base.copyWith(tastingEvents: tasted ? [ts] : const [], updatedAt: ts),
+    now,
+  );
 
   // --- Internal helpers ---
+
+  /// Applies [transform] to the base state for [drinkId] and stores the
+  /// result. Creates a fresh [UserDrinkState] when no record exists yet.
+  /// Returns the updated state, or null when it became empty and was pruned.
+  UserDrinkState? _mutate(
+    String drinkId,
+    UserDrinkState Function(UserDrinkState, DateTime) transform,
+    DateTime? now,
+  ) {
+    final (timestamp, base) = _baseFor(drinkId, now);
+    return _apply(drinkId, transform(base, timestamp));
+  }
 
   /// Resolves the effective timestamp and base state for a mutation. Creates a
   /// fresh [UserDrinkState] when no record exists yet for [drinkId].

--- a/lib/services/user_data_store.dart
+++ b/lib/services/user_data_store.dart
@@ -115,6 +115,8 @@ class SharedPreferencesUserDataStore implements UserDataStore {
   /// rather than overwriting. Idempotent: once the legacy keys are removed a
   /// second call finds nothing and does no work.
   Future<void> migrateLegacyData() async {
+    if (_prefs.getBool(PreferenceKeys.legacyMigrationComplete) == true) return;
+
     const favKey = PreferenceKeys.favoritesLegacy;
     const ratingsKey = PreferenceKeys.ratingsLegacy;
     const tastingKey = PreferenceKeys.tastingLogLegacyPrefix;
@@ -151,36 +153,38 @@ class SharedPreferencesUserDataStore implements UserDataStore {
       }
     }
 
-    if (legacyKeys.isEmpty) return;
+    if (legacyKeys.isNotEmpty) {
+      final touched = <(String, String)>{
+        for (final entry in favourites.entries)
+          for (final drinkId in entry.value) (entry.key, drinkId),
+        ...ratings.keys,
+        ...tastings.keys,
+      };
 
-    final touched = <(String, String)>{
-      for (final entry in favourites.entries)
-        for (final drinkId in entry.value) (entry.key, drinkId),
-      ...ratings.keys,
-      ...tastings.keys,
-    };
+      for (final (festivalId, drinkId) in touched) {
+        final existing = read(festivalId, drinkId) ?? UserDrinkState.initial();
+        final millis = tastings[(festivalId, drinkId)];
+        final merged = existing.copyWith(
+          wantToTry:
+              existing.wantToTry ||
+              (favourites[festivalId]?.contains(drinkId) ?? false),
+          rating: existing.rating ?? ratings[(festivalId, drinkId)],
+          // Only seed a tasting event when the new record has none, so
+          // re-running can't duplicate events.
+          tastingEvents: millis != null && existing.tastingEvents.isEmpty
+              ? [DateTime.fromMillisecondsSinceEpoch(millis)]
+              : existing.tastingEvents,
+          updatedAt: DateTime.now(),
+        );
+        await write(festivalId, drinkId, merged);
+      }
 
-    for (final (festivalId, drinkId) in touched) {
-      final existing = read(festivalId, drinkId) ?? UserDrinkState.initial();
-      final millis = tastings[(festivalId, drinkId)];
-      final merged = existing.copyWith(
-        wantToTry:
-            existing.wantToTry ||
-            (favourites[festivalId]?.contains(drinkId) ?? false),
-        rating: existing.rating ?? ratings[(festivalId, drinkId)],
-        // Only seed a tasting event when the new record has none, so re-running
-        // can't duplicate events.
-        tastingEvents: millis != null && existing.tastingEvents.isEmpty
-            ? [DateTime.fromMillisecondsSinceEpoch(millis)]
-            : existing.tastingEvents,
-        updatedAt: DateTime.now(),
-      );
-      await write(festivalId, drinkId, merged);
+      for (final key in legacyKeys) {
+        await _prefs.remove(key);
+      }
     }
 
-    for (final key in legacyKeys) {
-      await _prefs.remove(key);
-    }
+    await _prefs.setBool(PreferenceKeys.legacyMigrationComplete, true);
   }
 
   /// Upgrade a raw persisted payload to the current schema, then deserialise.

--- a/lib/services/user_data_store.dart
+++ b/lib/services/user_data_store.dart
@@ -112,8 +112,9 @@ class SharedPreferencesUserDataStore implements UserDataStore {
   /// `ratings_{festivalId}_{drinkId}` (int → rating) and
   /// `tasting_log_{festivalId}|{drinkId}` (int millis → a tasting event) into
   /// the matching `user_state_*` record, merging with any record already there
-  /// rather than overwriting. Idempotent: once the legacy keys are removed a
-  /// second call finds nothing and does no work.
+  /// rather than overwriting. Idempotent: a persisted [PreferenceKeys
+  /// .legacyMigrationComplete] flag short-circuits the method on every launch
+  /// after the first successful run, so no key scan occurs.
   Future<void> migrateLegacyData() async {
     if (_prefs.getBool(PreferenceKeys.legacyMigrationComplete) == true) return;
 

--- a/lib/services/user_data_store.dart
+++ b/lib/services/user_data_store.dart
@@ -112,9 +112,9 @@ class SharedPreferencesUserDataStore implements UserDataStore {
   /// `ratings_{festivalId}_{drinkId}` (int → rating) and
   /// `tasting_log_{festivalId}|{drinkId}` (int millis → a tasting event) into
   /// the matching `user_state_*` record, merging with any record already there
-  /// rather than overwriting. Idempotent: a persisted [PreferenceKeys
-  /// .legacyMigrationComplete] flag short-circuits the method on every launch
-  /// after the first successful run, so no key scan occurs.
+  /// rather than overwriting. Idempotent: a persisted
+  /// [PreferenceKeys.legacyMigrationComplete] flag short-circuits the method
+  /// on every launch after the first successful run, so no key scan occurs.
   Future<void> migrateLegacyData() async {
     if (_prefs.getBool(PreferenceKeys.legacyMigrationComplete) == true) return;
 

--- a/lib/widgets/drink_filter_sheets.dart
+++ b/lib/widgets/drink_filter_sheets.dart
@@ -7,38 +7,28 @@ import '../utils/utils.dart';
 /// Shows the category filter as a modal bottom sheet.
 void showCategoryFilter(BuildContext context) {
   final provider = context.read<BeerProvider>();
-  showModalBottomSheet(
-    context: context,
-    isScrollControlled: true,
-    builder: (context) => CategoryFilterSheet(provider: provider),
-  );
+  _showSheet(context, (_) => CategoryFilterSheet(provider: provider));
 }
 
 /// Shows the style filter (multi-select) as a modal bottom sheet.
-void showStyleFilter(BuildContext context) {
-  showModalBottomSheet(
-    context: context,
-    isScrollControlled: true,
-    builder: (context) => const StyleFilterSheet(),
-  );
-}
+void showStyleFilter(BuildContext context) =>
+    _showSheet(context, (_) => const StyleFilterSheet());
 
 /// Shows the sort-options picker as a modal bottom sheet.
 void showSortOptions(BuildContext context) {
   final provider = context.read<BeerProvider>();
-  showModalBottomSheet(
-    context: context,
-    isScrollControlled: true,
-    builder: (context) => SortOptionsSheet(provider: provider),
-  );
+  _showSheet(context, (_) => SortOptionsSheet(provider: provider));
 }
 
 /// Shows the availability/dietary view filters as a modal bottom sheet.
-void showVisibilityFilter(BuildContext context) {
+void showVisibilityFilter(BuildContext context) =>
+    _showSheet(context, (_) => const VisibilityFilterSheet());
+
+void _showSheet(BuildContext context, WidgetBuilder builder) {
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
-    builder: (context) => const VisibilityFilterSheet(),
+    builder: builder,
   );
 }
 

--- a/lib/widgets/festival_header.dart
+++ b/lib/widgets/festival_header.dart
@@ -26,7 +26,7 @@ class FestivalHeader extends StatelessWidget {
     return Semantics(
       label:
           'Current festival: ${provider.currentFestival.name}, '
-          '$drinkCountLabel, ${_statusLabel(status)}',
+          '$drinkCountLabel, ${FestivalStatusBadge.spokenLabel(status)}',
       excludeSemantics: true,
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -68,21 +68,6 @@ class FestivalHeader extends StatelessWidget {
       ),
     );
   }
-
-  /// Spoken form of the status for the screen-reader label (the badge text
-  /// itself — LIVE/SOON/… — is terse and now excluded from semantics).
-  static String _statusLabel(FestivalStatus status) {
-    switch (status) {
-      case FestivalStatus.live:
-        return 'live now';
-      case FestivalStatus.upcoming:
-        return 'starting soon';
-      case FestivalStatus.mostRecent:
-        return 'most recent';
-      case FestivalStatus.past:
-        return 'past';
-    }
-  }
 }
 
 /// Small coloured pill summarising a festival's [FestivalStatus]
@@ -95,7 +80,7 @@ class FestivalStatusBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final (label, lightColor, darkColor) = _styleFor(status);
+    final (badgeLabel, _, lightColor, darkColor) = _styleFor(status);
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
@@ -104,7 +89,7 @@ class FestivalStatusBadge extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Text(
-        label,
+        badgeLabel,
         style: const TextStyle(
           color: Colors.white,
           fontSize: 9,
@@ -114,17 +99,32 @@ class FestivalStatusBadge extends StatelessWidget {
     );
   }
 
-  /// Returns the badge label and its (light, dark) background colours.
-  static (String, Color, Color) _styleFor(FestivalStatus status) {
+  /// Spoken form of the status for screen-reader labels (the badge text is
+  /// terse and is excluded from semantics at the parent level).
+  static String spokenLabel(FestivalStatus status) => _styleFor(status).$2;
+
+  /// Returns the badge label, spoken label, and (light, dark) background
+  /// colours for [status]. Single source of truth for all status styling.
+  static (String, String, Color, Color) _styleFor(FestivalStatus status) {
     switch (status) {
       case FestivalStatus.live:
-        return const ('LIVE', Color(0xFF2E7D32), Color(0xFF4CAF50));
+        return const ('LIVE', 'live now', Color(0xFF2E7D32), Color(0xFF4CAF50));
       case FestivalStatus.upcoming:
-        return const ('SOON', Color(0xFF1976D2), Color(0xFF42A5F5));
+        return const (
+          'SOON',
+          'starting soon',
+          Color(0xFF1976D2),
+          Color(0xFF42A5F5),
+        );
       case FestivalStatus.mostRecent:
-        return const ('RECENT', Color(0xFFEF6C00), Color(0xFFFF9800));
+        return const (
+          'RECENT',
+          'most recent',
+          Color(0xFFEF6C00),
+          Color(0xFFFF9800),
+        );
       case FestivalStatus.past:
-        return const ('PAST', Color(0xFF616161), Color(0xFF9E9E9E));
+        return const ('PAST', 'past', Color(0xFF616161), Color(0xFF9E9E9E));
     }
   }
 }

--- a/test/constants/preference_keys_test.dart
+++ b/test/constants/preference_keys_test.dart
@@ -12,6 +12,7 @@ void main() {
       expect(PreferenceKeys.hideUnavailableLegacy, 'hideUnavailable');
       expect(PreferenceKeys.excludedAllergens, 'excludedAllergens');
       expect(PreferenceKeys.userStatePrefix, 'user_state_');
+      expect(PreferenceKeys.legacyMigrationComplete, 'user_state_migration_v1');
       expect(PreferenceKeys.favoritesLegacy, 'favorites');
       expect(PreferenceKeys.ratingsLegacy, 'ratings');
       expect(PreferenceKeys.tastingLogLegacyPrefix, 'tasting_log_');
@@ -27,6 +28,7 @@ void main() {
         PreferenceKeys.hideUnavailableLegacy,
         PreferenceKeys.excludedAllergens,
         PreferenceKeys.userStatePrefix,
+        PreferenceKeys.legacyMigrationComplete,
         PreferenceKeys.favoritesLegacy,
         PreferenceKeys.ratingsLegacy,
         PreferenceKeys.tastingLogLegacyPrefix,

--- a/test/constants/preference_keys_test.dart
+++ b/test/constants/preference_keys_test.dart
@@ -12,7 +12,10 @@ void main() {
       expect(PreferenceKeys.hideUnavailableLegacy, 'hideUnavailable');
       expect(PreferenceKeys.excludedAllergens, 'excludedAllergens');
       expect(PreferenceKeys.userStatePrefix, 'user_state_');
-      expect(PreferenceKeys.legacyMigrationComplete, 'user_state_migration_v1');
+      expect(
+        PreferenceKeys.legacyMigrationComplete,
+        'personal_state_migration_v1',
+      );
       expect(PreferenceKeys.favoritesLegacy, 'favorites');
       expect(PreferenceKeys.ratingsLegacy, 'ratings');
       expect(PreferenceKeys.tastingLogLegacyPrefix, 'tasting_log_');


### PR DESCRIPTION
- user_drink_state_controller: extract _mutate() helper; the three
  apply* methods shared an identical _baseFor → copyWith → _apply
  pattern that was repeated verbatim

- drink_filter_sheets: extract _showSheet(); the four show* functions
  repeated showModalBottomSheet(isScrollControlled: true, ...) verbatim

- festival_header: merge _statusLabel and _styleFor into one switch on
  FestivalStatusBadge; parallel switches over the same enum meant adding
  a new status required two edits; spokenLabel() replaces the separate
  FestivalHeader._statusLabel static

- user_data_store: guard migrateLegacyData() with a legacyMigrationComplete
  flag so subsequent launches skip the full SharedPreferences key scan;
  adds PreferenceKeys.legacyMigrationComplete and pins it in the test

https://claude.ai/code/session_01GJd7anfRpw2SyHeAaQoZSN