### PR TITLE
feat(domain): extract FestivalController from BeerProvider

### DIFF
--- a/lib/domain/controllers/controllers.dart
+++ b/lib/domain/controllers/controllers.dart
@@ -1,3 +1,4 @@
 // Domain controllers - stateful application logic independent of UI and data layers
 export 'drink_filter_controller.dart';
+export 'festival_controller.dart';
 export 'user_drink_state_controller.dart';

--- a/lib/domain/controllers/festival_controller.dart
+++ b/lib/domain/controllers/festival_controller.dart
@@ -1,0 +1,190 @@
+import 'package:collection/collection.dart';
+
+import '../../models/models.dart';
+
+/// Owns in-memory festival registry state: the festivals list, the current
+/// selection, staleness timestamps, and beverage-type comparison.
+///
+/// Pure application logic: no Flutter, persistence, async, or analytics
+/// dependencies, so it can be unit-tested in isolation. [BeerProvider] composes
+/// this controller and handles the cross-cutting concerns (persistence,
+/// analytics, change notification, and async I/O) around it.
+///
+/// All mutators are synchronous and side-effect free; callers are responsible
+/// for persisting and broadcasting changes.
+class FestivalController {
+  List<Festival> _festivals = [];
+  Festival? _currentFestival;
+
+  /// When the festivals list was last successfully refreshed from the network.
+  ///
+  /// Exposed as a public field so callers (tests and [BeerProvider]'s own
+  /// [visibleForTesting] delegates) can inject a timestamp for testing the
+  /// staleness logic.
+  DateTime? lastFestivalsRefresh;
+
+  /// When a festivals refresh was last attempted (success or failure).
+  ///
+  /// Exposed as a public field for the same reason as [lastFestivalsRefresh].
+  DateTime? lastFestivalsRefreshAttempt;
+
+  static const Duration _festivalsStalenessThreshold = Duration(hours: 24);
+
+  // --- Getters ---
+
+  /// Unmodifiable view of the loaded festivals.
+  List<Festival> get festivals => List.unmodifiable(_festivals);
+
+  /// The currently selected festival.
+  ///
+  /// Returns [_currentFestival] if set, otherwise the first festival in the
+  /// list, or the first [DefaultFestivals.all] entry as a final fallback.
+  Festival get currentFestival =>
+      _currentFestival ??
+      _festivals.firstOrNull ??
+      DefaultFestivals.all.firstWhere(
+        (f) => f.isActive,
+        orElse: () => DefaultFestivals.all.first,
+      );
+
+  /// True when the festivals list is non-empty.
+  bool get hasFestivals => _festivals.isNotEmpty;
+
+  /// Festivals sorted by date: live first, then upcoming (soonest first),
+  /// then past (most recent first). Delegates to [Festival.sortByDate].
+  List<Festival> get sortedFestivals => Festival.sortByDate(_festivals);
+
+  /// True when the festivals data is stale and should be refreshed.
+  ///
+  /// Stale means: never refreshed, or last refreshed more than 24 hours ago.
+  bool get isFestivalsDataStale {
+    if (lastFestivalsRefresh == null) return true;
+    return DateTime.now().difference(lastFestivalsRefresh!) >
+        _festivalsStalenessThreshold;
+  }
+
+  // --- Source management ---
+
+  /// Replace the festivals list and update internal state.
+  ///
+  /// - Updates [lastFestivalsRefresh] to now.
+  /// - Re-points [_currentFestival] to the refreshed object if already
+  ///   selected (matched by id), so any updated metadata (e.g. new beverage
+  ///   types) is reflected immediately.
+  /// - Applies [defaultFestival] only if [_currentFestival] is still null
+  ///   after the re-point step.
+  ///
+  /// Returns true when the current festival's beverage types changed (so the
+  /// caller knows to trigger a drinks reload), false otherwise.
+  bool setSource(List<Festival> festivals, {Festival? defaultFestival}) {
+    _festivals = festivals;
+    lastFestivalsRefresh = DateTime.now();
+
+    // Re-point the current selection at the refreshed object if the id matches.
+    // Capture old beverage types before re-pointing so we can compare.
+    final previousBeverageTypes = _currentFestival?.availableBeverageTypes;
+    if (_currentFestival != null) {
+      final refreshed = _festivals.firstWhereOrNull(
+        (f) => f.id == _currentFestival!.id,
+      );
+      if (refreshed != null) {
+        _currentFestival = refreshed;
+      }
+    }
+
+    // Apply the default only when no selection exists.
+    if (_currentFestival == null && defaultFestival != null) {
+      _currentFestival = defaultFestival;
+    }
+
+    // Report whether the beverage types actually changed.
+    if (previousBeverageTypes == null) return false;
+    return !_sameBeverageTypes(
+      previousBeverageTypes,
+      _currentFestival?.availableBeverageTypes,
+    );
+  }
+
+  /// Set the fallback festivals list (e.g. from cache) without touching
+  /// [lastFestivalsRefresh]. Records [lastFestivalsRefreshAttempt] instead.
+  void setFallbackFestivals(
+    List<Festival> festivals, {
+    Festival? defaultFestival,
+  }) {
+    _festivals = festivals;
+    if (_currentFestival == null && defaultFestival != null) {
+      _currentFestival = defaultFestival;
+    }
+    lastFestivalsRefreshAttempt = DateTime.now();
+  }
+
+  // --- Selection management ---
+
+  /// Explicitly set the current festival.
+  void selectFestival(Festival festival) {
+    _currentFestival = festival;
+  }
+
+  /// Restore the previous selection from a saved festival id.
+  ///
+  /// Looks up [savedId] in the current festivals list and sets
+  /// [_currentFestival] if found. No-op (no exception) if [savedId] is null,
+  /// empty, or not found in the list.
+  void restoreSelection(String? savedId) {
+    if (savedId == null || savedId.isEmpty) return;
+    final found = _festivals.firstWhereOrNull((f) => f.id == savedId);
+    if (found != null) {
+      _currentFestival = found;
+    }
+  }
+
+  /// Set [_currentFestival] to [defaultFestival] only when no festival is
+  /// currently selected. No-op when already selected or [defaultFestival] is
+  /// null.
+  void applyFallback({Festival? defaultFestival}) {
+    if (_currentFestival != null) return;
+    if (defaultFestival == null) return;
+    _currentFestival = defaultFestival;
+  }
+
+  // --- Timestamp management ---
+
+  /// Record that a festivals refresh was attempted (success or failure).
+  void recordAttempt() {
+    lastFestivalsRefreshAttempt = DateTime.now();
+  }
+
+  // --- Query helpers ---
+
+  /// True when [festivalId] refers to a festival in the current list.
+  ///
+  /// Returns false for null, empty, or unrecognised ids.
+  bool isValidFestivalId(String? festivalId) {
+    if (festivalId == null || festivalId.isEmpty) return false;
+    return _festivals.any((f) => f.id == festivalId);
+  }
+
+  /// Return the festival with [festivalId], or null if not found.
+  Festival? getFestivalById(String festivalId) {
+    return _festivals.firstWhereOrNull((f) => f.id == festivalId);
+  }
+
+  // --- Lifecycle ---
+
+  /// Clear the festivals list.
+  void clearFestivals() {
+    _festivals = [];
+  }
+
+  // --- Private helpers ---
+
+  /// Compares two beverage-type lists as unordered sets, so a harmless
+  /// reordering in the registry doesn't trigger a needless drinks refetch.
+  static bool _sameBeverageTypes(List<String>? a, List<String>? b) {
+    if (a == null && b == null) return true;
+    if (a == null || b == null) return false;
+    final setA = a.toSet();
+    final setB = b.toSet();
+    return setA.length == setB.length && setA.containsAll(setB);
+  }
+}

--- a/lib/domain/controllers/festival_controller.dart
+++ b/lib/domain/controllers/festival_controller.dart
@@ -18,9 +18,8 @@ class FestivalController {
 
   /// When the festivals list was last successfully refreshed from the network.
   ///
-  /// Exposed as a public field so callers (tests and [BeerProvider]'s own
-  /// [visibleForTesting] delegates) can inject a timestamp for testing the
-  /// staleness logic.
+  /// Exposed as a public field so callers (tests and [BeerProvider]) can
+  /// inject a timestamp for testing the staleness logic.
   DateTime? lastFestivalsRefresh;
 
   /// When a festivals refresh was last attempted (success or failure).
@@ -103,6 +102,27 @@ class FestivalController {
       previousBeverageTypes,
       _currentFestival?.availableBeverageTypes,
     );
+  }
+
+  /// Restore the festivals list from cache without updating [lastFestivalsRefresh].
+  ///
+  /// Used during app initialization to populate the UI from cached data. Does
+  /// not record a refresh timestamp, allowing [isFestivalsDataStale] to remain
+  /// true and [refreshIfStale()] to immediately try the network. Re-points
+  /// [_currentFestival] to the refreshed object if a festival is already
+  /// selected (matched by id).
+  void setCachedFestivals(List<Festival> festivals) {
+    _festivals = festivals;
+
+    // Re-point the current selection at the refreshed object if the id matches.
+    if (_currentFestival != null) {
+      final refreshed = _festivals.firstWhereOrNull(
+        (f) => f.id == _currentFestival!.id,
+      );
+      if (refreshed != null) {
+        _currentFestival = refreshed;
+      }
+    }
   }
 
   /// Set the fallback festivals list (e.g. from cache) without touching

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -24,6 +24,11 @@ class BeerProvider extends ChangeNotifier {
   /// drink ID. This provider feeds it the loaded drinks and handles
   /// persistence, analytics, and change notification around it.
   final UserDrinkStateController _personalState = UserDrinkStateController();
+
+  /// Owns in-memory festival registry state: the festivals list, the current
+  /// selection, staleness timestamps, and beverage-type comparison.
+  final FestivalController _festivalController = FestivalController();
+
   DrinkRepository? _drinkRepository;
   FestivalRepository? _festivalRepository;
   ApiDrinkRepository? _ownedDrinkRepository;
@@ -43,8 +48,6 @@ class BeerProvider extends ChangeNotifier {
   String? _favoriteEntriesCacheFestivalId;
   List<Drink>? _favoriteEntriesCacheDrinksRef;
 
-  List<Festival> _festivals = [];
-  Festival? _currentFestival;
   bool _isLoading = false;
   bool _isRefreshing = false;
   bool _isFestivalsLoading = false;
@@ -56,17 +59,14 @@ class BeerProvider extends ChangeNotifier {
 
   // Timestamp tracking for automatic refresh
   DateTime? _lastDrinksRefresh;
-  DateTime? _lastFestivalsRefresh;
 
   // Per-attempt timestamps — set on every call regardless of success/failure.
   // Used by refreshIfStale to rate-limit retries without suppressing the
   // staleness window for a successfully recovered network.
   DateTime? _lastDrinksRefreshAttempt;
-  DateTime? _lastFestivalsRefreshAttempt;
 
   // Staleness thresholds
   static const Duration _drinksStalenessThreshold = Duration(hours: 1);
-  static const Duration _festivalsStalenessThreshold = Duration(hours: 24);
 
   // Minimum interval between refresh attempts (covers failed refreshes so the
   // app doesn't hammer the network on every resume when offline).
@@ -92,16 +92,11 @@ class BeerProvider extends ChangeNotifier {
   // Getters
   List<Drink> get drinks => _filter.filteredDrinks;
   List<Drink> get allDrinks => _allDrinks;
-  List<Festival> get festivals => _festivals;
+  List<Festival> get festivals => _festivalController.festivals;
 
   /// Get festivals sorted by date (live/upcoming first, then past in reverse chronological order)
-  List<Festival> get sortedFestivals => Festival.sortByDate(_festivals);
-  Festival get currentFestival =>
-      _currentFestival ??
-      DefaultFestivals.all.firstWhere(
-        (f) => f.isActive,
-        orElse: () => DefaultFestivals.all.first,
-      );
+  List<Festival> get sortedFestivals => _festivalController.sortedFestivals;
+  Festival get currentFestival => _festivalController.currentFestival;
   bool get isLoading => _isLoading;
 
   /// True while a background refresh runs with data already on screen.
@@ -123,7 +118,7 @@ class BeerProvider extends ChangeNotifier {
   Set<String> get excludedAllergens => _filter.excludedAllergens;
   Set<String> get availableAllergens => _filter.availableAllergens;
 
-  bool get hasFestivals => _festivals.isNotEmpty;
+  bool get hasFestivals => _festivalController.hasFestivals;
   ThemeMode get themeMode => _themeMode;
   DateTime? get lastDrinksRefresh => _lastDrinksRefresh;
   @visibleForTesting
@@ -134,10 +129,11 @@ class BeerProvider extends ChangeNotifier {
   set lastDrinksRefreshAttempt(DateTime? value) =>
       _lastDrinksRefreshAttempt = value;
   @visibleForTesting
-  DateTime? get lastFestivalsRefreshAttempt => _lastFestivalsRefreshAttempt;
+  DateTime? get lastFestivalsRefreshAttempt =>
+      _festivalController.lastFestivalsRefreshAttempt;
   @visibleForTesting
   set lastFestivalsRefreshAttempt(DateTime? value) =>
-      _lastFestivalsRefreshAttempt = value;
+      _festivalController.lastFestivalsRefreshAttempt = value;
   AnalyticsService get analyticsService => _analyticsService;
 
   /// Get unique categories from loaded drinks
@@ -213,15 +209,12 @@ class BeerProvider extends ChangeNotifier {
   }
 
   /// Check if a festival ID is valid (exists in the registry)
-  bool isValidFestivalId(String? festivalId) {
-    if (festivalId == null || festivalId.isEmpty) return false;
-    return _festivals.any((f) => f.id == festivalId);
-  }
+  bool isValidFestivalId(String? festivalId) =>
+      _festivalController.isValidFestivalId(festivalId);
 
   /// Get a festival by ID, or null if not found
-  Festival? getFestivalById(String festivalId) {
-    return _festivals.firstWhereOrNull((f) => f.id == festivalId);
-  }
+  Festival? getFestivalById(String festivalId) =>
+      _festivalController.getFestivalById(festivalId);
 
   /// Check if drinks data is stale and should be refreshed
   bool get isDrinksDataStale {
@@ -231,11 +224,7 @@ class BeerProvider extends ChangeNotifier {
   }
 
   /// Check if festivals data is stale and should be refreshed
-  bool get isFestivalsDataStale {
-    if (_lastFestivalsRefresh == null) return true;
-    return DateTime.now().difference(_lastFestivalsRefresh!) >
-        _festivalsStalenessThreshold;
-  }
+  bool get isFestivalsDataStale => _festivalController.isFestivalsDataStale;
 
   /// Initialize with SharedPreferences and load festivals
   Future<void> initialize() async {
@@ -315,7 +304,7 @@ class BeerProvider extends ChangeNotifier {
     // resolve the saved selection without waiting on the network.
     final cachedFestivals = await _festivalRepository!.getCachedFestivals();
     if (cachedFestivals != null) {
-      _festivals = cachedFestivals.festivals;
+      _festivalController.setSource(cachedFestivals.festivals);
     } else {
       // First launch (nothing cached): we have nothing to show until the
       // registry loads, so block on it as before.
@@ -330,14 +319,11 @@ class BeerProvider extends ChangeNotifier {
     // overwrite _currentFestival when the saved id matches an active entry
     // so we don't clobber a default already set by loadFestivals above.
     final savedFestivalId = await _festivalRepository!.getSelectedFestivalId();
-    if (savedFestivalId != null) {
-      final saved = _festivals
-          .where((f) => f.id == savedFestivalId)
-          .firstOrNull;
-      if (saved != null) _currentFestival = saved;
-    }
-    if (_currentFestival == null && cachedFestivals?.defaultFestival != null) {
-      _currentFestival = cachedFestivals!.defaultFestival;
+    _festivalController.restoreSelection(savedFestivalId);
+    if (cachedFestivals != null) {
+      _festivalController.applyFallback(
+        defaultFestival: cachedFestivals.defaultFestival,
+      );
     }
 
     _isInitialized = true;
@@ -358,65 +344,35 @@ class BeerProvider extends ChangeNotifier {
 
     try {
       final response = await _festivalRepository!.getFestivals();
-      _festivals = response.festivals;
+      final beverageTypesChanged = _festivalController.setSource(
+        response.festivals,
+        defaultFestival: response.defaultFestival,
+      );
 
-      if (_currentFestival == null) {
-        // Set default festival if not already set.
-        if (response.defaultFestival != null) {
-          _currentFestival = response.defaultFestival;
-        }
-      } else {
-        // A festival is already selected (typically from the cached registry).
-        // The fresh registry may carry an updated copy of that same festival —
-        // e.g. a beverage type added server-side. Re-point _currentFestival at
-        // the fresh object so its metadata is current, and re-fetch drinks if
-        // the set of beverage types actually changed. Without this, an
-        // in-flight loadDrinks captured against the stale object would silently
-        // never load the newly-added type this session (see #306).
-        final refreshed = _festivals
-            .where((f) => f.id == _currentFestival!.id)
-            .firstOrNull;
-        if (refreshed != null) {
-          final beverageTypesChanged = !_sameBeverageTypes(
-            _currentFestival!.availableBeverageTypes,
-            refreshed.availableBeverageTypes,
-          );
-          _currentFestival = refreshed;
-          if (beverageTypesChanged) {
-            unawaited(loadDrinks());
-          }
-        }
+      if (beverageTypesChanged) {
+        unawaited(loadDrinks());
       }
 
       _festivalsError = null;
-      _lastFestivalsRefresh = DateTime.now();
     } catch (e) {
       // Fall back to cached festivals so the switcher keeps working offline
       // instead of emptying the list and blocking the app.
       final cached = await _festivalRepository?.getCachedFestivals();
       if (cached != null && cached.festivals.isNotEmpty) {
-        _festivals = cached.festivals;
-        if (_currentFestival == null && cached.defaultFestival != null) {
-          _currentFestival = cached.defaultFestival;
-        }
+        _festivalController.setFallbackFestivals(
+          cached.festivals,
+          defaultFestival: cached.defaultFestival,
+        );
         _festivalsError = null;
       } else {
         _festivalsError = _getUserFriendlyErrorMessage(e);
-        _festivals = [];
+        _festivalController.clearFestivals();
       }
     } finally {
-      _lastFestivalsRefreshAttempt = DateTime.now();
+      _festivalController.recordAttempt();
       _isFestivalsLoading = false;
       notifyListeners();
     }
-  }
-
-  /// Compares two beverage-type lists as unordered sets, so a harmless
-  /// reordering in the registry doesn't trigger a needless drinks refetch.
-  static bool _sameBeverageTypes(List<String> a, List<String> b) {
-    final setA = a.toSet();
-    final setB = b.toSet();
-    return setA.length == setB.length && setA.containsAll(setB);
   }
 
   /// Load drinks for the current festival.
@@ -426,14 +382,18 @@ class BeerProvider extends ChangeNotifier {
   /// background. A failed refresh keeps any cached data on screen rather than
   /// blanking to an error.
   Future<void> loadDrinks() async {
-    if (_currentFestival == null) {
+    if (!_festivalController.hasFestivals) {
       // Wait for festivals to be loaded first
-      if (_festivals.isEmpty) {
-        await loadFestivals();
-      }
-      _currentFestival ??= DefaultFestivals.all.firstWhere(
-        (f) => f.isActive,
-        orElse: () => DefaultFestivals.all.first,
+      await loadFestivals();
+    }
+    // Apply a hard-coded fallback if the controller still has no selection
+    // (loadFestivals may have failed).
+    if (!_festivalController.hasFestivals) {
+      _festivalController.applyFallback(
+        defaultFestival: DefaultFestivals.all.firstWhere(
+          (f) => f.isActive,
+          orElse: () => DefaultFestivals.all.first,
+        ),
       );
     }
 
@@ -470,11 +430,11 @@ class BeerProvider extends ChangeNotifier {
     // Tapping the current festival is a no-op unless a refresh notice is
     // up — in which case treat it as a retry so the switcher offers an
     // obvious way back to a fresh load.
-    if (_currentFestival?.id == festival.id) {
+    if (currentFestival.id == festival.id) {
       if (_refreshNotice != null) await loadDrinks();
       return;
     }
-    _currentFestival = festival;
+    _festivalController.selectFestival(festival);
     _filter.clearCategoryStyleSearch();
     // Clear existing drinks and signal the switch immediately so the UI rebuilds
     // against the new festival id; the new festival's cached drinks (if any)
@@ -595,9 +555,11 @@ class BeerProvider extends ChangeNotifier {
     // This prevents hammering the network on every app-resume while offline.
     // DateTime.now() is evaluated separately for each check so that a slow
     // loadFestivals() await doesn't cause the drinks check to use a stale time.
+    final lastFestivalsAttempt =
+        _festivalController.lastFestivalsRefreshAttempt;
     final festivalsRetryReady =
-        _lastFestivalsRefreshAttempt == null ||
-        DateTime.now().difference(_lastFestivalsRefreshAttempt!) >
+        lastFestivalsAttempt == null ||
+        DateTime.now().difference(lastFestivalsAttempt) >
             _refreshRetryThreshold;
     if (isFestivalsDataStale && festivalsRetryReady) {
       await loadFestivals();

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -304,7 +304,7 @@ class BeerProvider extends ChangeNotifier {
     // resolve the saved selection without waiting on the network.
     final cachedFestivals = await _festivalRepository!.getCachedFestivals();
     if (cachedFestivals != null) {
-      _festivalController.setSource(cachedFestivals.festivals);
+      _festivalController.setCachedFestivals(cachedFestivals.festivals);
     } else {
       // First launch (nothing cached): we have nothing to show until the
       // registry loads, so block on it as before.

--- a/test/domain/controllers/festival_controller_test.dart
+++ b/test/domain/controllers/festival_controller_test.dart
@@ -239,7 +239,7 @@ void main() {
       });
 
       test(
-        'true when lastFestivalsRefresh is forced to >24h ago via @visibleForTesting setter',
+        'true when lastFestivalsRefresh is set to a timestamp older than the staleness threshold',
         () {
           final f = createSampleFestival();
           // Set source then force the timestamp to be 25 hours ago

--- a/test/domain/controllers/festival_controller_test.dart
+++ b/test/domain/controllers/festival_controller_test.dart
@@ -1,0 +1,346 @@
+import 'package:cambridge_beer_festival/domain/controllers/controllers.dart';
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Festival createSampleFestival({
+  String id = 'cbf2025',
+  String name = 'Test Festival',
+  List<String> beverageTypes = const ['beer'],
+}) {
+  return Festival(
+    id: id,
+    name: name,
+    availableBeverageTypes: beverageTypes,
+    dataBaseUrl: 'https://data.example.com/$id',
+  );
+}
+
+void main() {
+  group('FestivalController', () {
+    late FestivalController controller;
+
+    setUp(() {
+      controller = FestivalController();
+    });
+
+    group('initial state', () {
+      test('festivals is empty list', () {
+        expect(controller.festivals, isEmpty);
+      });
+
+      test('hasFestivals is false', () {
+        expect(controller.hasFestivals, isFalse);
+      });
+
+      test('isFestivalsDataStale is true when no refresh recorded', () {
+        expect(controller.isFestivalsDataStale, isTrue);
+      });
+
+      test('lastFestivalsRefresh is null', () {
+        expect(controller.lastFestivalsRefresh, isNull);
+      });
+
+      test('lastFestivalsRefreshAttempt is null', () {
+        expect(controller.lastFestivalsRefreshAttempt, isNull);
+      });
+    });
+
+    group('setSource', () {
+      test('sets festivals list', () {
+        final festivals = [
+          createSampleFestival(id: 'cbf2025'),
+          createSampleFestival(id: 'cbf2024'),
+        ];
+        controller.setSource(festivals, defaultFestival: festivals.first);
+        expect(controller.festivals, hasLength(2));
+        expect(
+          controller.festivals.map((f) => f.id),
+          containsAll(['cbf2025', 'cbf2024']),
+        );
+      });
+
+      test(
+        'sets currentFestival to defaultFestival when none previously selected',
+        () {
+          final festivals = [createSampleFestival(id: 'cbf2025')];
+          final defaultFestival = festivals.first;
+          controller.setSource(festivals, defaultFestival: defaultFestival);
+          expect(controller.currentFestival.id, equals('cbf2025'));
+        },
+      );
+
+      test(
+        'does not overwrite existing currentFestival with defaultFestival',
+        () {
+          final first = createSampleFestival(id: 'cbf2025');
+          final second = createSampleFestival(id: 'cbf2024');
+          // set source, select second explicitly, then refresh with first as default
+          controller
+            ..setSource([first, second], defaultFestival: first)
+            ..selectFestival(second)
+            ..setSource([first, second], defaultFestival: first);
+          // should keep cbf2024 because it was explicitly selected
+          expect(controller.currentFestival.id, equals('cbf2024'));
+        },
+      );
+
+      test('re-points currentFestival to refreshed object when id matches', () {
+        final original = createSampleFestival(
+          id: 'cbf2025',
+          beverageTypes: ['beer'],
+        );
+        controller
+          ..setSource([original], defaultFestival: original)
+          ..selectFestival(original);
+
+        final refreshed = createSampleFestival(
+          id: 'cbf2025',
+          beverageTypes: ['beer', 'cider'],
+        );
+        controller.setSource([refreshed], defaultFestival: refreshed);
+
+        // The current festival should now be the refreshed object
+        expect(
+          controller.currentFestival.availableBeverageTypes,
+          containsAll(['beer', 'cider']),
+        );
+      });
+
+      test(
+        'returns true (beverageTypesChanged) when beverage types differ',
+        () {
+          final original = createSampleFestival(
+            id: 'cbf2025',
+            beverageTypes: ['beer'],
+          );
+          controller
+            ..setSource([original], defaultFestival: original)
+            ..selectFestival(original);
+
+          final refreshed = createSampleFestival(
+            id: 'cbf2025',
+            beverageTypes: ['beer', 'cider'],
+          );
+          final changed = controller.setSource([
+            refreshed,
+          ], defaultFestival: refreshed);
+          expect(changed, isTrue);
+        },
+      );
+
+      test('returns false when beverage types unchanged', () {
+        final original = createSampleFestival(
+          id: 'cbf2025',
+          beverageTypes: ['beer'],
+        );
+        controller
+          ..setSource([original], defaultFestival: original)
+          ..selectFestival(original);
+
+        final refreshed = createSampleFestival(
+          id: 'cbf2025',
+          beverageTypes: ['beer'],
+        );
+        final changed = controller.setSource([
+          refreshed,
+        ], defaultFestival: refreshed);
+        expect(changed, isFalse);
+      });
+
+      test('sets lastFestivalsRefresh to non-null after call', () {
+        final festivals = [createSampleFestival()];
+        controller.setSource(festivals, defaultFestival: festivals.first);
+        expect(controller.lastFestivalsRefresh, isNotNull);
+      });
+    });
+
+    group('selectFestival', () {
+      test('sets currentFestival', () {
+        final festival = createSampleFestival(id: 'cbf2025');
+        controller
+          ..setSource([festival], defaultFestival: festival)
+          ..selectFestival(festival);
+        expect(controller.currentFestival.id, equals('cbf2025'));
+      });
+
+      test('overrides previous selection', () {
+        final first = createSampleFestival(id: 'cbf2025');
+        final second = createSampleFestival(id: 'cbf2024');
+        controller
+          ..setSource([first, second], defaultFestival: first)
+          ..selectFestival(first);
+        expect(controller.currentFestival.id, equals('cbf2025'));
+
+        controller.selectFestival(second);
+        expect(controller.currentFestival.id, equals('cbf2024'));
+      });
+    });
+
+    group('restoreSelection', () {
+      test('sets currentFestival to matching festival in list', () {
+        final f1 = createSampleFestival(id: 'cbf2025');
+        final f2 = createSampleFestival(id: 'cbf2024');
+        controller
+          ..setSource([f1, f2], defaultFestival: f1)
+          ..restoreSelection('cbf2024');
+        expect(controller.currentFestival.id, equals('cbf2024'));
+      });
+
+      test('no-op when savedId not in list (no exception)', () {
+        final f = createSampleFestival(id: 'cbf2025');
+        controller.setSource([f], defaultFestival: f);
+        expect(
+          () => controller.restoreSelection('nonexistent'),
+          returnsNormally,
+        );
+      });
+
+      test('no-op when savedId is null (no exception)', () {
+        final f = createSampleFestival(id: 'cbf2025');
+        controller.setSource([f], defaultFestival: f);
+        expect(() => controller.restoreSelection(null), returnsNormally);
+      });
+    });
+
+    group('applyFallback', () {
+      test('sets currentFestival when not yet selected', () {
+        final f = createSampleFestival(id: 'cbf2025');
+        controller
+          ..setSource([f])
+          ..applyFallback(defaultFestival: f);
+        expect(controller.currentFestival.id, equals('cbf2025'));
+      });
+
+      test('no-op when currentFestival already set', () {
+        final first = createSampleFestival(id: 'cbf2025');
+        final second = createSampleFestival(id: 'cbf2024');
+        controller
+          ..setSource([first, second], defaultFestival: first)
+          ..selectFestival(first)
+          // try to apply second as fallback — should not change
+          ..applyFallback(defaultFestival: second);
+        expect(controller.currentFestival.id, equals('cbf2025'));
+      });
+
+      test('no-op when defaultFestival is null', () {
+        // No festivals set, no current selection — apply null fallback
+        expect(
+          () => controller.applyFallback(defaultFestival: null),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('isFestivalsDataStale', () {
+      test('false immediately after setSource', () {
+        final f = createSampleFestival();
+        controller.setSource([f]);
+        expect(controller.isFestivalsDataStale, isFalse);
+      });
+
+      test(
+        'true when lastFestivalsRefresh is forced to >24h ago via @visibleForTesting setter',
+        () {
+          final f = createSampleFestival();
+          // Set source then force the timestamp to be 25 hours ago
+          controller
+            ..setSource([f])
+            ..lastFestivalsRefresh = DateTime.now().subtract(
+              const Duration(hours: 25),
+            );
+          expect(controller.isFestivalsDataStale, isTrue);
+        },
+      );
+    });
+
+    group('isValidFestivalId', () {
+      setUp(() {
+        final festivals = [
+          createSampleFestival(id: 'cbf2025'),
+          createSampleFestival(id: 'cbf2024'),
+        ];
+        controller.setSource(festivals, defaultFestival: festivals.first);
+      });
+
+      test('true for id in list', () {
+        expect(controller.isValidFestivalId('cbf2025'), isTrue);
+      });
+
+      test('false for id not in list', () {
+        expect(controller.isValidFestivalId('cbf2099'), isFalse);
+      });
+
+      test('false for null', () {
+        expect(controller.isValidFestivalId(null), isFalse);
+      });
+
+      test('false for empty string', () {
+        expect(controller.isValidFestivalId(''), isFalse);
+      });
+    });
+
+    group('getFestivalById', () {
+      test('returns festival when found', () {
+        final f = createSampleFestival(id: 'cbf2025');
+        controller.setSource([f], defaultFestival: f);
+        final found = controller.getFestivalById('cbf2025');
+        expect(found, isNotNull);
+        expect(found!.id, equals('cbf2025'));
+      });
+
+      test('returns null when not found', () {
+        final f = createSampleFestival(id: 'cbf2025');
+        controller.setSource([f], defaultFestival: f);
+        expect(controller.getFestivalById('cbf9999'), isNull);
+      });
+    });
+
+    group('clearFestivals', () {
+      test('empties festival list', () {
+        final f = createSampleFestival();
+        controller.setSource([f], defaultFestival: f);
+        expect(controller.festivals, isNotEmpty);
+        controller.clearFestivals();
+        expect(controller.festivals, isEmpty);
+      });
+    });
+
+    group('recordAttempt', () {
+      test('sets lastFestivalsRefreshAttempt to non-null and recent', () {
+        expect(controller.lastFestivalsRefreshAttempt, isNull);
+        controller.recordAttempt();
+        expect(controller.lastFestivalsRefreshAttempt, isNotNull);
+        final diff = DateTime.now().difference(
+          controller.lastFestivalsRefreshAttempt!,
+        );
+        expect(diff.inSeconds, lessThan(5));
+      });
+    });
+
+    group('sortedFestivals', () {
+      test('returns festivals in date order', () {
+        final past = Festival(
+          id: 'cbf2024',
+          name: 'Festival 2024',
+          startDate: DateTime(2024, 5, 20),
+          endDate: DateTime(2024, 5, 25),
+          availableBeverageTypes: const ['beer'],
+          dataBaseUrl: 'https://data.example.com/cbf2024',
+        );
+        final upcoming = Festival(
+          id: 'cbf2026',
+          name: 'Festival 2026',
+          startDate: DateTime(2026, 5, 18),
+          endDate: DateTime(2026, 5, 23),
+          availableBeverageTypes: const ['beer'],
+          dataBaseUrl: 'https://data.example.com/cbf2026',
+        );
+        controller.setSource([past, upcoming], defaultFestival: upcoming);
+        final sorted = controller.sortedFestivals;
+        // upcoming (2026) should come before past (2024)
+        expect(sorted.first.id, equals('cbf2026'));
+        expect(sorted.last.id, equals('cbf2024'));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Extracts festival registry state from `BeerProvider` into a new pure-Dart `FestivalController` in `lib/domain/controllers/`
- Controller owns: festivals list, current selection, staleness timestamps, beverage-type comparison, `isValidFestivalId`, `getFestivalById`
- `BeerProvider` retains async I/O (`loadFestivals`), loading flags (`_isFestivalsLoading`), and error state (`_festivalsError`) — only in-memory state moves
- 31 new unit tests covering `setSource`, `selectFestival`, `restoreSelection`, `applyFallback`, staleness, `isValidFestivalId`, `getFestivalById`, `clearFestivals`, `recordAttempt`

## Test plan

- [ ] `./bin/mise run test test/domain/controllers/festival_controller_test.dart` — 31 new tests pass
- [ ] `./bin/mise run check` — 1032 total tests green, analyzer clean

Fixes #400

---
_Generated by [Claude Code](https://claude.ai/code/session_01Muas9RsyuroCSzTTu73kvY)_