### PR TITLE
fix(cache): serialise DrinkCacheService writes to prevent race

### DIFF
--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -54,9 +54,10 @@ class DrinkCacheService {
     freshByType.forEach((type, drinks) {
       types[type] = _producersJson(drinks);
     });
-    final written = _writeChain = _writeChain.then(
-      (_) => _persistTypes(festivalId, types),
-    );
+    // catchError on _writeChain keeps the serial queue healthy if a write fails.
+    final writeTask = _writeChain.then((_) => _persistTypes(festivalId, types));
+    _writeChain = writeTask.catchError((_) {});
+    final written = writeTask;
     return DrinkCacheUpdate(_flatten(types, festivalId), written);
   }
 

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -22,6 +22,7 @@ class DrinkCacheService {
   static const _maxCachedFestivals = 12;
 
   final SharedPreferences _prefs;
+  Future<void> _writeChain = Future.value();
 
   DrinkCacheService(this._prefs);
 
@@ -53,7 +54,9 @@ class DrinkCacheService {
     freshByType.forEach((type, drinks) {
       types[type] = _producersJson(drinks);
     });
-    final written = _persistTypes(festivalId, types);
+    final written = _writeChain = _writeChain.then(
+      (_) => _persistTypes(festivalId, types),
+    );
     return DrinkCacheUpdate(_flatten(types, festivalId), written);
   }
 

--- a/test/cache_service_test.dart
+++ b/test/cache_service_test.dart
@@ -200,6 +200,23 @@ void main() {
       expect(cache.read('cbf0'), isNull); // oldest evicted
       expect(cache.read('cbf12'), isNotNull); // newest retained
     });
+
+    test('concurrent merge calls preserve the latest write on disk', () async {
+      // Fire two overlapping merges without awaiting either write.
+      // Write A (older) must not overwrite Write B (newer) on disk.
+      final updateA = cache.merge('cbf2025', {
+        'beer': [makeDrink('b1', 'beer-A', name: 'OldBeer')],
+      });
+      final updateB = cache.merge('cbf2025', {
+        'beer': [makeDrink('b1', 'beer-B', name: 'NewBeer')],
+      });
+      await updateA.written;
+      await updateB.written;
+
+      final read = cache.read('cbf2025')!;
+      expect(read.map((d) => d.id), contains('beer-B'));
+      expect(read.map((d) => d.id), isNot(contains('beer-A')));
+    });
   });
 
   group('FestivalCacheService', () {


### PR DESCRIPTION
## Summary

- Adds a `_writeChain` serial queue to `DrinkCacheService` so concurrent `merge()` calls are serialised in call order
- Two overlapping calls each fired an unawaited `_persistTypes()`; whichever `setString` completed last won on disk, potentially reverting to an older snapshot on next cold start
- Adds a regression test that fires two overlapping merges and asserts only the newest write survives on disk

## Test plan

- [ ] `./bin/mise run test test/cache_service_test.dart` — all existing tests pass plus new `'concurrent merge calls preserve the latest write on disk'` test
- [ ] `./bin/mise run check` — generate → analyze → test all green

Fixes #309

---
_Generated by [Claude Code](https://claude.ai/code/session_01TznNDGyThh2AuKNHZvVKp2)_