### PR TITLE
chore(proto): add WIRE breaking rule and document promotion path

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -15,6 +15,18 @@ lint:
 breaking:
   use:
     - FILE
-  ignore_unstable_packages: true
+    - WIRE
+  # WIRE catches field-number renumbering and field-type changes on the wire.
+  # FILE catches deleted files and moved definitions.
+  #
+  # Promotion path:
+  #   v1alpha → v1beta1: copy package to cambeerfestival.myfestival.v1beta1,
+  #     keep alpha alongside for one release cycle, then delete alpha package.
+  #     No buf.yaml changes needed — ignore_unstable_packages stays absent so
+  #     beta breaking changes are caught from day one.
+  #   v1beta1 → v1: copy package to cambeerfestival.myfestival.v1 and delete
+  #     beta. Switch breaking.use to WIRE_JSON_COMPATIBLE here (superset of
+  #     WIRE; also checks JSON field name stability). Add ignore_unstable_packages:
+  #     true only if a new v2alpha package coexists with stable v1.
   ignore:
     - google/protobuf/empty.proto


### PR DESCRIPTION
FILE alone misses field-number renumbering and field-type changes that
break wire compatibility. WIRE closes that gap for the v1alpha package.

Comment documents the v1alpha → v1beta1 → v1 promotion steps and the
buf.yaml changes required at each stage (WIRE_JSON_COMPATIBLE on stable,
ignore_unstable_packages only when a new vNalpha coexists with stable v1).

https://claude.ai/code/session_01M8UuEB3uyQnJsvYHSeWju9