### PR TITLE
chore(proto): gate AIP lint in CI and fix buf.yaml accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,11 @@ jobs:
           mapfile -t SH_FILES < <(find . -name '*.sh' -not -path './.git/*' -not -path './.mise/*' -not -path '*/node_modules/*' | sort)
           [[ ${#SH_FILES[@]} -gt 0 ]] && shfmt -d -i 0 -ci "${SH_FILES[@]}"
 
-  # Lint proto files and check for breaking changes against main.
-  # buf breaking runs on PRs only (bufbuild/buf-action skips it on push to main
-  # where the change is already merged). FILE stability level (configured in
-  # proto/buf.yaml) is appropriate for v1alpha; switch to WIRE_JSON_COMPATIBLE
-  # when the API graduates to v1.
+  # Lint proto files, check for breaking changes against main, and run the
+  # AIP design linter. buf breaking runs on PRs only (bufbuild/buf-action skips
+  # it on push to main where the change is already merged). buf.yaml uses WIRE
+  # breaking detection with ignore_unstable_packages while the API is alpha;
+  # it switches to WIRE_JSON when the first stable (v1) package lands.
   proto:
     needs: changes
     runs-on: ubuntu-latest
@@ -118,10 +118,37 @@ jobs:
 
       - uses: bufbuild/buf-action@v1
         with:
+          version: 1.70.0
           input: proto
           push: false
           pr_comment: false
           breaking_against: "https://github.com/${{ github.repository }}.git#branch=main,subdir=proto"
+
+      # AIP design lint (googleapis/api-linter) — the design-level rules buf's
+      # STANDARD ruleset doesn't cover. Mirrors the proto:api-lint mise task.
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install api-linter
+        run: go install github.com/googleapis/api-linter/v2/cmd/api-linter@v2.3.1
+
+      - name: AIP design lint
+        working-directory: proto
+        run: |
+          buf build -o /tmp/cambeerfestival.pb
+          api-linter \
+            --config .api-linter.yaml \
+            --descriptor-set-in=/tmp/cambeerfestival.pb \
+            --set-exit-status \
+            cambeerfestival/festival/v1alpha/festival.proto \
+            cambeerfestival/festival/v1alpha/producer.proto \
+            cambeerfestival/festival/v1alpha/drink.proto \
+            cambeerfestival/festival/v1alpha/catalog_service.proto \
+            cambeerfestival/festival/v1alpha/drink_entry.proto \
+            cambeerfestival/festival/v1alpha/drink_summary.proto \
+            cambeerfestival/festival/v1alpha/my_festival_service.proto
 
   # Analyze code in parallel with tests so builds can start sooner
   analyze:

--- a/mise.dev.toml
+++ b/mise.dev.toml
@@ -16,14 +16,14 @@
 
 [tools]
 watchexec = "2.5.1"
-buf = "latest"
+buf = "1.70.0"
 
 # --- Protobuf / OpenAPI (API contract is proto-first; see proto/README.md) ---
-# buf and api-linter live here (dev-only) while the API design is still in flux.
-# Move both to base mise.toml when the API stabilises and proto tasks enter CI.
-# Move it to base mise.toml once the resource shapes and method signatures
-# have stabilised and the linter output is expected to stay clean in CI.
-"github:googleapis/api-linter" = "latest"
+# buf and api-linter live here for local dev. CI runs the equivalent checks in
+# the `proto` job (buf-action + api-linter via go install), so these versions
+# are pinned to match CI. Move both to base mise.toml if the toolchain is ever
+# needed by base (non-dev) tasks.
+"github:googleapis/api-linter" = "2.3.1"
 
 [tasks."proto:lint"]
 description = "Lint the protobuf API contract (buf STANDARD ruleset)"
@@ -86,6 +86,7 @@ buf build -o /tmp/cambeerfestival.pb
 api-linter \
   --config .api-linter.yaml \
   --descriptor-set-in=/tmp/cambeerfestival.pb \
+  --set-exit-status \
   cambeerfestival/festival/v1alpha/festival.proto \
   cambeerfestival/festival/v1alpha/producer.proto \
   cambeerfestival/festival/v1alpha/drink.proto \

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -7,9 +7,10 @@ lint:
   use:
     - STANDARD
   except:
-    # AIP-131/134: Get and Update return the resource itself, and Delete
-    # returns google.protobuf.Empty — both intentionally diverge from buf's
-    # "<Method>Response" / unique-response defaults. Google's own APIs do the same.
+    # AIP-131/134/164: Get, Update, and Delete all return the resource itself
+    # (Delete is a soft delete that returns the tombstone), so one response
+    # message is shared across methods and none match buf's "<Method>Response"
+    # naming default. Google's own APIs do the same.
     - RPC_RESPONSE_STANDARD_NAME
     - RPC_REQUEST_RESPONSE_UNIQUE
 breaking:
@@ -40,9 +41,7 @@ breaking:
   # ignore_unstable_packages is true: alpha/beta packages are free to churn
   # (rename, move, restructure) without tripping breaking checks while the API
   # is still being shaped — only stable (v1+) packages are guarded. When the
-  # first stable (v1) package lands, switch breaking.use to WIRE_JSON_COMPATIBLE
-  # (superset of WIRE; also checks JSON field-name stability); the frozen v1 is
-  # then guarded while alpha stays exempt.
+  # first stable (v1) package lands, switch breaking.use to WIRE_JSON (superset
+  # of WIRE; also checks JSON field-name stability); the frozen v1 is then
+  # guarded while alpha stays exempt.
   ignore_unstable_packages: true
-  ignore:
-    - google/protobuf/empty.proto


### PR DESCRIPTION
## Summary

Tooling fixes for the proto API contract, rebased onto current `main` (after #433 added the festival catalogue API and renamed the proto tree `myfestival/` → `festival/`).

1. **AIP linter now gates CI** (`.github/workflows/ci.yml`, `mise.dev.toml`)
   Added an `api-linter` step to the CI `proto` job with `--set-exit-status` so design-level regressions — the rules buf's STANDARD ruleset doesn't cover — actually fail the build. Added the same flag to the `proto:api-lint` mise task (it previously printed problems but exited 0, so it wasn't really a gate). Lints all 7 `festival/v1alpha/` protos. Pinned `buf` (1.70.0) and `api-linter` (2.3.1) in both dev and CI so local and CI results agree.

2. **`buf.yaml` accuracy fixes**
   - Corrected the lint-exception comment: `Delete` returns the `DrinkEntry` tombstone (soft delete, AIP-164), not `google.protobuf.Empty`.
   - Removed the now-dead `ignore: google/protobuf/empty.proto` breaking entry (nothing imports `empty.proto`).
   - Fixed the promotion-path comment to reference the real buf category **`WIRE_JSON`** — `WIRE_JSON_COMPATIBLE` is not a valid category, so following the documented v1 plan as written would fail.

### Note on breaking strategy

This PR originally proposed switching active breaking detection to `WIRE_JSON` now. After #433 adopted `ignore_unstable_packages: true` (alpha packages exempt from breaking checks, JSON-level checks deferred to v1), that strategy is left **unchanged** — it's the right call for a churning alpha API (it's what enabled the `myfestival→festival` rename). The only breaking-config change here is fixing the invalid category name in the forward-looking comment.

## Verification

Run locally against the real binaries (caught two bugs before they reached CI: `WIRE_JSON_COMPATIBLE` isn't a valid buf category — it's `WIRE_JSON`; and `go install` of api-linter v2 needs the `/v2` module path):

- `buf lint` → exit 0
- `buf format --diff --exit-code` → exit 0
- `buf breaking` (config valid, `WIRE` + `ignore_unstable_packages`) → exit 0
- `api-linter --set-exit-status` → `problems: []` for all 7 protos, exit 0

https://claude.ai/code/session_01MPdgVxaNBHJdL8hnyFGYpC