### PR TITLE
test: add widget tests for StarRating and FestivalInfoScreen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -485,6 +485,69 @@ static bool isProductionHost(String hostname) { ... }
 
 Tests call `isProductionHost(...)` directly, bypassing any platform guards. Note: lines that delegate to `Uri.base.host` will show as uncovered in Codecov — this is expected and acceptable, since the logic itself is fully covered via the helper.
 
+### Screen Widget Tests
+
+Screens that use navigation (`context.go()`, `context.push()`) must be wrapped in a real GoRouter in tests — pumping them as bare widgets throws a routing error. Use `MaterialApp.router` with a `GoRouter` that declares the initial route:
+
+```dart
+final router = GoRouter(
+  initialLocation: '/${festival.id}/info',
+  routes: [
+    GoRoute(
+      path: '/:festivalId/info',
+      builder: (context, state) =>
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: FestivalInfoScreen(
+              festivalId: state.pathParameters['festivalId']!,
+            ),
+          ),
+    ),
+    GoRoute(path: '/', builder: (_, __) => const Scaffold()),  // stub for back/home navigation
+  ],
+);
+await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+await tester.pumpAndSettle();
+```
+
+Always include a stub `/` route so any `context.go('/')` calls within the screen don't throw.
+
+### Semantics Testing
+
+Three strategies for asserting accessibility labels in widget tests, in order of use:
+
+**1. Widget predicate** — finds a `Semantics` widget directly by its `properties.label`. Most reliable when you know the exact wrapper you added:
+
+```dart
+expect(
+  find.byWidgetPredicate(
+    (widget) => widget is Semantics && widget.properties.label == 'Open location in maps',
+  ),
+  findsOneWidget,
+);
+```
+
+**2. Rendered semantics label** — searches the rendered a11y tree. Use `tester.ensureSemantics()` to enable semantics, assert, then dispose:
+
+```dart
+final handle = tester.ensureSemantics();
+// ... pump widget ...
+expect(find.bySemanticsLabel('Visit festival website'), findsOneWidget);
+handle.dispose();
+```
+
+**3. Semantics node properties** — read `label`, `value`, `hint` off a specific node (useful for compound widgets like `StarRating`):
+
+```dart
+final semantics = tester.getSemantics(
+  find.ancestor(of: find.byType(Row), matching: find.byType(Semantics)).first,
+);
+expect(semantics.label, 'Rating');
+expect(semantics.value, '3 out of 5 stars');
+```
+
+**Gotcha: duplicate semantics nodes** — Flutter button widgets (e.g. `FilledButton.icon`) synthesise a semantics node from their visible text label. If you also wrap the button with an explicit `Semantics(label: '...')`, two nodes exist with the same label and `findsOneWidget` fails. Use `findsWidgets` instead, or prefer the widget predicate strategy.
+
 ---
 
 ## API Integration

--- a/test/festival_info_screen_test.dart
+++ b/test/festival_info_screen_test.dart
@@ -11,6 +11,43 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'provider_test.mocks.dart';
 
+Festival createFestival({
+  String id = 'cbf2025',
+  String name = 'Cambridge Beer Festival 2025',
+  String? hashtag,
+  DateTime? startDate,
+  DateTime? endDate,
+  String? location,
+  String? address,
+  double? latitude,
+  double? longitude,
+  String? description,
+  String? websiteUrl,
+  Map<String, String>? hours,
+  List<String> availableBeverageTypes = const ['beer'],
+  bool isActive = false,
+  String? charityPartnerName,
+  String? charityDonationUrl,
+}) => Festival(
+  id: id,
+  name: name,
+  dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+  hashtag: hashtag,
+  startDate: startDate,
+  endDate: endDate,
+  location: location,
+  address: address,
+  latitude: latitude,
+  longitude: longitude,
+  description: description,
+  websiteUrl: websiteUrl,
+  hours: hours,
+  availableBeverageTypes: availableBeverageTypes,
+  isActive: isActive,
+  charityPartnerName: charityPartnerName,
+  charityDonationUrl: charityDonationUrl,
+);
+
 void main() {
   group('FestivalInfoScreen', () {
     late MockDrinkRepository mockDrinkRepository;
@@ -74,96 +111,50 @@ void main() {
 
     group('header content', () {
       testWidgets('displays festival name', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.text('Cambridge Beer Festival 2025'), findsOneWidget);
       });
 
       testWidgets('displays formatted dates when set', (tester) async {
-        final festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          startDate: DateTime(2025, 5, 19),
-          endDate: DateTime(2025, 5, 24),
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        await pumpScreen(
+          tester,
+          createFestival(
+            startDate: DateTime(2025, 5, 19),
+            endDate: DateTime(2025, 5, 24),
+          ),
         );
-
-        await pumpScreen(tester, festival);
-
         expect(find.text('May 19-24, 2025'), findsOneWidget);
       });
 
       testWidgets('does not show date row when no dates set', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.byIcon(Icons.calendar_today), findsNothing);
       });
 
       testWidgets('displays hashtag when set', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          hashtag: '#cbf2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival(hashtag: '#cbf2025'));
         expect(find.text('#cbf2025'), findsOneWidget);
       });
 
       testWidgets('shows ACTIVE badge when festival is active', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          isActive: true,
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival(isActive: true));
         expect(find.text('ACTIVE'), findsOneWidget);
       });
 
       testWidgets('does not show ACTIVE badge when festival is not active', (
         tester,
       ) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          isActive: false,
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.text('ACTIVE'), findsNothing);
       });
     });
 
     group('overview section', () {
       testWidgets('shows beverage type chips', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          availableBeverageTypes: ['beer', 'cider'],
+        await pumpScreen(
+          tester,
+          createFestival(availableBeverageTypes: ['beer', 'cider']),
         );
-
-        await pumpScreen(tester, festival);
-
         expect(find.text('Overview'), findsOneWidget);
         expect(find.byType(Chip), findsNWidgets(2));
       });
@@ -173,60 +164,42 @@ void main() {
       testWidgets('shows location section when location is set', (
         tester,
       ) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          location: 'Jesus Green, Cambridge',
+        await pumpScreen(
+          tester,
+          createFestival(location: 'Jesus Green, Cambridge'),
         );
-
-        await pumpScreen(tester, festival);
-
         expect(find.text('Location'), findsOneWidget);
         expect(find.text('Jesus Green, Cambridge'), findsOneWidget);
       });
 
       testWidgets('shows address when set', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          location: 'Jesus Green',
-          address: 'Jesus Green, Cambridge CB5 8AB',
+        await pumpScreen(
+          tester,
+          createFestival(
+            location: 'Jesus Green',
+            address: 'Jesus Green, Cambridge CB5 8AB',
+          ),
         );
-
-        await pumpScreen(tester, festival);
-
         expect(find.text('Jesus Green, Cambridge CB5 8AB'), findsOneWidget);
       });
 
       testWidgets('does not show location section when neither location nor '
           'address is set', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.text('Location'), findsNothing);
       });
 
       testWidgets('shows map button with semantics when coordinates are set', (
         tester,
       ) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          location: 'Jesus Green, Cambridge',
-          latitude: 52.2127,
-          longitude: 0.1234,
+        await pumpScreen(
+          tester,
+          createFestival(
+            location: 'Jesus Green, Cambridge',
+            latitude: 52.2127,
+            longitude: 0.1234,
+          ),
         );
-
-        await pumpScreen(tester, festival);
-
         expect(find.byIcon(Icons.map), findsOneWidget);
         expect(
           find.byWidgetPredicate(
@@ -241,30 +214,22 @@ void main() {
       testWidgets('does not show map button when coordinates are not set', (
         tester,
       ) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          location: 'Jesus Green, Cambridge',
+        await pumpScreen(
+          tester,
+          createFestival(location: 'Jesus Green, Cambridge'),
         );
-
-        await pumpScreen(tester, festival);
-
         expect(find.byIcon(Icons.map), findsNothing);
       });
     });
 
     group('hours section', () {
       testWidgets('shows hours when set', (tester) async {
-        final festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          hours: {'Monday': '12:00 - 22:00', 'Tuesday': '11:00 - 22:00'},
+        await pumpScreen(
+          tester,
+          createFestival(
+            hours: {'Monday': '12:00 - 22:00', 'Tuesday': '11:00 - 22:00'},
+          ),
         );
-
-        await pumpScreen(tester, festival);
-
         expect(find.text('Festival Hours'), findsOneWidget);
         expect(find.text('Monday'), findsOneWidget);
         expect(find.text('12:00 - 22:00'), findsOneWidget);
@@ -273,29 +238,17 @@ void main() {
       testWidgets('does not show hours section when hours is null', (
         tester,
       ) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.text('Festival Hours'), findsNothing);
       });
     });
 
     group('description section', () {
       testWidgets('shows description when set', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          description: 'The best beer festival in the world.',
+        await pumpScreen(
+          tester,
+          createFestival(description: 'The best beer festival in the world.'),
         );
-
-        await pumpScreen(tester, festival);
-
         expect(find.text('About'), findsOneWidget);
         expect(
           find.text('The best beer festival in the world.'),
@@ -306,29 +259,15 @@ void main() {
       testWidgets('does not show description section when not set', (
         tester,
       ) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.text('About'), findsNothing);
       });
     });
 
     group('action buttons', () {
       testWidgets('always shows GitHub button with semantics', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
         final handle = tester.ensureSemantics();
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.text('View App on GitHub'), findsOneWidget);
         expect(
           find.bySemanticsLabel('View app source code on GitHub'),
@@ -340,16 +279,11 @@ void main() {
       testWidgets('shows website button with semantics when url is set', (
         tester,
       ) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-          websiteUrl: 'https://www.cambridgebeerfestival.com',
-        );
-
         final handle = tester.ensureSemantics();
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(
+          tester,
+          createFestival(websiteUrl: 'https://www.cambridgebeerfestival.com'),
+        );
         expect(find.text('Visit Festival Website'), findsOneWidget);
         expect(find.bySemanticsLabel('Visit festival website'), findsOneWidget);
         handle.dispose();
@@ -358,31 +292,21 @@ void main() {
       testWidgets('does not show website button when url is not set', (
         tester,
       ) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.text('Visit Festival Website'), findsNothing);
       });
 
       testWidgets(
         'shows charity donation button with semantics when charity is set',
         (tester) async {
-          const festival = Festival(
-            id: 'cbf2025',
-            name: 'Cambridge Beer Festival 2025',
-            dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-            charityPartnerName: 'Water Aid',
-            charityDonationUrl: 'https://wateraid.org/donate',
-          );
-
           final handle = tester.ensureSemantics();
-          await pumpScreen(tester, festival);
-
+          await pumpScreen(
+            tester,
+            createFestival(
+              charityPartnerName: 'Water Aid',
+              charityDonationUrl: 'https://wateraid.org/donate',
+            ),
+          );
           expect(find.text('Donate to Water Aid'), findsOneWidget);
           expect(find.bySemanticsLabel('Donate to Water Aid'), findsWidgets);
           handle.dispose();
@@ -392,29 +316,17 @@ void main() {
       testWidgets('does not show charity button when charity fields not set', (
         tester,
       ) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.byIcon(Icons.favorite), findsNothing);
       });
 
       testWidgets(
         'does not show charity button when only name is set (url missing)',
         (tester) async {
-          const festival = Festival(
-            id: 'cbf2025',
-            name: 'Cambridge Beer Festival 2025',
-            dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-            charityPartnerName: 'Water Aid',
+          await pumpScreen(
+            tester,
+            createFestival(charityPartnerName: 'Water Aid'),
           );
-
-          await pumpScreen(tester, festival);
-
           expect(find.byIcon(Icons.favorite), findsNothing);
         },
       );
@@ -422,14 +334,7 @@ void main() {
 
     group('app bar', () {
       testWidgets('shows Festival Info title', (tester) async {
-        const festival = Festival(
-          id: 'cbf2025',
-          name: 'Cambridge Beer Festival 2025',
-          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
-        );
-
-        await pumpScreen(tester, festival);
-
+        await pumpScreen(tester, createFestival());
         expect(find.text('Festival Info'), findsOneWidget);
       });
     });

--- a/test/festival_info_screen_test.dart
+++ b/test/festival_info_screen_test.dart
@@ -101,7 +101,7 @@ void main() {
                   ),
                 ),
           ),
-          GoRoute(path: '/', builder: (_, __) => const Scaffold()),
+          GoRoute(path: '/', builder: (_, _) => const Scaffold()),
         ],
       );
 

--- a/test/festival_info_screen_test.dart
+++ b/test/festival_info_screen_test.dart
@@ -1,0 +1,437 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cambridge_beer_festival/screens/screens.dart';
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:cambridge_beer_festival/providers/providers.dart';
+import 'package:cambridge_beer_festival/services/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'provider_test.mocks.dart';
+
+void main() {
+  group('FestivalInfoScreen', () {
+    late MockDrinkRepository mockDrinkRepository;
+    late MockFestivalRepository mockFestivalRepository;
+    late MockAnalyticsService mockAnalyticsService;
+    late BeerProvider provider;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      mockDrinkRepository = MockDrinkRepository();
+      mockFestivalRepository = MockFestivalRepository();
+      mockAnalyticsService = MockAnalyticsService();
+
+      when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => []);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
+
+      provider = BeerProvider(
+        drinkRepository: mockDrinkRepository,
+        festivalRepository: mockFestivalRepository,
+        analyticsService: mockAnalyticsService,
+      );
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    Future<void> pumpScreen(WidgetTester tester, Festival festival) async {
+      when(mockFestivalRepository.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: [festival],
+          defaultFestivalId: festival.id,
+          version: '1.0',
+          baseUrl: 'https://data.cambeerfestival.app',
+        ),
+      );
+      await provider.initialize();
+
+      final router = GoRouter(
+        initialLocation: '/${festival.id}/info',
+        routes: [
+          GoRoute(
+            path: '/:festivalId/info',
+            builder: (context, state) =>
+                ChangeNotifierProvider<BeerProvider>.value(
+                  value: provider,
+                  child: FestivalInfoScreen(
+                    festivalId: state.pathParameters['festivalId']!,
+                  ),
+                ),
+          ),
+          GoRoute(path: '/', builder: (_, __) => const Scaffold()),
+        ],
+      );
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+    }
+
+    group('header content', () {
+      testWidgets('displays festival name', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Cambridge Beer Festival 2025'), findsOneWidget);
+      });
+
+      testWidgets('displays formatted dates when set', (tester) async {
+        final festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          startDate: DateTime(2025, 5, 19),
+          endDate: DateTime(2025, 5, 24),
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('May 19-24, 2025'), findsOneWidget);
+      });
+
+      testWidgets('does not show date row when no dates set', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.byIcon(Icons.calendar_today), findsNothing);
+      });
+
+      testWidgets('displays hashtag when set', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          hashtag: '#cbf2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('#cbf2025'), findsOneWidget);
+      });
+
+      testWidgets('shows ACTIVE badge when festival is active', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          isActive: true,
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('ACTIVE'), findsOneWidget);
+      });
+
+      testWidgets('does not show ACTIVE badge when festival is not active', (
+        tester,
+      ) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          isActive: false,
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('ACTIVE'), findsNothing);
+      });
+    });
+
+    group('overview section', () {
+      testWidgets('shows beverage type chips', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          availableBeverageTypes: ['beer', 'cider'],
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Overview'), findsOneWidget);
+        expect(find.byType(Chip), findsNWidgets(2));
+      });
+    });
+
+    group('location section', () {
+      testWidgets('shows location section when location is set', (
+        tester,
+      ) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          location: 'Jesus Green, Cambridge',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Location'), findsOneWidget);
+        expect(find.text('Jesus Green, Cambridge'), findsOneWidget);
+      });
+
+      testWidgets('shows address when set', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          location: 'Jesus Green',
+          address: 'Jesus Green, Cambridge CB5 8AB',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Jesus Green, Cambridge CB5 8AB'), findsOneWidget);
+      });
+
+      testWidgets('does not show location section when neither location nor '
+          'address is set', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Location'), findsNothing);
+      });
+
+      testWidgets('shows map button with semantics when coordinates are set', (
+        tester,
+      ) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          location: 'Jesus Green, Cambridge',
+          latitude: 52.2127,
+          longitude: 0.1234,
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.byIcon(Icons.map), findsOneWidget);
+        expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Semantics &&
+                widget.properties.label == 'Open location in maps',
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('does not show map button when coordinates are not set', (
+        tester,
+      ) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          location: 'Jesus Green, Cambridge',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.byIcon(Icons.map), findsNothing);
+      });
+    });
+
+    group('hours section', () {
+      testWidgets('shows hours when set', (tester) async {
+        final festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          hours: {'Monday': '12:00 - 22:00', 'Tuesday': '11:00 - 22:00'},
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Festival Hours'), findsOneWidget);
+        expect(find.text('Monday'), findsOneWidget);
+        expect(find.text('12:00 - 22:00'), findsOneWidget);
+      });
+
+      testWidgets('does not show hours section when hours is null', (
+        tester,
+      ) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Festival Hours'), findsNothing);
+      });
+    });
+
+    group('description section', () {
+      testWidgets('shows description when set', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          description: 'The best beer festival in the world.',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('About'), findsOneWidget);
+        expect(
+          find.text('The best beer festival in the world.'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('does not show description section when not set', (
+        tester,
+      ) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('About'), findsNothing);
+      });
+    });
+
+    group('action buttons', () {
+      testWidgets('always shows GitHub button with semantics', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        final handle = tester.ensureSemantics();
+        await pumpScreen(tester, festival);
+
+        expect(find.text('View App on GitHub'), findsOneWidget);
+        expect(
+          find.bySemanticsLabel('View app source code on GitHub'),
+          findsOneWidget,
+        );
+        handle.dispose();
+      });
+
+      testWidgets('shows website button with semantics when url is set', (
+        tester,
+      ) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+          websiteUrl: 'https://www.cambridgebeerfestival.com',
+        );
+
+        final handle = tester.ensureSemantics();
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Visit Festival Website'), findsOneWidget);
+        expect(find.bySemanticsLabel('Visit festival website'), findsOneWidget);
+        handle.dispose();
+      });
+
+      testWidgets('does not show website button when url is not set', (
+        tester,
+      ) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Visit Festival Website'), findsNothing);
+      });
+
+      testWidgets(
+        'shows charity donation button with semantics when charity is set',
+        (tester) async {
+          const festival = Festival(
+            id: 'cbf2025',
+            name: 'Cambridge Beer Festival 2025',
+            dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+            charityPartnerName: 'Water Aid',
+            charityDonationUrl: 'https://wateraid.org/donate',
+          );
+
+          final handle = tester.ensureSemantics();
+          await pumpScreen(tester, festival);
+
+          expect(find.text('Donate to Water Aid'), findsOneWidget);
+          expect(find.bySemanticsLabel('Donate to Water Aid'), findsWidgets);
+          handle.dispose();
+        },
+      );
+
+      testWidgets('does not show charity button when charity fields not set', (
+        tester,
+      ) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.byIcon(Icons.favorite), findsNothing);
+      });
+
+      testWidgets(
+        'does not show charity button when only name is set (url missing)',
+        (tester) async {
+          const festival = Festival(
+            id: 'cbf2025',
+            name: 'Cambridge Beer Festival 2025',
+            dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+            charityPartnerName: 'Water Aid',
+          );
+
+          await pumpScreen(tester, festival);
+
+          expect(find.byIcon(Icons.favorite), findsNothing);
+        },
+      );
+    });
+
+    group('app bar', () {
+      testWidgets('shows Festival Info title', (tester) async {
+        const festival = Festival(
+          id: 'cbf2025',
+          name: 'Cambridge Beer Festival 2025',
+          dataBaseUrl: 'https://data.cambeerfestival.app/cbf2025',
+        );
+
+        await pumpScreen(tester, festival);
+
+        expect(find.text('Festival Info'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/festival_info_screen_test.dart
+++ b/test/festival_info_screen_test.dart
@@ -11,7 +11,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'provider_test.mocks.dart';
 
-Festival createFestival({
+Festival createSampleFestival({
   String id = 'cbf2025',
   String name = 'Cambridge Beer Festival 2025',
   String? hashtag,
@@ -111,14 +111,14 @@ void main() {
 
     group('header content', () {
       testWidgets('displays festival name', (tester) async {
-        await pumpScreen(tester, createFestival());
+        await pumpScreen(tester, createSampleFestival());
         expect(find.text('Cambridge Beer Festival 2025'), findsOneWidget);
       });
 
       testWidgets('displays formatted dates when set', (tester) async {
         await pumpScreen(
           tester,
-          createFestival(
+          createSampleFestival(
             startDate: DateTime(2025, 5, 19),
             endDate: DateTime(2025, 5, 24),
           ),
@@ -127,24 +127,24 @@ void main() {
       });
 
       testWidgets('does not show date row when no dates set', (tester) async {
-        await pumpScreen(tester, createFestival());
+        await pumpScreen(tester, createSampleFestival());
         expect(find.byIcon(Icons.calendar_today), findsNothing);
       });
 
       testWidgets('displays hashtag when set', (tester) async {
-        await pumpScreen(tester, createFestival(hashtag: '#cbf2025'));
+        await pumpScreen(tester, createSampleFestival(hashtag: '#cbf2025'));
         expect(find.text('#cbf2025'), findsOneWidget);
       });
 
       testWidgets('shows ACTIVE badge when festival is active', (tester) async {
-        await pumpScreen(tester, createFestival(isActive: true));
+        await pumpScreen(tester, createSampleFestival(isActive: true));
         expect(find.text('ACTIVE'), findsOneWidget);
       });
 
       testWidgets('does not show ACTIVE badge when festival is not active', (
         tester,
       ) async {
-        await pumpScreen(tester, createFestival());
+        await pumpScreen(tester, createSampleFestival());
         expect(find.text('ACTIVE'), findsNothing);
       });
     });
@@ -153,7 +153,7 @@ void main() {
       testWidgets('shows beverage type chips', (tester) async {
         await pumpScreen(
           tester,
-          createFestival(availableBeverageTypes: ['beer', 'cider']),
+          createSampleFestival(availableBeverageTypes: ['beer', 'cider']),
         );
         expect(find.text('Overview'), findsOneWidget);
         expect(find.byType(Chip), findsNWidgets(2));
@@ -166,16 +166,28 @@ void main() {
       ) async {
         await pumpScreen(
           tester,
-          createFestival(location: 'Jesus Green, Cambridge'),
+          createSampleFestival(location: 'Jesus Green, Cambridge'),
         );
         expect(find.text('Location'), findsOneWidget);
         expect(find.text('Jesus Green, Cambridge'), findsOneWidget);
       });
 
+      testWidgets(
+        'shows location section with fallback title when only address is set',
+        (tester) async {
+          await pumpScreen(
+            tester,
+            createSampleFestival(address: 'Jesus Green, Cambridge CB5 8AB'),
+          );
+          expect(find.text('Location'), findsOneWidget);
+          expect(find.text('Jesus Green, Cambridge CB5 8AB'), findsOneWidget);
+        },
+      );
+
       testWidgets('shows address when set', (tester) async {
         await pumpScreen(
           tester,
-          createFestival(
+          createSampleFestival(
             location: 'Jesus Green',
             address: 'Jesus Green, Cambridge CB5 8AB',
           ),
@@ -185,7 +197,7 @@ void main() {
 
       testWidgets('does not show location section when neither location nor '
           'address is set', (tester) async {
-        await pumpScreen(tester, createFestival());
+        await pumpScreen(tester, createSampleFestival());
         expect(find.text('Location'), findsNothing);
       });
 
@@ -194,7 +206,7 @@ void main() {
       ) async {
         await pumpScreen(
           tester,
-          createFestival(
+          createSampleFestival(
             location: 'Jesus Green, Cambridge',
             latitude: 52.2127,
             longitude: 0.1234,
@@ -216,7 +228,7 @@ void main() {
       ) async {
         await pumpScreen(
           tester,
-          createFestival(location: 'Jesus Green, Cambridge'),
+          createSampleFestival(location: 'Jesus Green, Cambridge'),
         );
         expect(find.byIcon(Icons.map), findsNothing);
       });
@@ -226,7 +238,7 @@ void main() {
       testWidgets('shows hours when set', (tester) async {
         await pumpScreen(
           tester,
-          createFestival(
+          createSampleFestival(
             hours: {'Monday': '12:00 - 22:00', 'Tuesday': '11:00 - 22:00'},
           ),
         );
@@ -238,7 +250,14 @@ void main() {
       testWidgets('does not show hours section when hours is null', (
         tester,
       ) async {
-        await pumpScreen(tester, createFestival());
+        await pumpScreen(tester, createSampleFestival());
+        expect(find.text('Festival Hours'), findsNothing);
+      });
+
+      testWidgets('does not show hours section when hours is empty map', (
+        tester,
+      ) async {
+        await pumpScreen(tester, createSampleFestival(hours: {}));
         expect(find.text('Festival Hours'), findsNothing);
       });
     });
@@ -247,7 +266,9 @@ void main() {
       testWidgets('shows description when set', (tester) async {
         await pumpScreen(
           tester,
-          createFestival(description: 'The best beer festival in the world.'),
+          createSampleFestival(
+            description: 'The best beer festival in the world.',
+          ),
         );
         expect(find.text('About'), findsOneWidget);
         expect(
@@ -259,7 +280,7 @@ void main() {
       testWidgets('does not show description section when not set', (
         tester,
       ) async {
-        await pumpScreen(tester, createFestival());
+        await pumpScreen(tester, createSampleFestival());
         expect(find.text('About'), findsNothing);
       });
     });
@@ -267,32 +288,43 @@ void main() {
     group('action buttons', () {
       testWidgets('always shows GitHub button with semantics', (tester) async {
         final handle = tester.ensureSemantics();
-        await pumpScreen(tester, createFestival());
-        expect(find.text('View App on GitHub'), findsOneWidget);
-        expect(
-          find.bySemanticsLabel('View app source code on GitHub'),
-          findsOneWidget,
-        );
-        handle.dispose();
+        try {
+          await pumpScreen(tester, createSampleFestival());
+          expect(find.text('View App on GitHub'), findsOneWidget);
+          expect(
+            find.bySemanticsLabel('View app source code on GitHub'),
+            findsOneWidget,
+          );
+        } finally {
+          handle.dispose();
+        }
       });
 
       testWidgets('shows website button with semantics when url is set', (
         tester,
       ) async {
         final handle = tester.ensureSemantics();
-        await pumpScreen(
-          tester,
-          createFestival(websiteUrl: 'https://www.cambridgebeerfestival.com'),
-        );
-        expect(find.text('Visit Festival Website'), findsOneWidget);
-        expect(find.bySemanticsLabel('Visit festival website'), findsOneWidget);
-        handle.dispose();
+        try {
+          await pumpScreen(
+            tester,
+            createSampleFestival(
+              websiteUrl: 'https://www.cambridgebeerfestival.com',
+            ),
+          );
+          expect(find.text('Visit Festival Website'), findsOneWidget);
+          expect(
+            find.bySemanticsLabel('Visit festival website'),
+            findsOneWidget,
+          );
+        } finally {
+          handle.dispose();
+        }
       });
 
       testWidgets('does not show website button when url is not set', (
         tester,
       ) async {
-        await pumpScreen(tester, createFestival());
+        await pumpScreen(tester, createSampleFestival());
         expect(find.text('Visit Festival Website'), findsNothing);
       });
 
@@ -300,23 +332,26 @@ void main() {
         'shows charity donation button with semantics when charity is set',
         (tester) async {
           final handle = tester.ensureSemantics();
-          await pumpScreen(
-            tester,
-            createFestival(
-              charityPartnerName: 'Water Aid',
-              charityDonationUrl: 'https://wateraid.org/donate',
-            ),
-          );
-          expect(find.text('Donate to Water Aid'), findsOneWidget);
-          expect(find.bySemanticsLabel('Donate to Water Aid'), findsWidgets);
-          handle.dispose();
+          try {
+            await pumpScreen(
+              tester,
+              createSampleFestival(
+                charityPartnerName: 'Water Aid',
+                charityDonationUrl: 'https://wateraid.org/donate',
+              ),
+            );
+            expect(find.text('Donate to Water Aid'), findsOneWidget);
+            expect(find.bySemanticsLabel('Donate to Water Aid'), findsWidgets);
+          } finally {
+            handle.dispose();
+          }
         },
       );
 
       testWidgets('does not show charity button when charity fields not set', (
         tester,
       ) async {
-        await pumpScreen(tester, createFestival());
+        await pumpScreen(tester, createSampleFestival());
         expect(find.byIcon(Icons.favorite), findsNothing);
       });
 
@@ -325,7 +360,7 @@ void main() {
         (tester) async {
           await pumpScreen(
             tester,
-            createFestival(charityPartnerName: 'Water Aid'),
+            createSampleFestival(charityPartnerName: 'Water Aid'),
           );
           expect(find.byIcon(Icons.favorite), findsNothing);
         },
@@ -334,7 +369,7 @@ void main() {
 
     group('app bar', () {
       testWidgets('shows Festival Info title', (tester) async {
-        await pumpScreen(tester, createFestival());
+        await pumpScreen(tester, createSampleFestival());
         expect(find.text('Festival Info'), findsOneWidget);
       });
     });

--- a/test/widgets/star_rating_test.dart
+++ b/test/widgets/star_rating_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cambridge_beer_festival/widgets/star_rating.dart';
 
@@ -83,6 +84,34 @@ void main() {
       testWidgets('no hint text when not editable', (tester) async {
         await tester.pumpWidget(buildWidget(rating: 2));
         expect(outerSemantics(tester).hint, isEmpty);
+      });
+
+      testWidgets('stars are marked as buttons when editable', (tester) async {
+        await tester.pumpWidget(buildWidget(isEditable: true));
+        final node = tester.getSemantics(
+          find
+              .descendant(
+                of: find.byType(StarRating),
+                matching: find.byType(Semantics),
+              )
+              .at(1),
+        );
+        expect(node.hasFlag(SemanticsFlag.isButton), isTrue);
+      });
+
+      testWidgets('stars are not marked as buttons when not editable', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        final node = tester.getSemantics(
+          find
+              .descendant(
+                of: find.byType(StarRating),
+                matching: find.byType(Semantics),
+              )
+              .at(1),
+        );
+        expect(node.hasFlag(SemanticsFlag.isButton), isFalse);
       });
     });
 

--- a/test/widgets/star_rating_test.dart
+++ b/test/widgets/star_rating_test.dart
@@ -37,12 +37,6 @@ void main() {
         }
       });
 
-      testWidgets('shows no filled stars when rating is null', (tester) async {
-        await tester.pumpWidget(buildWidget());
-        expect(find.byIcon(Icons.star), findsNothing);
-        expect(find.byIcon(Icons.star_border), findsNWidgets(5));
-      });
-
       testWidgets('shows all 5 filled stars for rating 5', (tester) async {
         await tester.pumpWidget(buildWidget(rating: 5));
         expect(find.byIcon(Icons.star), findsNWidgets(5));
@@ -51,74 +45,44 @@ void main() {
     });
 
     group('semantics', () {
+      outerSemantics(WidgetTester tester) => tester.getSemantics(
+        find
+            .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
+            .first,
+      );
+
       testWidgets('outer label is "Rate this drink" when editable', (
         tester,
       ) async {
         await tester.pumpWidget(buildWidget(isEditable: true));
-
-        final semantics = tester.getSemantics(
-          find
-              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
-              .first,
-        );
-        expect(semantics.label, 'Rate this drink');
+        expect(outerSemantics(tester).label, 'Rate this drink');
       });
 
       testWidgets('outer label is "Rating" when not editable', (tester) async {
         await tester.pumpWidget(buildWidget(rating: 3));
-
-        final semantics = tester.getSemantics(
-          find
-              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
-              .first,
-        );
-        expect(semantics.label, 'Rating');
+        expect(outerSemantics(tester).label, 'Rating');
       });
 
       testWidgets('semantic value reflects current rating', (tester) async {
         await tester.pumpWidget(buildWidget(rating: 3));
-
-        final semantics = tester.getSemantics(
-          find
-              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
-              .first,
-        );
-        expect(semantics.value, '3 out of 5 stars');
+        expect(outerSemantics(tester).value, '3 out of 5 stars');
       });
 
       testWidgets('semantic value is "0 out of 5 stars" when unrated', (
         tester,
       ) async {
         await tester.pumpWidget(buildWidget());
-
-        final semantics = tester.getSemantics(
-          find
-              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
-              .first,
-        );
-        expect(semantics.value, '0 out of 5 stars');
+        expect(outerSemantics(tester).value, '0 out of 5 stars');
       });
 
       testWidgets('hint text present when editable', (tester) async {
         await tester.pumpWidget(buildWidget(isEditable: true));
-
-        final semantics = tester.getSemantics(
-          find
-              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
-              .first,
-        );
-        expect(semantics.hint, isNotEmpty);
+        expect(outerSemantics(tester).hint, isNotEmpty);
       });
 
       testWidgets('no hint text when not editable', (tester) async {
         await tester.pumpWidget(buildWidget(rating: 2));
-
-        final semantics = tester.getSemantics(
-          find
-              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
-              .first,
-        );
-        expect(semantics.hint, isEmpty);
+        expect(outerSemantics(tester).hint, isEmpty);
       });
     });
 
@@ -192,14 +156,7 @@ void main() {
           buildWidget(rating: 3, onRatingChanged: (_) => called = true),
         );
 
-        await tester.tap(
-          find
-              .descendant(
-                of: find.byType(StarRating),
-                matching: find.byType(GestureDetector),
-              )
-              .first,
-        );
+        await tester.tap(find.byIcon(Icons.star).first);
         expect(called, isFalse);
       });
     });

--- a/test/widgets/star_rating_test.dart
+++ b/test/widgets/star_rating_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cambridge_beer_festival/widgets/star_rating.dart';
+
+void main() {
+  Widget buildWidget({
+    int? rating,
+    bool isEditable = false,
+    ValueChanged<int?>? onRatingChanged,
+    double starSize = 24,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: StarRating(
+          rating: rating,
+          isEditable: isEditable,
+          onRatingChanged: onRatingChanged,
+          starSize: starSize,
+        ),
+      ),
+    );
+  }
+
+  group('StarRating', () {
+    group('star rendering', () {
+      testWidgets('renders exactly 5 stars', (tester) async {
+        await tester.pumpWidget(buildWidget());
+        expect(find.byIcon(Icons.star), findsNothing);
+        expect(find.byIcon(Icons.star_border), findsNWidgets(5));
+      });
+
+      testWidgets('shows N filled stars for rating N', (tester) async {
+        for (var n = 1; n <= 5; n++) {
+          await tester.pumpWidget(buildWidget(rating: n));
+          expect(find.byIcon(Icons.star), findsNWidgets(n));
+          expect(find.byIcon(Icons.star_border), findsNWidgets(5 - n));
+        }
+      });
+
+      testWidgets('shows no filled stars when rating is null', (tester) async {
+        await tester.pumpWidget(buildWidget());
+        expect(find.byIcon(Icons.star), findsNothing);
+        expect(find.byIcon(Icons.star_border), findsNWidgets(5));
+      });
+
+      testWidgets('shows all 5 filled stars for rating 5', (tester) async {
+        await tester.pumpWidget(buildWidget(rating: 5));
+        expect(find.byIcon(Icons.star), findsNWidgets(5));
+        expect(find.byIcon(Icons.star_border), findsNothing);
+      });
+    });
+
+    group('semantics', () {
+      testWidgets('outer label is "Rate this drink" when editable', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(isEditable: true));
+
+        final semantics = tester.getSemantics(
+          find
+              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
+              .first,
+        );
+        expect(semantics.label, 'Rate this drink');
+      });
+
+      testWidgets('outer label is "Rating" when not editable', (tester) async {
+        await tester.pumpWidget(buildWidget(rating: 3));
+
+        final semantics = tester.getSemantics(
+          find
+              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
+              .first,
+        );
+        expect(semantics.label, 'Rating');
+      });
+
+      testWidgets('semantic value reflects current rating', (tester) async {
+        await tester.pumpWidget(buildWidget(rating: 3));
+
+        final semantics = tester.getSemantics(
+          find
+              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
+              .first,
+        );
+        expect(semantics.value, '3 out of 5 stars');
+      });
+
+      testWidgets('semantic value is "0 out of 5 stars" when unrated', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+
+        final semantics = tester.getSemantics(
+          find
+              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
+              .first,
+        );
+        expect(semantics.value, '0 out of 5 stars');
+      });
+
+      testWidgets('hint text present when editable', (tester) async {
+        await tester.pumpWidget(buildWidget(isEditable: true));
+
+        final semantics = tester.getSemantics(
+          find
+              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
+              .first,
+        );
+        expect(semantics.hint, isNotEmpty);
+      });
+
+      testWidgets('no hint text when not editable', (tester) async {
+        await tester.pumpWidget(buildWidget(rating: 2));
+
+        final semantics = tester.getSemantics(
+          find
+              .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
+              .first,
+        );
+        expect(semantics.hint, isEmpty);
+      });
+    });
+
+    group('tap interactions', () {
+      testWidgets('tapping star N calls onRatingChanged with N', (
+        tester,
+      ) async {
+        int? received;
+        await tester.pumpWidget(
+          buildWidget(isEditable: true, onRatingChanged: (v) => received = v),
+        );
+
+        await tester.tap(
+          find
+              .descendant(
+                of: find.byType(StarRating),
+                matching: find.byType(GestureDetector),
+              )
+              .at(2),
+        );
+        expect(received, 3);
+      });
+
+      testWidgets('tapping the current rating clears it (calls with null)', (
+        tester,
+      ) async {
+        int? received = -1;
+        await tester.pumpWidget(
+          buildWidget(
+            rating: 3,
+            isEditable: true,
+            onRatingChanged: (v) => received = v,
+          ),
+        );
+
+        await tester.tap(
+          find
+              .descendant(
+                of: find.byType(StarRating),
+                matching: find.byType(GestureDetector),
+              )
+              .at(2),
+        );
+        expect(received, isNull);
+      });
+
+      testWidgets('tapping different star updates rating', (tester) async {
+        int? received;
+        await tester.pumpWidget(
+          buildWidget(
+            rating: 3,
+            isEditable: true,
+            onRatingChanged: (v) => received = v,
+          ),
+        );
+
+        await tester.tap(
+          find
+              .descendant(
+                of: find.byType(StarRating),
+                matching: find.byType(GestureDetector),
+              )
+              .at(4),
+        );
+        expect(received, 5);
+      });
+
+      testWidgets('tapping does nothing when not editable', (tester) async {
+        var called = false;
+        await tester.pumpWidget(
+          buildWidget(rating: 3, onRatingChanged: (_) => called = true),
+        );
+
+        await tester.tap(
+          find
+              .descendant(
+                of: find.byType(StarRating),
+                matching: find.byType(GestureDetector),
+              )
+              .first,
+        );
+        expect(called, isFalse);
+      });
+    });
+
+    group('display options', () {
+      testWidgets('respects custom starSize', (tester) async {
+        await tester.pumpWidget(buildWidget(rating: 1, starSize: 32));
+
+        final icon = tester.widget<Icon>(find.byIcon(Icons.star));
+        expect(icon.size, 32);
+      });
+
+      testWidgets('respects custom activeColor', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StarRating(rating: 1, activeColor: Colors.red),
+            ),
+          ),
+        );
+
+        final filledIcon = tester.widget<Icon>(find.byIcon(Icons.star));
+        expect(filledIcon.color, Colors.red);
+      });
+    });
+  });
+}

--- a/test/widgets/star_rating_test.dart
+++ b/test/widgets/star_rating_test.dart
@@ -46,7 +46,7 @@ void main() {
     });
 
     group('semantics', () {
-      outerSemantics(WidgetTester tester) => tester.getSemantics(
+      SemanticsNode outerSemantics(WidgetTester tester) => tester.getSemantics(
         find
             .ancestor(of: find.byType(Row), matching: find.byType(Semantics))
             .first,
@@ -96,7 +96,7 @@ void main() {
               )
               .at(1),
         );
-        expect(node.hasFlag(SemanticsFlag.isButton), isTrue);
+        expect(node.flagsCollection.isButton, isTrue);
       });
 
       testWidgets('stars are not marked as buttons when not editable', (
@@ -111,7 +111,7 @@ void main() {
               )
               .at(1),
         );
-        expect(node.hasFlag(SemanticsFlag.isButton), isFalse);
+        expect(node.flagsCollection.isButton, isFalse);
       });
     });
 
@@ -200,7 +200,7 @@ void main() {
 
       testWidgets('respects custom activeColor', (tester) async {
         await tester.pumpWidget(
-          MaterialApp(
+          const MaterialApp(
             home: Scaffold(
               body: StarRating(rating: 1, activeColor: Colors.red),
             ),


### PR DESCRIPTION
Add 16 tests for StarRating covering star rendering (0–5 ratings),
accessibility semantics (label, value, hint), tap interactions
(set/clear rating, no-op when not editable), and display options
(custom size and color).

Add 23 tests for FestivalInfoScreen covering header content (name,
dates, hashtag, ACTIVE badge), overview chips, location section
(conditional display, map button with semantics), hours and
description sections, action buttons (GitHub always present,
website/charity conditional), and app bar title. Uses GoRouter
integration pattern to satisfy screen's navigation dependencies.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AWuJ5ykJbU5mXsqAQV2krX