### PR TITLE
test(widgets): expand festival_menu_sheets test coverage

### DIFF
--- a/lib/widgets/festival_menu_sheets.dart
+++ b/lib/widgets/festival_menu_sheets.dart
@@ -375,6 +375,7 @@ class FestivalCard extends StatelessWidget {
               if (festival.availableBeverageTypes.isNotEmpty) ...[
                 const SizedBox(height: 12),
                 Wrap(
+                  key: const Key('beverage_chips_wrap'),
                   spacing: 6,
                   runSpacing: 4,
                   children: festival.availableBeverageTypes

--- a/test/services/user_data_store_test.dart
+++ b/test/services/user_data_store_test.dart
@@ -283,6 +283,79 @@ void main() {
         expect(d1.rating, 2); // preserved
         expect(d1.wantToTry, isTrue); // legacy favourite folded in
       });
+
+      test(
+        'does not add a second tasting event when one already exists in the unified record',
+        () async {
+          final existingEvent = DateTime(2025, 5, 17, 10, 0);
+          final legacyMillis = DateTime(2025, 5, 15).millisecondsSinceEpoch;
+          SharedPreferences.setMockInitialValues({
+            'tasting_log_cbf2025|d1': legacyMillis,
+          });
+          final prefs = await SharedPreferences.getInstance();
+          final migrating = SharedPreferencesUserDataStore(prefs);
+          // Pre-seed a unified record that already has a tasting event.
+          await migrating.write(
+            'cbf2025',
+            'd1',
+            UserDrinkState.initial().copyWith(tastingEvents: [existingEvent]),
+          );
+
+          await migrating.migrateLegacyData();
+
+          final d1 = migrating.read('cbf2025', 'd1')!;
+          expect(d1.tastingEvents, hasLength(1));
+          expect(d1.tastingEvents.single, existingEvent);
+        },
+      );
+
+      test(
+        'silently skips a malformed ratings key with no drink-id separator',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            // Missing the second `_drinkId` segment — `sep` will be -1.
+            // The key is recognised by prefix but skipped before legacyKeys.add,
+            // so it is not deleted and no record is written.
+            'ratings_cbf2025': 4,
+          });
+          final prefs = await SharedPreferences.getInstance();
+          final migrating = SharedPreferencesUserDataStore(prefs);
+
+          await migrating.migrateLegacyData();
+
+          expect(migrating.readAll('cbf2025'), isEmpty);
+        },
+      );
+
+      test(
+        'silently skips a malformed tasting key with no pipe separator',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            // Missing the `|drinkId` segment — `sep` will be -1.
+            // Same as above: recognised by prefix, skipped, not deleted.
+            'tasting_log_cbf2025': 1747526400000,
+          });
+          final prefs = await SharedPreferences.getInstance();
+          final migrating = SharedPreferencesUserDataStore(prefs);
+
+          await migrating.migrateLegacyData();
+
+          expect(migrating.readAll('cbf2025'), isEmpty);
+        },
+      );
+
+      test(
+        'sets the completion flag even when there are no legacy keys to migrate',
+        () async {
+          SharedPreferences.setMockInitialValues({});
+          final prefs = await SharedPreferences.getInstance();
+          final migrating = SharedPreferencesUserDataStore(prefs);
+
+          await migrating.migrateLegacyData();
+
+          expect(prefs.getBool('personal_state_migration_v1'), isTrue);
+        },
+      );
     });
 
     group('migrate', () {

--- a/test/services/user_data_store_test.dart
+++ b/test/services/user_data_store_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:cambridge_beer_festival/constants/preference_keys.dart';
 import 'package:cambridge_beer_festival/models/models.dart';
 import 'package:cambridge_beer_festival/services/user_data_store.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -353,7 +354,7 @@ void main() {
 
           await migrating.migrateLegacyData();
 
-          expect(prefs.getBool('personal_state_migration_v1'), isTrue);
+          expect(prefs.getBool(PreferenceKeys.legacyMigrationComplete), isTrue);
         },
       );
     });

--- a/test/widgets/festival_menu_sheets_test.dart
+++ b/test/widgets/festival_menu_sheets_test.dart
@@ -122,6 +122,8 @@ void main() {
       expect(provider.currentFestival, equals(initialFestival));
     });
 
+    tearDown(() => provider.dispose());
+
     testWidgets('has correct semantics for screen readers', (tester) async {
       await tester.pumpWidget(buildTestWidget());
 
@@ -360,20 +362,17 @@ void main() {
       (tester) async {
         await tester.pumpWidget(buildTestWidget());
 
-        final semanticsWidgets = tester
-            .widgetList<Semantics>(
-              find.ancestor(
-                of: find.byType(FestivalCard),
-                matching: find.byType(Semantics),
-              ),
-            )
-            .toList();
-
-        final selected = semanticsWidgets.firstWhere(
-          (s) => s.properties.label?.contains(testFestival.name) ?? false,
+        expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Semantics &&
+                (widget.properties.label?.contains(testFestival.name) ??
+                    false) &&
+                (widget.properties.label?.contains('currently selected') ??
+                    false),
+          ),
+          findsOneWidget,
         );
-
-        expect(selected.properties.label, contains('currently selected'));
       },
     );
 
@@ -421,22 +420,16 @@ void main() {
           ),
         );
 
-        final semanticsWidgets = tester
-            .widgetList<Semantics>(
-              find.ancestor(
-                of: find.byType(FestivalCard),
-                matching: find.byType(Semantics),
-              ),
-            )
-            .toList();
-
-        final nonSelected = semanticsWidgets.firstWhere(
-          (s) => s.properties.label?.contains('Other Festival 2023') ?? false,
-        );
-
         expect(
-          nonSelected.properties.label,
-          isNot(contains('currently selected')),
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Semantics &&
+                (widget.properties.label?.contains('Other Festival 2023') ??
+                    false) &&
+                !(widget.properties.label?.contains('currently selected') ??
+                    false),
+          ),
+          findsOneWidget,
         );
         twoFestivalProvider.dispose();
       },
@@ -705,7 +698,7 @@ void main() {
           ),
         );
 
-        expect(find.byType(Wrap), findsNothing);
+        expect(find.byKey(const Key('beverage_chips_wrap')), findsNothing);
       },
     );
 
@@ -742,7 +735,10 @@ void main() {
       );
 
       expect(
-        find.descendant(of: find.byType(Wrap), matching: find.byType(Text)),
+        find.descendant(
+          of: find.byKey(const Key('beverage_chips_wrap')),
+          matching: find.byType(Text),
+        ),
         findsNWidgets(5),
       );
     });
@@ -808,6 +804,8 @@ void main() {
         ),
       );
     }
+
+    tearDown(() => provider.dispose());
 
     testWidgets('displays settings title and theme option', (tester) async {
       await tester.pumpWidget(buildTestWidget());
@@ -918,6 +916,8 @@ void main() {
         ),
       );
     }
+
+    tearDown(() => provider.dispose());
 
     testWidgets('displays all three theme options', (tester) async {
       await tester.pumpWidget(buildTestWidget());

--- a/test/widgets/festival_menu_sheets_test.dart
+++ b/test/widgets/festival_menu_sheets_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cambridge_beer_festival/domain/repositories/repositories.dart';
 import 'package:cambridge_beer_festival/models/models.dart';
 import 'package:cambridge_beer_festival/providers/beer_provider.dart';
@@ -149,6 +151,296 @@ void main() {
 
       expect(decoration.color, lightTheme.colorScheme.onSurfaceVariant);
     });
+
+    testWidgets('shows loading indicator when festivals are loading', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final drinkRepo = MockDrinkRepository();
+      final festivalRepo = MockFestivalRepository();
+      final analytics = MockAnalyticsService();
+      final completer = Completer<FestivalsResponse>();
+
+      when(festivalRepo.getFestivals()).thenAnswer((_) => completer.future);
+      when(drinkRepo.getDrinks(any)).thenAnswer((_) async => []);
+
+      final loadingProvider = BeerProvider(
+        drinkRepository: drinkRepo,
+        festivalRepository: festivalRepo,
+        analyticsService: analytics,
+      );
+
+      // loadFestivals sets _isFestivalsLoading = true synchronously before awaiting
+      unawaited(loadingProvider.loadFestivals());
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FestivalSelectorSheet(provider: loadingProvider),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      completer.complete(
+        FestivalsResponse(
+          festivals: [],
+          defaultFestivalId: '',
+          version: '1.0.0',
+          baseUrl: 'https://data.cambeerfestival.app',
+        ),
+      );
+      // Don't pumpAndSettle — FestivalSelectorSheet is a StatelessWidget and
+      // won't rebuild, so CircularProgressIndicator keeps animating indefinitely.
+      await tester.pump();
+      loadingProvider.dispose();
+    });
+
+    testWidgets('shows error state when festival loading fails', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final drinkRepo = MockDrinkRepository();
+      final festivalRepo = MockFestivalRepository();
+      final analytics = MockAnalyticsService();
+
+      when(festivalRepo.getFestivals()).thenThrow(Exception('Network error'));
+      when(festivalRepo.getSelectedFestivalId()).thenAnswer((_) async => null);
+      when(drinkRepo.getDrinks(any)).thenAnswer((_) async => []);
+
+      final errorProvider = BeerProvider(
+        drinkRepository: drinkRepo,
+        festivalRepository: festivalRepo,
+        analyticsService: analytics,
+      );
+
+      await errorProvider.initialize();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: FestivalSelectorSheet(provider: errorProvider)),
+        ),
+      );
+
+      expect(find.text('Failed to load festivals'), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+
+      errorProvider.dispose();
+    });
+
+    testWidgets('retry button triggers loadFestivals and clears error', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final drinkRepo = MockDrinkRepository();
+      final festivalRepo = MockFestivalRepository();
+      final analytics = MockAnalyticsService();
+
+      var callCount = 0;
+      when(festivalRepo.getFestivals()).thenAnswer((_) async {
+        if (callCount++ == 0) throw Exception('Network error');
+        return FestivalsResponse(
+          festivals: [],
+          defaultFestivalId: '',
+          version: '1.0.0',
+          baseUrl: 'https://data.cambeerfestival.app',
+        );
+      });
+      when(festivalRepo.getSelectedFestivalId()).thenAnswer((_) async => null);
+      when(drinkRepo.getDrinks(any)).thenAnswer((_) async => []);
+
+      final retryProvider = BeerProvider(
+        drinkRepository: drinkRepo,
+        festivalRepository: festivalRepo,
+        analyticsService: analytics,
+      );
+
+      await retryProvider.initialize();
+      expect(retryProvider.festivalsError, isNotNull);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: FestivalSelectorSheet(provider: retryProvider)),
+        ),
+      );
+
+      await tester.tap(find.text('Retry'));
+      await tester.pumpAndSettle();
+
+      expect(retryProvider.festivalsError, isNull);
+      retryProvider.dispose();
+    });
+
+    testWidgets('shows empty state when no festivals are available', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final drinkRepo = MockDrinkRepository();
+      final festivalRepo = MockFestivalRepository();
+      final analytics = MockAnalyticsService();
+
+      when(festivalRepo.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: [],
+          defaultFestivalId: '',
+          version: '1.0.0',
+          baseUrl: 'https://data.cambeerfestival.app',
+        ),
+      );
+      when(festivalRepo.getSelectedFestivalId()).thenAnswer((_) async => null);
+      when(drinkRepo.getDrinks(any)).thenAnswer((_) async => []);
+
+      final emptyProvider = BeerProvider(
+        drinkRepository: drinkRepo,
+        festivalRepository: festivalRepo,
+        analyticsService: analytics,
+      );
+
+      await emptyProvider.initialize();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: FestivalSelectorSheet(provider: emptyProvider)),
+        ),
+      );
+
+      expect(find.text('No festivals available'), findsOneWidget);
+      expect(find.byIcon(Icons.festival_outlined), findsOneWidget);
+      expect(find.text('Refresh'), findsOneWidget);
+
+      emptyProvider.dispose();
+    });
+
+    testWidgets('refresh button triggers loadFestivals in empty state', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final drinkRepo = MockDrinkRepository();
+      final festivalRepo = MockFestivalRepository();
+      final analytics = MockAnalyticsService();
+
+      var callCount = 0;
+      when(festivalRepo.getFestivals()).thenAnswer((_) async {
+        callCount++;
+        return FestivalsResponse(
+          festivals: callCount > 1 ? [testFestival] : [],
+          defaultFestivalId: callCount > 1 ? testFestival.id : '',
+          version: '1.0.0',
+          baseUrl: 'https://data.cambeerfestival.app',
+        );
+      });
+      when(festivalRepo.getSelectedFestivalId()).thenAnswer((_) async => null);
+      when(drinkRepo.getDrinks(any)).thenAnswer((_) async => []);
+
+      final emptyProvider = BeerProvider(
+        drinkRepository: drinkRepo,
+        festivalRepository: festivalRepo,
+        analyticsService: analytics,
+      );
+
+      await emptyProvider.initialize();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: FestivalSelectorSheet(provider: emptyProvider)),
+        ),
+      );
+
+      await tester.tap(find.text('Refresh'));
+      await tester.pumpAndSettle();
+
+      expect(emptyProvider.sortedFestivals, isNotEmpty);
+      emptyProvider.dispose();
+    });
+
+    testWidgets(
+      'semantics label includes currently selected for current festival',
+      (tester) async {
+        await tester.pumpWidget(buildTestWidget());
+
+        final semanticsWidgets = tester
+            .widgetList<Semantics>(
+              find.ancestor(
+                of: find.byType(FestivalCard),
+                matching: find.byType(Semantics),
+              ),
+            )
+            .toList();
+
+        final selected = semanticsWidgets.firstWhere(
+          (s) => s.properties.label?.contains(testFestival.name) ?? false,
+        );
+
+        expect(selected.properties.label, contains('currently selected'));
+      },
+    );
+
+    testWidgets(
+      'semantics label omits currently selected for non-current festival',
+      (tester) async {
+        SharedPreferences.setMockInitialValues({});
+        final drinkRepo = MockDrinkRepository();
+        final festivalRepo = MockFestivalRepository();
+        final analytics = MockAnalyticsService();
+
+        final otherFestival = Festival(
+          id: 'other-2023',
+          name: 'Other Festival 2023',
+          dataBaseUrl: 'https://example.com',
+          startDate: DateTime(2023, 5, 15),
+          endDate: DateTime(2023, 5, 20),
+        );
+
+        when(festivalRepo.getFestivals()).thenAnswer(
+          (_) async => FestivalsResponse(
+            festivals: [testFestival, otherFestival],
+            defaultFestivalId: testFestival.id,
+            version: '1.0.0',
+            baseUrl: 'https://data.cambeerfestival.app',
+          ),
+        );
+        when(
+          festivalRepo.getSelectedFestivalId(),
+        ).thenAnswer((_) async => testFestival.id);
+        when(drinkRepo.getDrinks(any)).thenAnswer((_) async => []);
+
+        final twoFestivalProvider = BeerProvider(
+          drinkRepository: drinkRepo,
+          festivalRepository: festivalRepo,
+          analyticsService: analytics,
+        );
+        await twoFestivalProvider.initialize();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: FestivalSelectorSheet(provider: twoFestivalProvider),
+            ),
+          ),
+        );
+
+        final semanticsWidgets = tester
+            .widgetList<Semantics>(
+              find.ancestor(
+                of: find.byType(FestivalCard),
+                matching: find.byType(Semantics),
+              ),
+            )
+            .toList();
+
+        final nonSelected = semanticsWidgets.firstWhere(
+          (s) => s.properties.label?.contains('Other Festival 2023') ?? false,
+        );
+
+        expect(
+          nonSelected.properties.label,
+          isNot(contains('currently selected')),
+        );
+        twoFestivalProvider.dispose();
+      },
+    );
   });
 
   group('FestivalCard', () {
@@ -240,6 +532,234 @@ void main() {
       expect(find.text('Beer'), findsOneWidget);
       expect(find.text('Cider'), findsOneWidget);
     });
+
+    testWidgets('shows MOST RECENT badge for the only past festival', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.text('MOST RECENT'), findsOneWidget);
+    });
+
+    testWidgets(
+      'shows PAST badge for older festival when a newer past one exists',
+      (tester) async {
+        final newerFestival = Festival(
+          id: 'newer-2025',
+          name: 'Newer Festival 2025',
+          dataBaseUrl: 'https://example.com',
+          startDate: DateTime(2025, 5, 20),
+          endDate: DateTime(2025, 5, 25),
+        );
+        // getStatusInContext marks the FIRST past festival in the sorted list
+        // as mostRecent, so newerFestival must come first.
+        final bothFestivals = [newerFestival, testFestival];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: FestivalCard(
+                festival: testFestival,
+                sortedFestivals: bothFestivals,
+                isSelected: false,
+                onTap: () {},
+                onInfoTap: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('PAST'), findsOneWidget);
+      },
+    );
+
+    testWidgets('shows LIVE badge for a currently running festival', (
+      tester,
+    ) async {
+      final liveFestival = Festival(
+        id: 'live-now',
+        name: 'Live Festival',
+        dataBaseUrl: 'https://example.com',
+        startDate: DateTime.now().subtract(const Duration(days: 1)),
+        endDate: DateTime.now().add(const Duration(days: 1)),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FestivalCard(
+              festival: liveFestival,
+              sortedFestivals: [liveFestival],
+              isSelected: false,
+              onTap: () {},
+              onInfoTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('LIVE'), findsOneWidget);
+    });
+
+    testWidgets('shows COMING SOON badge for an upcoming festival', (
+      tester,
+    ) async {
+      final upcomingFestival = Festival(
+        id: 'upcoming-2099',
+        name: 'Future Festival',
+        dataBaseUrl: 'https://example.com',
+        startDate: DateTime(2099, 1, 1),
+        endDate: DateTime(2099, 1, 7),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FestivalCard(
+              festival: upcomingFestival,
+              sortedFestivals: [upcomingFestival],
+              isSelected: false,
+              onTap: () {},
+              onInfoTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('COMING SOON'), findsOneWidget);
+    });
+
+    testWidgets('does not show date row when festival has no dates', (
+      tester,
+    ) async {
+      final noDatesFestival = Festival(
+        id: 'no-dates',
+        name: 'No Dates Festival',
+        dataBaseUrl: 'https://example.com',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FestivalCard(
+              festival: noDatesFestival,
+              sortedFestivals: [noDatesFestival],
+              isSelected: false,
+              onTap: () {},
+              onInfoTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.calendar_today), findsNothing);
+    });
+
+    testWidgets('does not show location row when festival has no location', (
+      tester,
+    ) async {
+      final noLocationFestival = Festival(
+        id: 'no-location',
+        name: 'No Location Festival',
+        dataBaseUrl: 'https://example.com',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FestivalCard(
+              festival: noLocationFestival,
+              sortedFestivals: [noLocationFestival],
+              isSelected: false,
+              onTap: () {},
+              onInfoTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.location_on), findsNothing);
+    });
+
+    testWidgets(
+      'does not show beverage type chips when no types are available',
+      (tester) async {
+        final noTypesFestival = Festival(
+          id: 'no-types',
+          name: 'No Types Festival',
+          dataBaseUrl: 'https://example.com',
+          availableBeverageTypes: const [],
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: FestivalCard(
+                festival: noTypesFestival,
+                sortedFestivals: [noTypesFestival],
+                isSelected: false,
+                onTap: () {},
+                onInfoTap: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(Wrap), findsNothing);
+      },
+    );
+
+    testWidgets('shows at most 5 beverage type chips when more are available', (
+      tester,
+    ) async {
+      final manyTypesFestival = Festival(
+        id: 'many-types',
+        name: 'Many Types Festival',
+        dataBaseUrl: 'https://example.com',
+        availableBeverageTypes: const [
+          'beer',
+          'cider',
+          'perry',
+          'mead',
+          'wine',
+          'low-no',
+          'international-beer',
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FestivalCard(
+              festival: manyTypesFestival,
+              sortedFestivals: [manyTypesFestival],
+              isSelected: false,
+              onTap: () {},
+              onInfoTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(of: find.byType(Wrap), matching: find.byType(Text)),
+        findsNWidgets(5),
+      );
+    });
+
+    testWidgets('info button has correct semantics', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label == 'Festival information' &&
+              widget.properties.button == true,
+        ),
+        findsOneWidget,
+      );
+    });
   });
 
   group('SettingsSheet', () {
@@ -315,6 +835,40 @@ void main() {
       final decoration = handleContainer.decoration! as BoxDecoration;
 
       expect(decoration.color, lightTheme.colorScheme.onSurfaceVariant);
+    });
+
+    testWidgets('shows Light label and icon when theme is light', (
+      tester,
+    ) async {
+      provider.setThemeMode(ThemeMode.light);
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.text('Light mode'), findsOneWidget);
+      expect(find.byIcon(Icons.light_mode), findsOneWidget);
+    });
+
+    testWidgets('shows Dark label and icon when theme is dark', (tester) async {
+      provider.setThemeMode(ThemeMode.dark);
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.text('Dark mode'), findsOneWidget);
+      expect(find.byIcon(Icons.dark_mode), findsOneWidget);
+    });
+
+    testWidgets('theme card semantics label includes current theme mode', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              (widget.properties.label?.startsWith('Change theme, currently') ??
+                  false),
+        ),
+        findsOneWidget,
+      );
     });
   });
 
@@ -411,6 +965,26 @@ void main() {
       final decoration = handleContainer.decoration! as BoxDecoration;
 
       expect(decoration.color, lightTheme.colorScheme.onSurfaceVariant);
+    });
+
+    testWidgets('shows subtitles for all three theme options', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.text('Follow device settings'), findsOneWidget);
+      expect(find.text('Always use light theme'), findsOneWidget);
+      expect(find.text('Always use dark theme'), findsOneWidget);
+    });
+
+    testWidgets('changes theme to system when system option is tapped', (
+      tester,
+    ) async {
+      provider.setThemeMode(ThemeMode.light);
+      await tester.pumpWidget(buildTestWidget());
+
+      await tester.tap(find.text('System'));
+      await tester.pumpAndSettle();
+
+      expect(provider.themeMode, ThemeMode.system);
     });
   });
 }

--- a/test/widgets/festival_menu_sheets_test.dart
+++ b/test/widgets/festival_menu_sheets_test.dart
@@ -171,6 +171,7 @@ void main() {
         festivalRepository: festivalRepo,
         analyticsService: analytics,
       );
+      addTearDown(loadingProvider.dispose);
 
       // loadFestivals sets _isFestivalsLoading = true synchronously before awaiting
       unawaited(loadingProvider.loadFestivals());
@@ -196,7 +197,6 @@ void main() {
       // Don't pumpAndSettle — FestivalSelectorSheet is a StatelessWidget and
       // won't rebuild, so CircularProgressIndicator keeps animating indefinitely.
       await tester.pump();
-      loadingProvider.dispose();
     });
 
     testWidgets('shows error state when festival loading fails', (
@@ -216,6 +216,7 @@ void main() {
         festivalRepository: festivalRepo,
         analyticsService: analytics,
       );
+      addTearDown(errorProvider.dispose);
 
       await errorProvider.initialize();
 
@@ -228,8 +229,6 @@ void main() {
       expect(find.text('Failed to load festivals'), findsOneWidget);
       expect(find.byIcon(Icons.error_outline), findsOneWidget);
       expect(find.text('Retry'), findsOneWidget);
-
-      errorProvider.dispose();
     });
 
     testWidgets('retry button triggers loadFestivals and clears error', (
@@ -258,6 +257,7 @@ void main() {
         festivalRepository: festivalRepo,
         analyticsService: analytics,
       );
+      addTearDown(retryProvider.dispose);
 
       await retryProvider.initialize();
       expect(retryProvider.festivalsError, isNotNull);
@@ -272,7 +272,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(retryProvider.festivalsError, isNull);
-      retryProvider.dispose();
     });
 
     testWidgets('shows empty state when no festivals are available', (
@@ -299,6 +298,7 @@ void main() {
         festivalRepository: festivalRepo,
         analyticsService: analytics,
       );
+      addTearDown(emptyProvider.dispose);
 
       await emptyProvider.initialize();
 
@@ -311,8 +311,6 @@ void main() {
       expect(find.text('No festivals available'), findsOneWidget);
       expect(find.byIcon(Icons.festival_outlined), findsOneWidget);
       expect(find.text('Refresh'), findsOneWidget);
-
-      emptyProvider.dispose();
     });
 
     testWidgets('refresh button triggers loadFestivals in empty state', (
@@ -341,6 +339,7 @@ void main() {
         festivalRepository: festivalRepo,
         analyticsService: analytics,
       );
+      addTearDown(emptyProvider.dispose);
 
       await emptyProvider.initialize();
 
@@ -354,7 +353,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(emptyProvider.sortedFestivals, isNotEmpty);
-      emptyProvider.dispose();
     });
 
     testWidgets(
@@ -410,6 +408,7 @@ void main() {
           festivalRepository: festivalRepo,
           analyticsService: analytics,
         );
+        addTearDown(twoFestivalProvider.dispose);
         await twoFestivalProvider.initialize();
 
         await tester.pumpWidget(
@@ -431,7 +430,6 @@ void main() {
           ),
           findsOneWidget,
         );
-        twoFestivalProvider.dispose();
       },
     );
   });
@@ -544,9 +542,10 @@ void main() {
           startDate: DateTime(2025, 5, 20),
           endDate: DateTime(2025, 5, 25),
         );
-        // getStatusInContext marks the FIRST past festival in the sorted list
-        // as mostRecent, so newerFestival must come first.
-        final bothFestivals = [newerFestival, testFestival];
+        final bothFestivals = Festival.sortByDate([
+          newerFestival,
+          testFestival,
+        ]);
 
         await tester.pumpWidget(
           MaterialApp(


### PR DESCRIPTION
Add 26 new tests covering previously untested branches:

FestivalSelectorSheet: loading spinner, error state (with Retry),
empty state (with Refresh), retry/refresh triggering loadFestivals,
and semantics labels for selected vs non-selected festivals.

FestivalCard: all four status badges (LIVE, COMING SOON, MOST RECENT,
PAST), guard clauses for missing dates/location/beverage-types, the
5-item beverage type cap, and info button semantics.

SettingsSheet: Light/Dark theme label+icon variants, semantics label.

ThemeSelectorSheet: option subtitles, System theme selection.