### PR TITLE
chore: add SessionStart hook to install Flutter toolchain on web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+	exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install Flutter 3.44.0 and all mise-managed tools (Node, shellcheck, shfmt).
+# bin/mise self-bootstraps so no prior installation is required.
+./bin/mise install
+
+# Fetch pub dependencies and generate mocks.
+# [deps.flutter] auto=true in mise.toml triggers flutter pub get automatically.
+./bin/mise run generate

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,6 +6,8 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 	exit 0
 fi
 
+echo '{"async": true, "asyncTimeout": 300000}'
+
 cd "$CLAUDE_PROJECT_DIR"
 
 # Install Flutter 3.44.0 and all mise-managed tools (Node, shellcheck, shfmt).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,6 +42,16 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",


### PR DESCRIPTION
Installs Flutter 3.44.0 and other mise-managed tools (Node, shellcheck,
shfmt) then runs code generation (pub get + build_runner) so tests and
linters are ready without manual setup.

Only runs in remote environments (CLAUDE_CODE_REMOTE=true).