### PR TITLE
fix(repository): return UserDrinkState from mutators to eliminate dual DateTime.now()

### DIFF
--- a/lib/domain/controllers/user_drink_state_controller.dart
+++ b/lib/domain/controllers/user_drink_state_controller.dart
@@ -94,6 +94,19 @@ class UserDrinkStateController {
     now,
   );
 
+  /// Store [state] directly under [drinkId], bypassing re-computation.
+  ///
+  /// If [state] is null or [state].isEmpty, the entry is pruned and null is
+  /// returned. Use this to propagate state already persisted by the repository,
+  /// avoiding a second [DateTime.now()] call.
+  UserDrinkState? apply(String drinkId, UserDrinkState? state) {
+    if (state == null) {
+      _states.remove(drinkId);
+      return null;
+    }
+    return _apply(drinkId, state);
+  }
+
   // --- Internal helpers ---
 
   /// Applies [transform] to the base state for [drinkId] and stores the

--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -125,15 +125,17 @@ class ApiDrinkRepository implements DrinkRepository {
   }
 
   @override
-  Future<bool> toggleFavorite(String festivalId, String drinkId) async {
+  Future<UserDrinkState?> toggleFavorite(
+    String festivalId,
+    String drinkId,
+  ) async {
     final current = _mutableState(festivalId, drinkId);
-    final next = !current.wantToTry;
-    await _userDataStore.write(
-      festivalId,
-      drinkId,
-      current.copyWith(wantToTry: next, updatedAt: DateTime.now()),
+    final persisted = current.copyWith(
+      wantToTry: !current.wantToTry,
+      updatedAt: DateTime.now(),
     );
-    return next;
+    await _userDataStore.write(festivalId, drinkId, persisted);
+    return persisted.isEmpty ? null : persisted;
   }
 
   @override
@@ -142,7 +144,11 @@ class ApiDrinkRepository implements DrinkRepository {
   }
 
   @override
-  Future<void> setRating(String festivalId, String drinkId, int rating) async {
+  Future<UserDrinkState?> setRating(
+    String festivalId,
+    String drinkId,
+    int rating,
+  ) async {
     if (rating < 1 || rating > 5) {
       throw ArgumentError.value(
         rating,
@@ -151,22 +157,24 @@ class ApiDrinkRepository implements DrinkRepository {
       );
     }
     final current = _mutableState(festivalId, drinkId);
-    await _userDataStore.write(
-      festivalId,
-      drinkId,
-      current.copyWith(rating: rating, updatedAt: DateTime.now()),
+    final persisted = current.copyWith(
+      rating: rating,
+      updatedAt: DateTime.now(),
     );
+    await _userDataStore.write(festivalId, drinkId, persisted);
+    return persisted.isEmpty ? null : persisted;
   }
 
   @override
-  Future<void> removeRating(String festivalId, String drinkId) async {
+  Future<UserDrinkState?> removeRating(
+    String festivalId,
+    String drinkId,
+  ) async {
     final current = _userDataStore.read(festivalId, drinkId);
-    if (current == null) return;
-    await _userDataStore.write(
-      festivalId,
-      drinkId,
-      current.copyWith(rating: null, updatedAt: DateTime.now()),
-    );
+    if (current == null) return null;
+    final persisted = current.copyWith(rating: null, updatedAt: DateTime.now());
+    await _userDataStore.write(festivalId, drinkId, persisted);
+    return persisted.isEmpty ? null : persisted;
   }
 
   @override
@@ -175,7 +183,10 @@ class ApiDrinkRepository implements DrinkRepository {
   }
 
   @override
-  Future<bool> toggleTasted(String festivalId, String drinkId) async {
+  Future<UserDrinkState?> toggleTasted(
+    String festivalId,
+    String drinkId,
+  ) async {
     final current = _mutableState(festivalId, drinkId);
     final now = DateTime.now();
     // Binary toggle preserves the prior single-timestamp behaviour: tasting a
@@ -185,7 +196,7 @@ class ApiDrinkRepository implements DrinkRepository {
         ? current.copyWith(tastingEvents: const [], updatedAt: now)
         : current.copyWith(tastingEvents: [now], updatedAt: now);
     await _userDataStore.write(festivalId, drinkId, next);
-    return next.isTasted;
+    return next.isEmpty ? null : next;
   }
 
   @override

--- a/lib/domain/repositories/drink_repository.dart
+++ b/lib/domain/repositories/drink_repository.dart
@@ -22,25 +22,33 @@ abstract class DrinkRepository {
 
   /// Toggle favorite status for a drink
   ///
-  /// Returns the new favorite status (true if now favorited, false if unfavorited).
-  Future<bool> toggleFavorite(String festivalId, String drinkId);
+  /// Returns the persisted state, or null when the record was pruned to empty.
+  Future<UserDrinkState?> toggleFavorite(String festivalId, String drinkId);
 
   /// Get rating for a drink (1-5 stars, or null if not rated)
   Future<int?> getRating(String festivalId, String drinkId);
 
   /// Set rating for a drink (1-5 stars)
-  Future<void> setRating(String festivalId, String drinkId, int rating);
+  ///
+  /// Returns the persisted state.
+  Future<UserDrinkState?> setRating(
+    String festivalId,
+    String drinkId,
+    int rating,
+  );
 
   /// Remove rating for a drink
-  Future<void> removeRating(String festivalId, String drinkId);
+  ///
+  /// Returns the persisted state, or null when the record was pruned to empty.
+  Future<UserDrinkState?> removeRating(String festivalId, String drinkId);
 
   /// Check if a drink has been tasted at a festival
   Future<bool> hasTasted(String festivalId, String drinkId);
 
   /// Toggle tasted status for a drink
   ///
-  /// Returns the new tasted status (true if now tasted, false if untasted).
-  Future<bool> toggleTasted(String festivalId, String drinkId);
+  /// Returns the persisted state, or null when the record was pruned to empty.
+  Future<UserDrinkState?> toggleTasted(String festivalId, String drinkId);
 
   /// Get list of tasted drink IDs for a festival
   Future<List<String>> getTastedDrinks(String festivalId);

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -723,17 +723,16 @@ class BeerProvider extends ChangeNotifier {
   Future<void> toggleFavorite(Drink drink) async {
     if (_drinkRepository == null) return;
 
-    final newStatus = await _drinkRepository!.toggleFavorite(
-      currentFestival.id,
+    final newState = _personalState.apply(
       drink.id,
+      await _drinkRepository!.toggleFavorite(currentFestival.id, drink.id),
     );
-    final newState = _personalState.applyWantToTry(drink.id, value: newStatus);
     _replaceDrink(drink, drink.copyWith(userState: newState));
 
     notifyListeners();
 
     // Log analytics event (fire and forget)
-    if (newStatus) {
+    if (newState?.wantToTry ?? false) {
       unawaited(_analyticsService.logFavoriteAdded(drink));
     } else {
       unawaited(_analyticsService.logFavoriteRemoved(drink));
@@ -744,14 +743,22 @@ class BeerProvider extends ChangeNotifier {
   Future<void> setRating(Drink drink, int? rating) async {
     if (_drinkRepository == null) return;
 
+    final UserDrinkState? persisted;
     if (rating == null) {
-      await _drinkRepository!.removeRating(currentFestival.id, drink.id);
+      persisted = await _drinkRepository!.removeRating(
+        currentFestival.id,
+        drink.id,
+      );
     } else {
-      await _drinkRepository!.setRating(currentFestival.id, drink.id, rating);
+      persisted = await _drinkRepository!.setRating(
+        currentFestival.id,
+        drink.id,
+        rating,
+      );
       // Log analytics event for rating (fire and forget)
       unawaited(_analyticsService.logRatingGiven(drink, rating));
     }
-    final newState = _personalState.applyRating(drink.id, rating: rating);
+    final newState = _personalState.apply(drink.id, persisted);
     _replaceDrink(drink, drink.copyWith(userState: newState));
     notifyListeners();
   }
@@ -760,19 +767,16 @@ class BeerProvider extends ChangeNotifier {
   Future<void> toggleTasted(Drink drink) async {
     if (_drinkRepository == null) return;
 
-    final newStatus = await _drinkRepository!.toggleTasted(
-      currentFestival.id,
+    final newState = _personalState.apply(
       drink.id,
+      await _drinkRepository!.toggleTasted(currentFestival.id, drink.id),
     );
-    // Binary toggle mirrors the repository: a single event when tasted, none
-    // when cleared. (Multiple-tasting support is feature work in #315.)
-    final newState = _personalState.applyTasted(drink.id, tasted: newStatus);
     _replaceDrink(drink, drink.copyWith(userState: newState));
 
     notifyListeners();
 
     // Log analytics event
-    if (newStatus) {
+    if (newState?.isTasted ?? false) {
       unawaited(analyticsService.logTastedAdded(drink));
     } else {
       unawaited(analyticsService.logTastedRemoved(drink));

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -702,10 +702,14 @@ void main() {
           final drinkId = invocation.positionalArguments[1] as String;
           if (favorites.contains(drinkId)) {
             favorites.remove(drinkId);
-            return false;
+            return null;
           } else {
             favorites.add(drinkId);
-            return true;
+            return UserDrinkState(
+              wantToTry: true,
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            );
           }
         });
 
@@ -1187,7 +1191,13 @@ void main() {
               provider.currentFestival.id,
               target.id,
             ),
-          ).thenAnswer((_) async => true);
+          ).thenAnswer(
+            (_) async => UserDrinkState(
+              tastingEvents: [DateTime.now()],
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            ),
+          );
           await provider.toggleTasted(target);
 
           // With the not-tasted filter active the drink must drop out
@@ -2513,16 +2523,20 @@ void main() {
         await provider.loadDrinks();
         final drink = provider.allDrinks.first;
 
-        when(
-          mockDrinkRepository.toggleTasted(any, any),
-        ).thenAnswer((_) async => true);
+        when(mockDrinkRepository.toggleTasted(any, any)).thenAnswer(
+          (_) async => UserDrinkState(
+            tastingEvents: [DateTime.now()],
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
         await provider.toggleTasted(drink);
         expect(provider.getDrinkById(drink.id)!.isTasted, isTrue);
         verify(mockAnalyticsService.logTastedAdded(drink)).called(1);
 
         when(
           mockDrinkRepository.toggleTasted(any, any),
-        ).thenAnswer((_) async => false);
+        ).thenAnswer((_) async => null);
         final drink2 = provider.getDrinkById(drink.id)!;
         await provider.toggleTasted(drink2);
         expect(provider.getDrinkById(drink.id)!.isTasted, isFalse);
@@ -2545,9 +2559,13 @@ void main() {
           final drink = provider.allDrinks.first;
 
           // Turn tasted on: the in-memory record now carries a single event.
-          when(
-            mockDrinkRepository.toggleTasted(any, any),
-          ).thenAnswer((_) async => true);
+          when(mockDrinkRepository.toggleTasted(any, any)).thenAnswer(
+            (_) async => UserDrinkState(
+              tastingEvents: [DateTime.now()],
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            ),
+          );
           await provider.toggleTasted(drink);
           expect(provider.getDrinkById(drink.id)!.userState, isNotNull);
 
@@ -2555,7 +2573,7 @@ void main() {
           // null to mirror the store, which prunes empty records.
           when(
             mockDrinkRepository.toggleTasted(any, any),
-          ).thenAnswer((_) async => false);
+          ).thenAnswer((_) async => null);
           await provider.toggleTasted(provider.getDrinkById(drink.id)!);
           expect(provider.getDrinkById(drink.id)!.userState, isNull);
         },
@@ -2710,9 +2728,13 @@ void main() {
           expect(provider.drinks, isEmpty);
 
           final drink = provider.allDrinks.first;
-          when(
-            mockDrinkRepository.toggleFavorite(any, any),
-          ).thenAnswer((_) async => true);
+          when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer(
+            (_) async => UserDrinkState(
+              wantToTry: true,
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            ),
+          );
           await provider.toggleFavorite(drink);
 
           // The favourites-only list is refreshed by toggleFavorite.

--- a/test/brewery_screen_test.dart
+++ b/test/brewery_screen_test.dart
@@ -210,10 +210,14 @@ void main() {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
-          return false;
+          return null;
         } else {
           favorites.add(drinkId);
-          return true;
+          return UserDrinkState(
+            wantToTry: true,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          );
         }
       });
 

--- a/test/domain/controllers/user_drink_state_controller_test.dart
+++ b/test/domain/controllers/user_drink_state_controller_test.dart
@@ -262,6 +262,49 @@ void main() {
       );
     });
 
+    // --- apply ---
+
+    group('apply', () {
+      test('stores a non-empty state and returns it', () {
+        final state = _sampleState(wantToTry: true);
+        final result = controller.apply('d1', state);
+
+        expect(result, equals(state));
+        expect(controller.stateFor('d1'), equals(state));
+      });
+
+      test('prunes and returns null when given null', () {
+        controller.setSource([
+          _drink(id: 'd1', userState: _sampleState(wantToTry: true)),
+        ]);
+        final result = controller.apply('d1', null);
+
+        expect(result, isNull);
+        expect(controller.stateFor('d1'), isNull);
+      });
+
+      test('prunes and returns null when given an empty state', () {
+        controller.setSource([
+          _drink(id: 'd1', userState: _sampleState(wantToTry: true)),
+        ]);
+        final result = controller.apply('d1', _sampleState());
+
+        expect(result, isNull);
+        expect(controller.stateFor('d1'), isNull);
+      });
+
+      test('replaces existing state wholesale, does not merge', () {
+        controller.setSource([
+          _drink(id: 'd1', userState: _sampleState(wantToTry: true, rating: 3)),
+        ]);
+        final incoming = _sampleState(rating: 5);
+        controller.apply('d1', incoming);
+
+        expect(controller.isFavorite('d1'), isFalse);
+        expect(controller.ratingFor('d1'), equals(5));
+      });
+    });
+
     // --- cross-field preservation ---
 
     group('cross-field preservation', () {

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -418,10 +418,13 @@ void main() {
       });
 
       test('toggleFavorite adds then removes a favourite', () async {
-        expect(await repository.toggleFavorite(festival.id, 'd1'), isTrue);
+        expect(
+          (await repository.toggleFavorite(festival.id, 'd1'))?.wantToTry,
+          isTrue,
+        );
         expect(userDataStore.read(festival.id, 'd1')?.wantToTry, isTrue);
 
-        expect(await repository.toggleFavorite(festival.id, 'd1'), isFalse);
+        expect(await repository.toggleFavorite(festival.id, 'd1'), isNull);
         expect(
           userDataStore.read(festival.id, 'd1')?.wantToTry ?? false,
           isFalse,
@@ -461,8 +464,11 @@ void main() {
       });
 
       test('toggleTasted returns the resulting tasted state', () async {
-        expect(await repository.toggleTasted(festival.id, 'd1'), isTrue);
-        expect(await repository.toggleTasted(festival.id, 'd1'), isFalse);
+        expect(
+          (await repository.toggleTasted(festival.id, 'd1'))?.isTasted,
+          isTrue,
+        );
+        expect(await repository.toggleTasted(festival.id, 'd1'), isNull);
       });
 
       test('getTastedDrinks lists tasted drink IDs', () async {

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -330,10 +330,14 @@ void main() {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
-          return false;
+          return null;
         } else {
           favorites.add(drinkId);
-          return true;
+          return UserDrinkState(
+            wantToTry: true,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          );
         }
       });
 
@@ -455,9 +459,13 @@ void main() {
       expect(provider.getDrinkById('drink1')!.rating, null);
 
       // Simulate rating change through provider
-      when(
-        mockDrinkRepository.setRating(any, any, any),
-      ).thenAnswer((_) async {});
+      when(mockDrinkRepository.setRating(any, any, any)).thenAnswer(
+        (_) async => UserDrinkState(
+          rating: 5,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
       await provider.setRating(provider.getDrinkById('drink1')!, 5);
       await tester.pumpAndSettle();
 

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -541,10 +541,14 @@ void main() {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
-          return false;
+          return null;
         } else {
           favorites.add(drinkId);
-          return true;
+          return UserDrinkState(
+            wantToTry: true,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          );
         }
       });
 
@@ -595,10 +599,14 @@ void main() {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
-          return false;
+          return null;
         } else {
           favorites.add(drinkId);
-          return true;
+          return UserDrinkState(
+            wantToTry: true,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          );
         }
       });
 

--- a/test/provider_test.mocks.dart
+++ b/test/provider_test.mocks.dart
@@ -85,13 +85,16 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
           as _i6.Future<List<String>>);
 
   @override
-  _i6.Future<bool> toggleFavorite(String? festivalId, String? drinkId) =>
+  _i6.Future<_i7.UserDrinkState?> toggleFavorite(
+    String? festivalId,
+    String? drinkId,
+  ) =>
       (super.noSuchMethod(
             Invocation.method(#toggleFavorite, [festivalId, drinkId]),
-            returnValue: _i6.Future<bool>.value(false),
-            returnValueForMissingStub: _i6.Future<bool>.value(false),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
           )
-          as _i6.Future<bool>);
+          as _i6.Future<_i7.UserDrinkState?>);
 
   @override
   _i6.Future<int?> getRating(String? festivalId, String? drinkId) =>
@@ -103,26 +106,29 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
           as _i6.Future<int?>);
 
   @override
-  _i6.Future<void> setRating(
+  _i6.Future<_i7.UserDrinkState?> setRating(
     String? festivalId,
     String? drinkId,
     int? rating,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#setRating, [festivalId, drinkId, rating]),
-            returnValue: _i6.Future<void>.value(),
-            returnValueForMissingStub: _i6.Future<void>.value(),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
           )
-          as _i6.Future<void>);
+          as _i6.Future<_i7.UserDrinkState?>);
 
   @override
-  _i6.Future<void> removeRating(String? festivalId, String? drinkId) =>
+  _i6.Future<_i7.UserDrinkState?> removeRating(
+    String? festivalId,
+    String? drinkId,
+  ) =>
       (super.noSuchMethod(
             Invocation.method(#removeRating, [festivalId, drinkId]),
-            returnValue: _i6.Future<void>.value(),
-            returnValueForMissingStub: _i6.Future<void>.value(),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
           )
-          as _i6.Future<void>);
+          as _i6.Future<_i7.UserDrinkState?>);
 
   @override
   _i6.Future<bool> hasTasted(String? festivalId, String? drinkId) =>
@@ -134,13 +140,16 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
           as _i6.Future<bool>);
 
   @override
-  _i6.Future<bool> toggleTasted(String? festivalId, String? drinkId) =>
+  _i6.Future<_i7.UserDrinkState?> toggleTasted(
+    String? festivalId,
+    String? drinkId,
+  ) =>
       (super.noSuchMethod(
             Invocation.method(#toggleTasted, [festivalId, drinkId]),
-            returnValue: _i6.Future<bool>.value(false),
-            returnValueForMissingStub: _i6.Future<bool>.value(false),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
           )
-          as _i6.Future<bool>);
+          as _i6.Future<_i7.UserDrinkState?>);
 
   @override
   _i6.Future<List<String>> getTastedDrinks(String? festivalId) =>

--- a/test/style_screen_test.dart
+++ b/test/style_screen_test.dart
@@ -229,10 +229,14 @@ void main() {
         final drinkId = invocation.positionalArguments[1] as String;
         if (favorites.contains(drinkId)) {
           favorites.remove(drinkId);
-          return false;
+          return null;
         } else {
           favorites.add(drinkId);
-          return true;
+          return UserDrinkState(
+            wantToTry: true,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          );
         }
       });
 

--- a/test/widgets/festival_menu_sheets_test.mocks.dart
+++ b/test/widgets/festival_menu_sheets_test.mocks.dart
@@ -85,13 +85,16 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
           as _i6.Future<List<String>>);
 
   @override
-  _i6.Future<bool> toggleFavorite(String? festivalId, String? drinkId) =>
+  _i6.Future<_i7.UserDrinkState?> toggleFavorite(
+    String? festivalId,
+    String? drinkId,
+  ) =>
       (super.noSuchMethod(
             Invocation.method(#toggleFavorite, [festivalId, drinkId]),
-            returnValue: _i6.Future<bool>.value(false),
-            returnValueForMissingStub: _i6.Future<bool>.value(false),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
           )
-          as _i6.Future<bool>);
+          as _i6.Future<_i7.UserDrinkState?>);
 
   @override
   _i6.Future<int?> getRating(String? festivalId, String? drinkId) =>
@@ -103,26 +106,29 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
           as _i6.Future<int?>);
 
   @override
-  _i6.Future<void> setRating(
+  _i6.Future<_i7.UserDrinkState?> setRating(
     String? festivalId,
     String? drinkId,
     int? rating,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#setRating, [festivalId, drinkId, rating]),
-            returnValue: _i6.Future<void>.value(),
-            returnValueForMissingStub: _i6.Future<void>.value(),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
           )
-          as _i6.Future<void>);
+          as _i6.Future<_i7.UserDrinkState?>);
 
   @override
-  _i6.Future<void> removeRating(String? festivalId, String? drinkId) =>
+  _i6.Future<_i7.UserDrinkState?> removeRating(
+    String? festivalId,
+    String? drinkId,
+  ) =>
       (super.noSuchMethod(
             Invocation.method(#removeRating, [festivalId, drinkId]),
-            returnValue: _i6.Future<void>.value(),
-            returnValueForMissingStub: _i6.Future<void>.value(),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
           )
-          as _i6.Future<void>);
+          as _i6.Future<_i7.UserDrinkState?>);
 
   @override
   _i6.Future<bool> hasTasted(String? festivalId, String? drinkId) =>
@@ -134,13 +140,16 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
           as _i6.Future<bool>);
 
   @override
-  _i6.Future<bool> toggleTasted(String? festivalId, String? drinkId) =>
+  _i6.Future<_i7.UserDrinkState?> toggleTasted(
+    String? festivalId,
+    String? drinkId,
+  ) =>
       (super.noSuchMethod(
             Invocation.method(#toggleTasted, [festivalId, drinkId]),
-            returnValue: _i6.Future<bool>.value(false),
-            returnValueForMissingStub: _i6.Future<bool>.value(false),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
           )
-          as _i6.Future<bool>);
+          as _i6.Future<_i7.UserDrinkState?>);
 
   @override
   _i6.Future<List<String>> getTastedDrinks(String? festivalId) =>


### PR DESCRIPTION
## Summary

- `DrinkRepository` mutators (`toggleFavorite`, `setRating`, `removeRating`, `toggleTasted`) now return `Future<UserDrinkState?>` — the state they actually wrote to disk — instead of `Future<bool>`/`Future<void>`
- `ApiDrinkRepository` captures the constructed state before writing and returns it (or `null` when `state.isEmpty`, i.e. the record was pruned)
- New `UserDrinkStateController.apply(drinkId, state)` stores a pre-computed state directly, bypassing re-computation
- `BeerProvider` mutators now call `_personalState.apply()` with the repository-returned state, eliminating the second `DateTime.now()` call that caused memory and disk timestamps to diverge

## Why

Each mutator previously called `DateTime.now()` twice: once in the repository (written to SharedPreferences) and again in the controller (`applyWantToTry` / `applyRating` / `applyTasted`). For boolean fields this silently corrupted `updatedAt` between memory and disk. Once multi-tasting lands (#315), timestamp divergence becomes user-visible: per-timestamp deletion matches by value, so a delete targeting the in-memory timestamp won't match the persisted one.

## Test plan

- All 1118 tests pass (`./bin/mise run check`)
- Collateral mock updates in `brewery_screen_test.dart`, `drink_detail_screen_test.dart`, `style_screen_test.dart`, and `festival_menu_sheets_test.mocks.dart` are required cascading changes from the interface return-type change
- New `apply()` unit tests added in `user_drink_state_controller_test.dart` covering store, null-prune, empty-prune, and wholesale-replace behaviour

Fixes #410

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uj4xXeiSjF7365ZbHcihys)_