### PR TITLE
feat(my-festival): add tasting-log and notes mutators through the stack

### DIFF
--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -215,7 +215,8 @@ class ApiDrinkRepository implements DrinkRepository {
       updatedAt: timestamp,
     );
     await _userDataStore.write(festivalId, drinkId, persisted);
-    return persisted.isEmpty ? null : persisted;
+    // An append always leaves at least one event, so the record is never empty.
+    return persisted;
   }
 
   @override
@@ -226,10 +227,10 @@ class ApiDrinkRepository implements DrinkRepository {
   ) async {
     final current = _userDataStore.read(festivalId, drinkId);
     if (current == null) return null;
-    final updated = List<DateTime>.from(current.tastingEvents);
-    final index = updated.indexOf(event);
-    if (index == -1) return current;
-    updated.removeAt(index);
+    final updated = [...current.tastingEvents];
+    // Removes the first matching pour; identical timestamps are distinct pours,
+    // so only one goes. Returns the record untouched when the event is absent.
+    if (!updated.remove(event)) return current;
     final persisted = current.copyWith(
       tastingEvents: updated,
       updatedAt: DateTime.now(),
@@ -245,7 +246,13 @@ class ApiDrinkRepository implements DrinkRepository {
     String? notes,
   ) async {
     final current = _mutableState(festivalId, drinkId);
-    final persisted = current.copyWith(notes: notes, updatedAt: DateTime.now());
+    // Blank is not a distinct signal from "no note": store it as null so the
+    // null-means-unset convention holds and the record can prune to empty.
+    final normalised = (notes == null || notes.isEmpty) ? null : notes;
+    final persisted = current.copyWith(
+      notes: normalised,
+      updatedAt: DateTime.now(),
+    );
     await _userDataStore.write(festivalId, drinkId, persisted);
     return persisted.isEmpty ? null : persisted;
   }

--- a/lib/domain/repositories/api_drink_repository.dart
+++ b/lib/domain/repositories/api_drink_repository.dart
@@ -200,6 +200,57 @@ class ApiDrinkRepository implements DrinkRepository {
   }
 
   @override
+  Future<UserDrinkState?> addTasting(
+    String festivalId,
+    String drinkId, {
+    DateTime? now,
+  }) async {
+    final current = _mutableState(festivalId, drinkId);
+    final timestamp = now ?? DateTime.now();
+    // Consecutive rapid taps intentionally append duplicate events rather
+    // than debouncing: v1 ships a per-timestamp delete UI to recover from
+    // accidents, and a debounce would add hidden temporal state (#411).
+    final persisted = current.copyWith(
+      tastingEvents: [...current.tastingEvents, timestamp],
+      updatedAt: timestamp,
+    );
+    await _userDataStore.write(festivalId, drinkId, persisted);
+    return persisted.isEmpty ? null : persisted;
+  }
+
+  @override
+  Future<UserDrinkState?> removeTasting(
+    String festivalId,
+    String drinkId,
+    DateTime event,
+  ) async {
+    final current = _userDataStore.read(festivalId, drinkId);
+    if (current == null) return null;
+    final updated = List<DateTime>.from(current.tastingEvents);
+    final index = updated.indexOf(event);
+    if (index == -1) return current;
+    updated.removeAt(index);
+    final persisted = current.copyWith(
+      tastingEvents: updated,
+      updatedAt: DateTime.now(),
+    );
+    await _userDataStore.write(festivalId, drinkId, persisted);
+    return persisted.isEmpty ? null : persisted;
+  }
+
+  @override
+  Future<UserDrinkState?> setUserNotes(
+    String festivalId,
+    String drinkId,
+    String? notes,
+  ) async {
+    final current = _mutableState(festivalId, drinkId);
+    final persisted = current.copyWith(notes: notes, updatedAt: DateTime.now());
+    await _userDataStore.write(festivalId, drinkId, persisted);
+    return persisted.isEmpty ? null : persisted;
+  }
+
+  @override
   Future<List<String>> getTastedDrinks(String festivalId) async {
     return _userDataStore
         .readAll(festivalId)

--- a/lib/domain/repositories/drink_repository.dart
+++ b/lib/domain/repositories/drink_repository.dart
@@ -50,6 +50,35 @@ abstract class DrinkRepository {
   /// Returns the persisted state, or null when the record was pruned to empty.
   Future<UserDrinkState?> toggleTasted(String festivalId, String drinkId);
 
+  /// Append a tasting event for a drink
+  ///
+  /// Records `now` (or the current time) as a new tasting event. Does not
+  /// change the want-to-try flag. Returns the persisted state.
+  Future<UserDrinkState?> addTasting(
+    String festivalId,
+    String drinkId, {
+    DateTime? now,
+  });
+
+  /// Remove a single tasting event from a drink
+  ///
+  /// Removes one occurrence matching [event]. Returns the persisted state,
+  /// or null when the record was pruned to empty (or never existed).
+  Future<UserDrinkState?> removeTasting(
+    String festivalId,
+    String drinkId,
+    DateTime event,
+  );
+
+  /// Set or clear (null) the user's free-text notes for a drink
+  ///
+  /// Returns the persisted state, or null when the record was pruned to empty.
+  Future<UserDrinkState?> setUserNotes(
+    String festivalId,
+    String drinkId,
+    String? notes,
+  );
+
   /// Get list of tasted drink IDs for a festival
   Future<List<String>> getTastedDrinks(String festivalId);
 

--- a/lib/models/user_drink_state.dart
+++ b/lib/models/user_drink_state.dart
@@ -41,8 +41,20 @@ class UserDrinkState {
     List<String>? photoIds,
     required this.createdAt,
     required this.updatedAt,
-  }) : tastingEvents = List.unmodifiable(tastingEvents ?? const []),
+  }) : tastingEvents = List.unmodifiable(
+         (tastingEvents ?? const []).map(_toMillisPrecision),
+       ),
        photoIds = List.unmodifiable(photoIds ?? const []);
+
+  /// Tasting events are deleted by matching a timestamp against the stored
+  /// list, but persistence round-trips through `millisecondsSinceEpoch` in
+  /// local time (see [toJson]/[fromJson]). A `DateTime.now()` on the VM carries
+  /// microseconds, so an in-memory event would never equal its persisted,
+  /// millisecond-truncated form — a same-session delete would silently miss.
+  /// Normalising every event to local millisecond precision on construction
+  /// keeps in-memory events equal to their reloaded form.
+  static DateTime _toMillisPrecision(DateTime dt) =>
+      DateTime.fromMillisecondsSinceEpoch(dt.millisecondsSinceEpoch);
 
   /// Returns an empty record with createdAt/updatedAt set to [now] (or
   /// `DateTime.now()`).

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -824,6 +824,7 @@ class BeerProvider extends ChangeNotifier {
   Future<void> removeTasting(Drink drink, DateTime event) async {
     if (_drinkRepository == null) return;
 
+    final before = drink.userState?.tastingCount ?? 0;
     final newState = _personalState.apply(
       drink.id,
       await _drinkRepository!.removeTasting(
@@ -836,8 +837,12 @@ class BeerProvider extends ChangeNotifier {
 
     notifyListeners();
 
-    // Log analytics event
-    unawaited(_analyticsService.logFestivalLogDeleteTimestamp(drink));
+    // Only log when an event was actually removed — the repository is a no-op
+    // when the record or the event is absent.
+    final after = newState?.tastingCount ?? 0;
+    if (after < before) {
+      unawaited(_analyticsService.logFestivalLogDeleteTimestamp(drink));
+    }
   }
 
   /// Set or clear (null) the user's notes for a drink

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -750,6 +750,7 @@ class BeerProvider extends ChangeNotifier {
     // Log analytics event (fire and forget)
     if (newState?.wantToTry ?? false) {
       unawaited(_analyticsService.logFavoriteAdded(drink));
+      unawaited(_analyticsService.logFestivalLogAddToTry(drink));
     } else {
       unawaited(_analyticsService.logFavoriteRemoved(drink));
     }
@@ -797,6 +798,59 @@ class BeerProvider extends ChangeNotifier {
     } else {
       unawaited(analyticsService.logTastedRemoved(drink));
     }
+  }
+
+  /// Record a new tasting event for a drink
+  Future<void> addTasting(Drink drink) async {
+    if (_drinkRepository == null) return;
+
+    final newState = _personalState.apply(
+      drink.id,
+      await _drinkRepository!.addTasting(currentFestival.id, drink.id),
+    );
+    _replaceDrink(drink, drink.copyWith(userState: newState));
+
+    notifyListeners();
+
+    // Log analytics event
+    unawaited(_analyticsService.logFestivalLogMarkTasted(drink));
+    final count = newState?.tastingCount ?? 0;
+    if (count > 1) {
+      unawaited(_analyticsService.logFestivalLogMultipleTasting(drink, count));
+    }
+  }
+
+  /// Remove a single tasting event from a drink
+  Future<void> removeTasting(Drink drink, DateTime event) async {
+    if (_drinkRepository == null) return;
+
+    final newState = _personalState.apply(
+      drink.id,
+      await _drinkRepository!.removeTasting(
+        currentFestival.id,
+        drink.id,
+        event,
+      ),
+    );
+    _replaceDrink(drink, drink.copyWith(userState: newState));
+
+    notifyListeners();
+
+    // Log analytics event
+    unawaited(_analyticsService.logFestivalLogDeleteTimestamp(drink));
+  }
+
+  /// Set or clear (null) the user's notes for a drink
+  Future<void> setUserNotes(Drink drink, String? notes) async {
+    if (_drinkRepository == null) return;
+
+    final newState = _personalState.apply(
+      drink.id,
+      await _drinkRepository!.setUserNotes(currentFestival.id, drink.id, notes),
+    );
+    _replaceDrink(drink, drink.copyWith(userState: newState));
+
+    notifyListeners();
   }
 
   /// Get a drink by ID

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -164,6 +164,76 @@ class AnalyticsService {
     );
   }
 
+  /// Log My Festival screen viewed
+  Future<void> logFestivalLogViewed() async {
+    await _logIfEnabled(() => analytics.logEvent(name: 'festival_log_viewed'));
+  }
+
+  /// Log drink added to want-to-try list
+  Future<void> logFestivalLogAddToTry(Drink drink) async {
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'festival_log_add_to_try',
+        // coverage:ignore-start
+        parameters: {
+          'drink_id': drink.id,
+          'drink_name': drink.name,
+          'brewery': drink.breweryName,
+          'category': drink.category,
+        },
+        // coverage:ignore-end
+      ),
+    );
+  }
+
+  /// Log drink marked as tasted (tasting event recorded)
+  Future<void> logFestivalLogMarkTasted(Drink drink) async {
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'festival_log_mark_tasted',
+        // coverage:ignore-start
+        parameters: {
+          'drink_id': drink.id,
+          'drink_name': drink.name,
+          'brewery': drink.breweryName,
+          'category': drink.category,
+        },
+        // coverage:ignore-end
+      ),
+    );
+  }
+
+  /// Log repeat tasting of the same drink
+  Future<void> logFestivalLogMultipleTasting(
+    Drink drink,
+    int tastingCount,
+  ) async {
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'festival_log_multiple_tasting',
+        // coverage:ignore-start
+        parameters: {
+          'drink_id': drink.id,
+          'drink_name': drink.name,
+          'tasting_count': tastingCount,
+        },
+        // coverage:ignore-end
+      ),
+    );
+  }
+
+  /// Log deletion of a tasting timestamp
+  Future<void> logFestivalLogDeleteTimestamp(Drink drink) async {
+    await _logIfEnabled(
+      () => analytics.logEvent(
+        name: 'festival_log_delete_timestamp',
+        // coverage:ignore-start
+        parameters: {'drink_id': drink.id, 'drink_name': drink.name},
+        // coverage:ignore-end
+      ),
+    );
+  }
+
   /// Log drink details viewed
   Future<void> logDrinkViewed(Drink drink) async {
     await _logIfEnabled(

--- a/test/analytics_service_test.dart
+++ b/test/analytics_service_test.dart
@@ -53,6 +53,11 @@ void main() {
       await service.logStyleViewed('IPA');
       await service.logRatingGiven(drink, 5);
       await service.logDrinkShared(drink);
+      await service.logFestivalLogViewed();
+      await service.logFestivalLogAddToTry(drink);
+      await service.logFestivalLogMarkTasted(drink);
+      await service.logFestivalLogMultipleTasting(drink, 2);
+      await service.logFestivalLogDeleteTimestamp(drink);
       await service.setUserProperty('theme', 'dark');
       await service.setUserId('test-user');
 

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -2991,13 +2991,23 @@ void main() {
             analyticsService: mockAnalyticsService,
           );
           await provider.initialize();
+          final eventTime = DateTime.now();
+          // Seed the drink with an existing tasting so the removal is a real
+          // decrement, not a no-op.
+          final sample = createSampleDrinks();
+          final tasted = sample.first.copyWith(
+            userState: UserDrinkState(
+              tastingEvents: [eventTime],
+              createdAt: eventTime,
+              updatedAt: eventTime,
+            ),
+          );
           when(
             mockDrinkRepository.getDrinks(any),
-          ).thenAnswer((_) async => createSampleDrinks());
+          ).thenAnswer((_) async => [tasted, ...sample.skip(1)]);
           await provider.loadDrinks();
           final drink = provider.allDrinks.first;
 
-          final eventTime = DateTime.now();
           when(mockDrinkRepository.removeTasting(any, any, any)).thenAnswer(
             (_) async => UserDrinkState(
               wantToTry: true,
@@ -3015,6 +3025,41 @@ void main() {
           ).called(1);
         },
       );
+
+      test('removeTasting does not log when nothing was removed', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+        final eventTime = DateTime.now();
+        final sample = createSampleDrinks();
+        final tasted = sample.first.copyWith(
+          userState: UserDrinkState(
+            tastingEvents: [eventTime],
+            createdAt: eventTime,
+            updatedAt: eventTime,
+          ),
+        );
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [tasted, ...sample.skip(1)]);
+        await provider.loadDrinks();
+        final drink = provider.allDrinks.first;
+
+        // Repository is a no-op (event not found): returns the state unchanged,
+        // so the tasting count does not decrease and no delete is logged.
+        when(mockDrinkRepository.removeTasting(any, any, any)).thenAnswer(
+          (_) async => UserDrinkState(
+            tastingEvents: [eventTime],
+            createdAt: eventTime,
+            updatedAt: eventTime,
+          ),
+        );
+        await provider.removeTasting(drink, DateTime(2000));
+        verifyNever(mockAnalyticsService.logFestivalLogDeleteTimestamp(any));
+      });
 
       test('removeTasting with pruned record clears userState', () async {
         provider = BeerProvider(

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -2916,6 +2916,176 @@ void main() {
 
         expect(provider.lastDrinksRefresh, isNotNull);
       });
+
+      test(
+        'addTasting updates the drink userState and logs mark_tasted',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          await provider.loadDrinks();
+          final drink = provider.allDrinks.first;
+
+          when(mockDrinkRepository.addTasting(any, any)).thenAnswer(
+            (_) async => UserDrinkState(
+              tastingEvents: [DateTime.now()],
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            ),
+          );
+          await provider.addTasting(drink);
+          final updatedDrink = provider.getDrinkById(drink.id)!;
+          expect(updatedDrink.userState!.tastingCount, 1);
+          verify(mockAnalyticsService.logFestivalLogMarkTasted(any)).called(1);
+          verifyNever(
+            mockAnalyticsService.logFestivalLogMultipleTasting(any, any),
+          );
+        },
+      );
+
+      test(
+        'addTasting logs multiple_tasting only when count exceeds one',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          await provider.loadDrinks();
+          final drink = provider.allDrinks.first;
+
+          when(mockDrinkRepository.addTasting(any, any)).thenAnswer(
+            (_) async => UserDrinkState(
+              tastingEvents: [
+                DateTime.now(),
+                DateTime.now().add(const Duration(hours: 1)),
+              ],
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            ),
+          );
+          await provider.addTasting(drink);
+          verify(mockAnalyticsService.logFestivalLogMarkTasted(any)).called(1);
+          verify(
+            mockAnalyticsService.logFestivalLogMultipleTasting(any, 2),
+          ).called(1);
+        },
+      );
+
+      test(
+        'removeTasting updates the drink userState and logs delete_timestamp',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          await provider.loadDrinks();
+          final drink = provider.allDrinks.first;
+
+          final eventTime = DateTime.now();
+          when(mockDrinkRepository.removeTasting(any, any, any)).thenAnswer(
+            (_) async => UserDrinkState(
+              wantToTry: true,
+              tastingEvents: const [],
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            ),
+          );
+          await provider.removeTasting(drink, eventTime);
+          final updatedDrink = provider.getDrinkById(drink.id)!;
+          expect(updatedDrink.userState!.isTasted, isFalse);
+          expect(updatedDrink.userState!.wantToTry, isTrue);
+          verify(
+            mockAnalyticsService.logFestivalLogDeleteTimestamp(any),
+          ).called(1);
+        },
+      );
+
+      test('removeTasting with pruned record clears userState', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
+        await provider.loadDrinks();
+        final drink = provider.allDrinks.first;
+
+        final eventTime = DateTime.now();
+        when(
+          mockDrinkRepository.removeTasting(any, any, any),
+        ).thenAnswer((_) async => null);
+        await provider.removeTasting(drink, eventTime);
+        final updatedDrink = provider.getDrinkById(drink.id)!;
+        expect(updatedDrink.userState, isNull);
+      });
+
+      test('setUserNotes persists notes onto the drink', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
+        await provider.loadDrinks();
+        final drink = provider.allDrinks.first;
+
+        when(mockDrinkRepository.setUserNotes(any, any, any)).thenAnswer(
+          (_) async => UserDrinkState(
+            notes: 'Great with cheese',
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+        await provider.setUserNotes(drink, 'Great with cheese');
+        final updatedDrink = provider.getDrinkById(drink.id)!;
+        expect(updatedDrink.userState!.notes, 'Great with cheese');
+      });
+
+      test('toggleFavorite logs festival_log_add_to_try when adding', () async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
+        await provider.loadDrinks();
+        final drink = provider.allDrinks.first;
+
+        when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer(
+          (_) async => UserDrinkState(
+            wantToTry: true,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+        await provider.toggleFavorite(drink);
+        verify(mockAnalyticsService.logFestivalLogAddToTry(any)).called(1);
+      });
     });
 
     group('stale-while-revalidate', () {

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -481,6 +481,164 @@ void main() {
         );
       });
     });
+
+    group('addTasting', () {
+      test('appends a tasting event to an empty record', () async {
+        final now = DateTime(2026, 6, 10, 14, 30);
+
+        final result = await repository.addTasting(festival.id, 'd1', now: now);
+
+        expect(result?.tastingEvents, equals([now]));
+        expect(result?.wantToTry, isFalse);
+      });
+
+      test('appends without clearing existing events', () async {
+        final time1 = DateTime(2026, 6, 10, 10, 0);
+        final time2 = DateTime(2026, 6, 10, 14, 30);
+
+        await repository.addTasting(festival.id, 'd1', now: time1);
+        final result = await repository.addTasting(
+          festival.id,
+          'd1',
+          now: time2,
+        );
+
+        expect(result?.tastingEvents, equals([time1, time2]));
+      });
+
+      test('preserves wantToTry', () async {
+        final now = DateTime(2026, 6, 10, 14, 30);
+        await repository.toggleFavorite(festival.id, 'd1');
+
+        final result = await repository.addTasting(festival.id, 'd1', now: now);
+
+        expect(result?.wantToTry, isTrue);
+        expect(result?.tastingEvents.length, equals(1));
+      });
+
+      test('uses the provided now for updatedAt', () async {
+        final now = DateTime(2026, 6, 10, 14, 30);
+
+        final result = await repository.addTasting(festival.id, 'd1', now: now);
+
+        expect(result?.updatedAt, equals(now));
+      });
+
+      test('allows duplicate identical timestamps', () async {
+        final now = DateTime(2026, 6, 10, 14, 30);
+
+        await repository.addTasting(festival.id, 'd1', now: now);
+        final result = await repository.addTasting(festival.id, 'd1', now: now);
+
+        expect(result?.tastingCount, equals(2));
+      });
+    });
+
+    group('removeTasting', () {
+      test('returns null when no record exists', () async {
+        final event = DateTime(2026, 6, 10, 14, 30);
+
+        final result = await repository.removeTasting(festival.id, 'd1', event);
+
+        expect(result, isNull);
+      });
+
+      test('removes exactly one occurrence when duplicates exist', () async {
+        final now = DateTime(2026, 6, 10, 14, 30);
+        await repository.addTasting(festival.id, 'd1', now: now);
+        await repository.addTasting(festival.id, 'd1', now: now);
+
+        final result = await repository.removeTasting(festival.id, 'd1', now);
+
+        expect(result?.tastingCount, equals(1));
+      });
+
+      test(
+        'returns the state unchanged when the event is not present',
+        () async {
+          final time1 = DateTime(2026, 6, 10, 10, 0);
+          final time2 = DateTime(2026, 6, 10, 14, 30);
+          await repository.addTasting(festival.id, 'd1', now: time1);
+
+          final result = await repository.removeTasting(
+            festival.id,
+            'd1',
+            time2,
+          );
+
+          expect(result?.tastingCount, equals(1));
+          expect(result?.tastingEvents.contains(time1), isTrue);
+        },
+      );
+
+      test('prunes to null when removing the last event', () async {
+        final now = DateTime(2026, 6, 10, 14, 30);
+        await repository.addTasting(festival.id, 'd1', now: now);
+
+        final result = await repository.removeTasting(festival.id, 'd1', now);
+
+        expect(result, isNull);
+        expect(userDataStore.read(festival.id, 'd1'), isNull);
+      });
+
+      test('reverts to want-to-try', () async {
+        final now = DateTime(2026, 6, 10, 14, 30);
+        await repository.toggleFavorite(festival.id, 'd1');
+        await repository.addTasting(festival.id, 'd1', now: now);
+
+        final result = await repository.removeTasting(festival.id, 'd1', now);
+
+        expect(result, isNotNull);
+        expect(result?.wantToTry, isTrue);
+        expect(result?.tastingEvents, isEmpty);
+      });
+    });
+
+    group('setUserNotes', () {
+      test('sets notes on a fresh record', () async {
+        final result = await repository.setUserNotes(
+          festival.id,
+          'd1',
+          'Lovely hoppy finish',
+        );
+
+        expect(result?.notes, equals('Lovely hoppy finish'));
+      });
+
+      test('overwrites existing notes', () async {
+        await repository.setUserNotes(festival.id, 'd1', 'First notes');
+
+        final result = await repository.setUserNotes(
+          festival.id,
+          'd1',
+          'Updated notes',
+        );
+
+        expect(result?.notes, equals('Updated notes'));
+      });
+
+      test(
+        'clearing notes with null on an otherwise-empty record prunes it',
+        () async {
+          await repository.setUserNotes(festival.id, 'd1', 'Some notes');
+
+          final result = await repository.setUserNotes(festival.id, 'd1', null);
+
+          expect(result, isNull);
+        },
+      );
+
+      test('clearing notes preserves other signals', () async {
+        await repository.setRating(festival.id, 'd1', 4);
+        await repository.setUserNotes(festival.id, 'd1', 'Some notes');
+
+        final result = await repository.setUserNotes(festival.id, 'd1', null);
+
+        expect(result, isNotNull);
+        expect(result?.rating, equals(4));
+        expect(result?.notes, isNull);
+      });
+    });
   });
 }
 

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -592,6 +592,26 @@ void main() {
         expect(result?.wantToTry, isTrue);
         expect(result?.tastingEvents, isEmpty);
       });
+
+      test('deletes an event recorded with sub-millisecond precision', () async {
+        // Simulates the real path: DateTime.now() carries microseconds, but the
+        // store persists millis. The event handed back to the caller from
+        // addTasting must still match the persisted form on delete.
+        final subMillis = DateTime.fromMicrosecondsSinceEpoch(
+          DateTime(2026, 6, 10, 14, 30).microsecondsSinceEpoch + 456,
+        );
+        final added = await repository.addTasting(
+          festival.id,
+          'd1',
+          now: subMillis,
+        );
+        final event = added!.tastingEvents.single;
+
+        final result = await repository.removeTasting(festival.id, 'd1', event);
+
+        expect(result, isNull);
+        expect(userDataStore.read(festival.id, 'd1'), isNull);
+      });
     });
 
     group('setUserNotes', () {
@@ -638,6 +658,19 @@ void main() {
         expect(result?.rating, equals(4));
         expect(result?.notes, isNull);
       });
+
+      test(
+        'normalises an empty string to null (not a distinct signal)',
+        () async {
+          await repository.setRating(festival.id, 'd1', 4);
+
+          final result = await repository.setUserNotes(festival.id, 'd1', '');
+
+          expect(result, isNotNull);
+          expect(result?.rating, equals(4));
+          expect(result?.notes, isNull);
+        },
+      );
     });
   });
 }

--- a/test/domain/repositories/api_drink_repository_test.dart
+++ b/test/domain/repositories/api_drink_repository_test.dart
@@ -532,6 +532,17 @@ void main() {
 
         expect(result?.tastingCount, equals(2));
       });
+
+      test('defaults to the current time when now is omitted', () async {
+        // Margin absorbs the constructor's millisecond truncation, which can
+        // round the event a fraction below a now() captured just beforehand.
+        final before = DateTime.now().subtract(const Duration(seconds: 1));
+
+        final result = await repository.addTasting(festival.id, 'd1');
+
+        expect(result?.tastingCount, equals(1));
+        expect(result!.tastingEvents.single.isAfter(before), isTrue);
+      });
     });
 
     group('removeTasting', () {

--- a/test/domain/repositories/api_drink_repository_test.mocks.dart
+++ b/test/domain/repositories/api_drink_repository_test.mocks.dart
@@ -245,6 +245,57 @@ class MockAnalyticsService extends _i1.Mock implements _i7.AnalyticsService {
           as _i5.Future<void>);
 
   @override
+  _i5.Future<void> logFestivalLogViewed() =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogViewed, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalLogAddToTry(_i6.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogAddToTry, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalLogMarkTasted(_i6.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogMarkTasted, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalLogMultipleTasting(
+    _i6.Drink? drink,
+    int? tastingCount,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogMultipleTasting, [
+              drink,
+              tastingCount,
+            ]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalLogDeleteTimestamp(_i6.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogDeleteTimestamp, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
   _i5.Future<void> logDrinkViewed(_i6.Drink? drink) =>
       (super.noSuchMethod(
             Invocation.method(#logDrinkViewed, [drink]),

--- a/test/domain/repositories/api_festival_repository_test.mocks.dart
+++ b/test/domain/repositories/api_festival_repository_test.mocks.dart
@@ -217,6 +217,57 @@ class MockAnalyticsService extends _i1.Mock implements _i6.AnalyticsService {
           as _i5.Future<void>);
 
   @override
+  _i5.Future<void> logFestivalLogViewed() =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogViewed, []),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalLogAddToTry(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogAddToTry, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalLogMarkTasted(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogMarkTasted, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalLogMultipleTasting(
+    _i7.Drink? drink,
+    int? tastingCount,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogMultipleTasting, [
+              drink,
+              tastingCount,
+            ]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logFestivalLogDeleteTimestamp(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogDeleteTimestamp, [drink]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
   _i5.Future<void> logDrinkViewed(_i7.Drink? drink) =>
       (super.noSuchMethod(
             Invocation.method(#logDrinkViewed, [drink]),

--- a/test/models/user_drink_state_test.dart
+++ b/test/models/user_drink_state_test.dart
@@ -60,6 +60,32 @@ void main() {
         expect(state.photoIds, ['photo1', 'photo2']);
       });
 
+      test('normalises tasting events to millisecond precision', () {
+        final now = DateTime(2026, 6, 6, 12, 0, 0);
+        // DateTime.now() on the VM carries microseconds; persistence truncates
+        // to millis, so the constructor normalises to keep in-memory events
+        // equal to their persisted-then-reloaded form.
+        final subMillis = DateTime.fromMicrosecondsSinceEpoch(
+          DateTime(2026, 5, 18, 14, 30).microsecondsSinceEpoch + 456,
+        );
+
+        final state = UserDrinkState(
+          tastingEvents: [subMillis],
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        final stored = state.tastingEvents.single;
+        expect(stored.microsecondsSinceEpoch % 1000, 0);
+        expect(
+          stored,
+          DateTime.fromMillisecondsSinceEpoch(subMillis.millisecondsSinceEpoch),
+        );
+        // Survives a JSON round-trip unchanged — the delete-by-value path.
+        final restored = UserDrinkState.fromJson(state.toJson());
+        expect(restored.tastingEvents.single, stored);
+      });
+
       test('defensively copies tastingEvents list to unmodifiable', () {
         final now = DateTime(2026, 6, 6, 12, 0, 0);
         final inputEvents = [DateTime(2026, 5, 18)];

--- a/test/provider_test.mocks.dart
+++ b/test/provider_test.mocks.dart
@@ -152,6 +152,45 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
           as _i6.Future<_i7.UserDrinkState?>);
 
   @override
+  _i6.Future<_i7.UserDrinkState?> addTasting(
+    String? festivalId,
+    String? drinkId, {
+    DateTime? now,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#addTasting, [festivalId, drinkId], {#now: now}),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
+          )
+          as _i6.Future<_i7.UserDrinkState?>);
+
+  @override
+  _i6.Future<_i7.UserDrinkState?> removeTasting(
+    String? festivalId,
+    String? drinkId,
+    DateTime? event,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#removeTasting, [festivalId, drinkId, event]),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
+          )
+          as _i6.Future<_i7.UserDrinkState?>);
+
+  @override
+  _i6.Future<_i7.UserDrinkState?> setUserNotes(
+    String? festivalId,
+    String? drinkId,
+    String? notes,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserNotes, [festivalId, drinkId, notes]),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
+          )
+          as _i6.Future<_i7.UserDrinkState?>);
+
+  @override
   _i6.Future<List<String>> getTastedDrinks(String? festivalId) =>
       (super.noSuchMethod(
             Invocation.method(#getTastedDrinks, [festivalId]),

--- a/test/provider_test.mocks.dart
+++ b/test/provider_test.mocks.dart
@@ -350,6 +350,57 @@ class MockAnalyticsService extends _i1.Mock implements _i9.AnalyticsService {
           as _i6.Future<void>);
 
   @override
+  _i6.Future<void> logFestivalLogViewed() =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogViewed, []),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFestivalLogAddToTry(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogAddToTry, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFestivalLogMarkTasted(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogMarkTasted, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFestivalLogMultipleTasting(
+    _i7.Drink? drink,
+    int? tastingCount,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogMultipleTasting, [
+              drink,
+              tastingCount,
+            ]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFestivalLogDeleteTimestamp(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogDeleteTimestamp, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
   _i6.Future<void> logDrinkViewed(_i7.Drink? drink) =>
       (super.noSuchMethod(
             Invocation.method(#logDrinkViewed, [drink]),

--- a/test/widgets/festival_menu_sheets_test.mocks.dart
+++ b/test/widgets/festival_menu_sheets_test.mocks.dart
@@ -152,6 +152,45 @@ class MockDrinkRepository extends _i1.Mock implements _i5.DrinkRepository {
           as _i6.Future<_i7.UserDrinkState?>);
 
   @override
+  _i6.Future<_i7.UserDrinkState?> addTasting(
+    String? festivalId,
+    String? drinkId, {
+    DateTime? now,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#addTasting, [festivalId, drinkId], {#now: now}),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
+          )
+          as _i6.Future<_i7.UserDrinkState?>);
+
+  @override
+  _i6.Future<_i7.UserDrinkState?> removeTasting(
+    String? festivalId,
+    String? drinkId,
+    DateTime? event,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#removeTasting, [festivalId, drinkId, event]),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
+          )
+          as _i6.Future<_i7.UserDrinkState?>);
+
+  @override
+  _i6.Future<_i7.UserDrinkState?> setUserNotes(
+    String? festivalId,
+    String? drinkId,
+    String? notes,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserNotes, [festivalId, drinkId, notes]),
+            returnValue: _i6.Future<_i7.UserDrinkState?>.value(),
+            returnValueForMissingStub: _i6.Future<_i7.UserDrinkState?>.value(),
+          )
+          as _i6.Future<_i7.UserDrinkState?>);
+
+  @override
   _i6.Future<List<String>> getTastedDrinks(String? festivalId) =>
       (super.noSuchMethod(
             Invocation.method(#getTastedDrinks, [festivalId]),

--- a/test/widgets/festival_menu_sheets_test.mocks.dart
+++ b/test/widgets/festival_menu_sheets_test.mocks.dart
@@ -350,6 +350,57 @@ class MockAnalyticsService extends _i1.Mock implements _i9.AnalyticsService {
           as _i6.Future<void>);
 
   @override
+  _i6.Future<void> logFestivalLogViewed() =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogViewed, []),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFestivalLogAddToTry(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogAddToTry, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFestivalLogMarkTasted(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogMarkTasted, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFestivalLogMultipleTasting(
+    _i7.Drink? drink,
+    int? tastingCount,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogMultipleTasting, [
+              drink,
+              tastingCount,
+            ]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> logFestivalLogDeleteTimestamp(_i7.Drink? drink) =>
+      (super.noSuchMethod(
+            Invocation.method(#logFestivalLogDeleteTimestamp, [drink]),
+            returnValue: _i6.Future<void>.value(),
+            returnValueForMissingStub: _i6.Future<void>.value(),
+          )
+          as _i6.Future<void>);
+
+  @override
   _i6.Future<void> logDrinkViewed(_i7.Drink? drink) =>
       (super.noSuchMethod(
             Invocation.method(#logDrinkViewed, [drink]),


### PR DESCRIPTION
## Summary

Implements the #411 data-layer work for "My Festival" Phase 1: multi-tasting and per-drink notes through the repository, provider, and analytics layers. `UserDrinkState` already modelled `tastingEvents` and `notes`, but every layer above it only exposed a binary `toggleTasted` and no notes mutation. This adds the granular mutators the Phase 1 UI issues (#413 card badge, #414 My Festival screen, #415 detail screen) depend on, with no UI changes yet.

Fixes #411.

## What changed

**Repository** (`drink_repository.dart`, `api_drink_repository.dart`)
- `addTasting(festivalId, drinkId, {now})` — appends a tasting event; never touches `wantToTry`. Consecutive rapid taps intentionally append duplicates rather than debouncing (the per-timestamp delete UI recovers from accidents; documented in a comment).
- `removeTasting(festivalId, drinkId, event)` — removes exactly one matching pour; a no-op (no write) when the record or event is absent.
- `setUserNotes(festivalId, drinkId, notes)` — sets or clears notes; blank normalises to `null`.
- Existing binary `toggleTasted` is unchanged and stays until #415 reworks the detail screen.

**Provider** (`beer_provider.dart`)
- `addTasting` / `removeTasting` / `setUserNotes` mirroring the existing mutator pattern (apply → replace drink → notify → analytics).
- `festival_log_delete_timestamp` fires only when a tasting was actually removed.
- `toggleFavorite` also emits `festival_log_add_to_try` on the add path.

**Analytics** (`analytics_service.dart`)
- The five `festival_log_*` events from the vision spec: `viewed`, `add_to_try`, `mark_tasted`, `multiple_tasting` (fires when count > 1 after the append), `delete_timestamp`.

**Model** (`user_drink_state.dart`)
- Tasting-event timestamps are normalised to millisecond precision on construction. Persistence round-trips through `millisecondsSinceEpoch`, so a microsecond-precision `DateTime.now()` never equalled its reloaded form — a same-session delete silently missed on Android/iOS. In-memory events now match their persisted form.

## Review fixes folded in

Findings from a code review of the initial mutators were addressed in this PR:
- Reliable same-session tasting deletes (the timestamp-precision fix above).
- Honest delete analytics (log only on a real removal).
- Blank notes stored as `null`, upholding the null-means-unset convention.
- `removeTasting` simplified to `List.remove`; unreachable prune branch dropped from `addTasting`.

## Tests

- Model: timestamp normalisation survives a JSON round-trip.
- Repository (against a real `SharedPreferencesUserDataStore`): append/preserve semantics, remove-one-of-duplicates, no-op on missing event, prune/revert-to-want-to-try, notes set/clear/normalise, sub-millisecond delete regression, and the `now`-defaulting path.
- Provider: `userState` propagation and correct `festival_log_*` analytics (including no-log-on-no-op).
- Analytics smoke test exercises the five new methods; mocks regenerated.

## Deferred (follow-ups, out of scope here)

- `toggleTasted`'s binary clear-all can wipe a multi-tasting history — resolve when #415 reworks the detail screen.
- Stale-snapshot / festival-switch races inherited from the existing mutators — best fixed by extracting a shared provider transaction helper.
- Duplication cleanup (provider mutator block, repository write-and-prune tail, analytics param map) and the now-dead `UserDrinkStateController.applyX` mutators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)