### PR TITLE
docs(adr): propose the check-in as the primary My Festival entity

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ Bugs, features, and tasks are tracked in [GitHub Issues](https://github.com/rich
 - Shared UI components → [code/ui-components.md](code/ui-components.md)
 
 **Understand a past decision:**
-- Why is a check-in (incl. non-drink) the primary My Festival entity? → [ADR 0006](adr/0006-check-in-as-primary-my-festival-entity.md) (Proposed)
+- Why is a check-in (a drink or non-drink entry) the primary My Festival entity? → [ADR 0006](adr/0006-check-in-as-primary-my-festival-entity.md) (Proposed)
 - Why path-based URLs? → [ADR 0004](adr/0004-path-based-url-strategy.md)
 - Why Playwright for E2E? → [ADR 0005](adr/0005-e2e-testing-strategy.md)
 - Why cache pub/npm but not build artifacts? → [ADR 0001](adr/0001-github-actions-caching-strategy.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Key decisions with context, alternatives considered, and consequences.
 - **[0003](adr/0003-parallel-build-strategy.md)** - Parallel Build Strategy for Android Releases
 - **[0004](adr/0004-path-based-url-strategy.md)** - Path-Based URL Strategy for Deep Linking
 - **[0005](adr/0005-e2e-testing-strategy.md)** - E2E Testing Strategy (Playwright for URL smoke tests)
-- **[0006](adr/0006-tasting-as-primary-my-festival-entity.md)** - Tasting as the Primary My Festival Entity (Proposed)
+- **[0006](adr/0006-tasting-as-primary-my-festival-entity.md)** - The Check-in as the Primary My Festival Entity (Proposed)
 
 ### 🔄 processes/ - Development & Operational Processes
 
@@ -78,7 +78,7 @@ Bugs, features, and tasks are tracked in [GitHub Issues](https://github.com/rich
 - Shared UI components → [code/ui-components.md](code/ui-components.md)
 
 **Understand a past decision:**
-- Why is a tasting a first-class "check-in"? → [ADR 0006](adr/0006-tasting-as-primary-my-festival-entity.md) (Proposed)
+- Why is a check-in (incl. non-drink) the primary My Festival entity? → [ADR 0006](adr/0006-tasting-as-primary-my-festival-entity.md) (Proposed)
 - Why path-based URLs? → [ADR 0004](adr/0004-path-based-url-strategy.md)
 - Why Playwright for E2E? → [ADR 0005](adr/0005-e2e-testing-strategy.md)
 - Why cache pub/npm but not build artifacts? → [ADR 0001](adr/0001-github-actions-caching-strategy.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Key decisions with context, alternatives considered, and consequences.
 - **[0003](adr/0003-parallel-build-strategy.md)** - Parallel Build Strategy for Android Releases
 - **[0004](adr/0004-path-based-url-strategy.md)** - Path-Based URL Strategy for Deep Linking
 - **[0005](adr/0005-e2e-testing-strategy.md)** - E2E Testing Strategy (Playwright for URL smoke tests)
-- **[0006](adr/0006-tasting-as-primary-my-festival-entity.md)** - The Check-in as the Primary My Festival Entity (Proposed)
+- **[0006](adr/0006-check-in-as-primary-my-festival-entity.md)** - The Check-in as the Primary My Festival Entity (Proposed)
 
 ### 🔄 processes/ - Development & Operational Processes
 
@@ -78,7 +78,7 @@ Bugs, features, and tasks are tracked in [GitHub Issues](https://github.com/rich
 - Shared UI components → [code/ui-components.md](code/ui-components.md)
 
 **Understand a past decision:**
-- Why is a check-in (incl. non-drink) the primary My Festival entity? → [ADR 0006](adr/0006-tasting-as-primary-my-festival-entity.md) (Proposed)
+- Why is a check-in (incl. non-drink) the primary My Festival entity? → [ADR 0006](adr/0006-check-in-as-primary-my-festival-entity.md) (Proposed)
 - Why path-based URLs? → [ADR 0004](adr/0004-path-based-url-strategy.md)
 - Why Playwright for E2E? → [ADR 0005](adr/0005-e2e-testing-strategy.md)
 - Why cache pub/npm but not build artifacts? → [ADR 0001](adr/0001-github-actions-caching-strategy.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Key decisions with context, alternatives considered, and consequences.
 - **[0003](adr/0003-parallel-build-strategy.md)** - Parallel Build Strategy for Android Releases
 - **[0004](adr/0004-path-based-url-strategy.md)** - Path-Based URL Strategy for Deep Linking
 - **[0005](adr/0005-e2e-testing-strategy.md)** - E2E Testing Strategy (Playwright for URL smoke tests)
+- **[0006](adr/0006-tasting-as-primary-my-festival-entity.md)** - Tasting as the Primary My Festival Entity (Proposed)
 
 ### 🔄 processes/ - Development & Operational Processes
 
@@ -77,6 +78,7 @@ Bugs, features, and tasks are tracked in [GitHub Issues](https://github.com/rich
 - Shared UI components → [code/ui-components.md](code/ui-components.md)
 
 **Understand a past decision:**
+- Why is a tasting a first-class "check-in"? → [ADR 0006](adr/0006-tasting-as-primary-my-festival-entity.md) (Proposed)
 - Why path-based URLs? → [ADR 0004](adr/0004-path-based-url-strategy.md)
 - Why Playwright for E2E? → [ADR 0005](adr/0005-e2e-testing-strategy.md)
 - Why cache pub/npm but not build artifacts? → [ADR 0001](adr/0001-github-actions-caching-strategy.md)
@@ -120,4 +122,4 @@ Bugs, features, and tasks are tracked in [GitHub Issues](https://github.com/rich
 
 ---
 
-**Last Updated**: February 2026
+**Last Updated**: July 2026

--- a/docs/adr/0006-check-in-as-primary-my-festival-entity.md
+++ b/docs/adr/0006-check-in-as-primary-my-festival-entity.md
@@ -35,16 +35,16 @@ per-drink `wantToTry` intent.
 
 A **tasting is simply the drink-kind check-in.** The entity generalises it:
 
-```
-LogEntry {                 // a My Festival check-in
-  id: String               // stable UUID — identity (see User Experience)
-  when: DateTime           // user-editable; defaults to now, can be backdated
-  drinkId?: String         // set = a tasting; null = a freeform `other` entry
-  title?: String           // freeform label for `other` ("Scotch egg from the pie stall")
-  note?: String            // any entry
-  photoIds: List<String>   // any entry (#416)
-  rating?: int             // tasting only (drinkId != null) — 1–5
-  wouldRecommend?: bool    // tasting only (#417)
+```dart
+class LogEntry {          // a My Festival check-in
+  String id;              // stable UUID — identity (see User Experience)
+  DateTime when;          // user-editable; defaults to now, can be backdated
+  String? drinkId;        // set = a tasting; null = a freeform `other` entry
+  String? title;          // freeform label for `other` ("Scotch egg from the pie stall")
+  String? note;           // any entry
+  List<String> photoIds;  // any entry (#416)
+  int? rating;            // tasting only (drinkId != null) — 1–5
+  bool? wouldRecommend;   // tasting only (#417)
 }
 ```
 
@@ -58,7 +58,7 @@ band, "arrived"), so there is no per-category kind explosion.
 Consequently:
 
 - **The festival timeline is the source of truth** for the diary. Drink-level
-  views derive from it by filtering `entries.where(drinkId == this)`.
+  views derive from it by filtering `entries.where((e) => e.drinkId == drink.id)`.
 - **`wantToTry` stays a per-drink intent**, separate from the timeline — it is
   the plan axis, not an event.
 - **Non-drink entries are first-class but minimal.** An `other` entry — food, a
@@ -116,8 +116,9 @@ create-with-a-past-`when`.
 
 ### Everything is editable after the fact
 A diary gets revised. Every field of an entry — rating, recommend, note, photos,
-`kind`/`title`, **and the timestamp** — is editable later; an entry is deletable
-(with a confirm, deletion being the one irreversible action).
+`title`, `drinkId` (which flips it between a tasting and an `other` entry), **and
+the timestamp** — is editable later; an entry is deletable (with a confirm,
+deletion being the one irreversible action).
 
 ### It's private
 My Festival is a **personal** log — not shared, not moderated, no audience. That
@@ -214,10 +215,10 @@ No data is discarded; the choice only affects *where* an existing rating lands.
 
 ## Implementation (outline — not built by this ADR)
 
-- **Model**: a `LogEntry` value object with a stable `id`, `kind`, optional
-  `drinkId`/`title`, and `when`/`rating`/`wouldRecommend`/`note`/`photoIds`.
-  Edit/delete key off `id`. Derive drink-level aggregates by filtering the
-  timeline.
+- **Model**: a `LogEntry` value object with a stable `id`, optional
+  `drinkId`/`title`, and `when`/`rating`/`wouldRecommend`/`note`/`photoIds` (a
+  tasting is `drinkId != null` — no stored `kind`). Edit/delete key off `id`.
+  Derive drink-level aggregates by filtering the timeline.
 - **Storage**: `UserDataStore` gains a festival-scoped entry collection +
   per-drink `wantToTry`; `currentSchemaVersion` 1→2 with the migration above.
 - **Provider**: expose the timeline and per-drink derived views; keep

--- a/docs/adr/0006-tasting-as-primary-my-festival-entity.md
+++ b/docs/adr/0006-tasting-as-primary-my-festival-entity.md
@@ -39,20 +39,21 @@ A **tasting is simply the drink-kind check-in.** The entity generalises it:
 LogEntry {                 // a My Festival check-in
   id: String               // stable UUID — identity (see User Experience)
   when: DateTime           // user-editable; defaults to now, can be backdated
-  kind: tasting | other    // tasting = drink check-in; other = freeform
-  drinkId?: String         // set iff kind == tasting
+  drinkId?: String         // set = a tasting; null = a freeform `other` entry
   title?: String           // freeform label for `other` ("Scotch egg from the pie stall")
-  note?: String            // any kind
-  photoIds: List<String>   // any kind (#416)
-  rating?: int             // tasting only — 1–5
+  note?: String            // any entry
+  photoIds: List<String>   // any entry (#416)
+  rating?: int             // tasting only (drinkId != null) — 1–5
   wouldRecommend?: bool    // tasting only (#417)
 }
 ```
 
-**Two kinds only.** `tasting` (a drink check-in) carries the full set;
-`other` is freeform — a `title`, an optional `note`, and photos, with a time —
-and carries **no rating or recommend**. A free-text `title` absorbs the long
-tail (food, a band, "arrived"), so there is no per-category kind explosion.
+**The kind is derived, not stored.** `drinkId != null` *is* a tasting; a null
+`drinkId` is a freeform `other` entry. One source of truth — there is no
+separate `kind` field to drift out of sync with `drinkId`. A tasting carries the
+full set; an `other` entry is a `title` + optional `note`/photos with a time,
+and **no rating/recommend** — a free-text `title` absorbs the long tail (food, a
+band, "arrived"), so there is no per-category kind explosion.
 
 Consequently:
 
@@ -64,17 +65,29 @@ Consequently:
   moment, anything — has no `drinkId`, a free-text `title`, and optionally a
   note/photos; it carries **no rating/recommend** and appears in the timeline
   only (nowhere drink-specific).
-- **Drink-level `rating`/`notes`/`photoIds` become derived**, not stored — a
-  drink's "your rating" is an aggregate over its tasting entries.
+- **Drink-level values are derived, not stored.** A drink's "your rating",
+  recommend, and pour count derive from its tasting entries: **rating/recommend =
+  the most recent tasting's value** (surfaced as "your latest", so the single
+  number never silently shifts meaning), **pours = count of tasting entries**.
+- **Storage shape.** Entries persist as **per-entry keyed records** (keyed by
+  `festivalId + id`), matching `UserDataStore`'s existing keyed pattern — an edit
+  or delete writes/removes one record, never rewrites the whole timeline.
+  `wantToTry` stays a per-drink flag, present only while true. There is **no
+  empty-record pruning** for entries (an entry always has `id`+`when`); the only
+  removal is an **explicit user delete**. Reads build a memoised `drinkId →
+  entries` index so per-drink derivations stay off the O(drinks × entries) path.
 
 **Local-first boundary (important):** this decides the **local** model only.
 The deployed Review API and the `DrinkEntry` proto are **per-drink**
 (`star_rating`, `would_recommend`, `note`, `pours` as a count). Per-entry detail
 — the timeline, per-pour notes/photos, and **all non-drink entries** (which have
 no wire home at all) — stays **device-local**. Sync continues to carry only the
-per-drink aggregate. Making the wire contract per-entry is a separate,
-proto-first decision (a future ADR) and must not block the local diary. This
-keeps the campaign's local-first / free-tier / low-ops constraints.
+per-drink aggregate: **any create/edit/delete of a tasting entry re-derives that
+drink's aggregate (latest rating/recommend, pour count) and enqueues its
+per-drink sync** — the wire stays per-drink even as the local model goes
+per-entry. Making the wire contract per-entry is a separate, proto-first
+decision (a future ADR) and must not block the local diary. This keeps the
+campaign's local-first / free-tier / low-ops constraints.
 
 ---
 
@@ -86,11 +99,12 @@ with an architectural consequence.
 
 ### Low-friction, inviting create
 On a drink page, "Mark as Tasted" is **one tap**: it creates+persists a tasting
-check-in at the current time with every other field empty, **before** anything
-else. An optional, dismissible capture sheet (rate / recommend / note / photo)
-then slides up. Log-and-move-on users are already done. No required fields, no
-wizard, no blocking spinner. The festival-conditions bar: one hand, a pint,
-patchy signal.
+check-in at the current time, **before** anything else. Detail (rate / recommend
+/ note / photo) is offered by a **non-blocking affordance** — a brief
+auto-dismissing sheet or an inline "add detail?" prompt — **never a modal the
+user must dismiss on every tap**. Log-and-move-on users are done after one tap.
+No required fields, no wizard, no blocking spinner. The festival-conditions bar:
+one hand, a pint, patchy signal.
 
 ### Add anything, including things you forgot
 A **"+" on the My Festival timeline** creates a check-in: pick a drink
@@ -165,7 +179,10 @@ per-entry key and idempotency handle if the wire contract ever goes per-entry.
 - **Storage restructure + released-app migration.** Storage moves from
   per-drink `UserDrinkState` blobs to a **festival-scoped entry collection** plus
   a small per-drink `wantToTry` set. That is a `UserDataStore` schema **v1→v2**
-  migration over real user data, routed through `UserDataStore.migrate`.
+  migration over real user data, routed through `UserDataStore.migrate`. The
+  bump is one-way: a subsequent app **rollback** would meet v2 data it predates,
+  so the store must fail safe (ignore/quarantine an unknown schema version, never
+  crash).
 - **Divergence from the wire contract.** The local model is richer than the
   per-drink Review API / `DrinkEntry`; non-drink entries have **no** wire home.
   Per-entry detail is device-local under this ADR; cross-device diary sync needs
@@ -184,9 +201,9 @@ per-entry key and idempotency handle if the wire contract ever goes per-entry.
 ### Migration approach (open sub-decision)
 On upgrade to schema v2, for each existing per-drink `UserDrinkState`:
 - its `wantToTry` flag moves to the per-drink intent set;
-- each existing tasting timestamp becomes a `LogEntry` (kind `tasting`, that
-  `drinkId`, a **freshly generated `id`**, `when` preserved) appended to the
-  festival timeline;
+- each existing tasting timestamp becomes a `LogEntry` (that `drinkId`, a
+  **freshly generated `id`**, `when` preserved) appended to the festival
+  timeline;
 - the drink-level `rating`/`notes`/`photoIds`, if any, attach to that drink's
   **most recent** tasting entry — or, if the drink was rated but never tasted,
   synthesise one tasting at `updatedAt` carrying them.
@@ -210,6 +227,22 @@ No data is discarded; the choice only affects *where* an existing rating lands.
 - **Sync**: unchanged — per-drink aggregate only; per-entry + non-drink detail
   stays device-local.
 
+### Phasing (migration-first, interface-preserving)
+
+The storage restructure touches the model, the store, and every existing
+consumer (#413 badge, #414 screen, drink card). To avoid the sweeping-change
+failure mode (AGENTS.md), it ships in ordered, independently-shippable PRs, the
+migration **first and alone**:
+
+1. **Model + migration** behind the *existing* public getters
+   (`tastingCount`, `isFavorite`, `rating`, …) so no consumer changes yet —
+   golden-tested v1→v2, **idempotent and crash-safe** (a partial migration must
+   recover, not corrupt).
+2. **Provider derivations + memoised `drinkId → entries` index**; existing view
+   behaviour unchanged.
+3. **#415** — drink-page capture/edit against the new entity.
+4. **Timeline "+" + non-drink `other` entries + backfill.**
+
 ---
 
 ## Related Documents
@@ -226,10 +259,14 @@ No data is discarded; the choice only affects *where* an existing rating lands.
 
 1. **Migration of a rating with no tasting**: synthesise a tasting entry, or keep
    a per-drink "overall"? (Recommended: synthesise, to keep one model.)
-2. **Derivation rule** for a drink's displayed/synced rating: latest tasting,
-   mean, or last non-null? (Community aggregate constrains this to one per drink.)
-3. **When, if ever, does the wire contract go per-entry?** (Deferred to a future
+2. **When, if ever, does the wire contract go per-entry?** (Deferred to a future
    proto-first ADR; not required for the local diary.)
 
-_Decided: the kind taxonomy is exactly two — `tasting` (drink) and `other`
-(freeform); rating/recommend apply to tastings only._
+_Decided:_
+- _Kind is **derived** from `drinkId` (present = tasting, absent = freeform
+  `other`); no stored `kind` field. Two kinds only; rating/recommend on tastings._
+- _A drink's displayed/synced rating & recommend = its **most recent tasting's**
+  value (shown as "your latest"); pours = tasting count._
+- _Storage is **per-entry keyed records** + a per-drink `wantToTry` flag; no
+  entry pruning (explicit delete only)._
+- _Rollout is **migration-first**, one consumer per PR (see Phasing)._

--- a/docs/adr/0006-tasting-as-primary-my-festival-entity.md
+++ b/docs/adr/0006-tasting-as-primary-my-festival-entity.md
@@ -1,4 +1,4 @@
-# ADR 0006: Tasting as the Primary My Festival Entity
+# ADR 0006: The Check-in as the Primary My Festival Entity
 
 **Status**: Proposed
 
@@ -8,204 +8,200 @@
 
 **Context**: "My Festival" has two jobs for a user: it is a **plan** (a
 forward-looking wishlist of drinks they intend to try) *and* a **diary** (a
-backward-looking record of what they actually drank, when, and what they
-thought). The current data model is **drink-centric**: `UserDrinkState`
-(`lib/models/user_drink_state.dart`) hangs `rating`, `notes`, and `photoIds`
-off the *drink*, and records tastings only as a bare `List<DateTime>`. That
-models the plan well but flattens the diary — a tasting is just a timestamp,
-carrying none of the "how was it" that a diary entry wants. Before building the
-detail-screen capture flow (#415) and the photo/recommend features (#416/#417)
-on top of that flat model, we need to decide what the **primary entity** of My
-Festival actually is.
+backward-looking record of their festival). The current model is
+**drink-centric**: `UserDrinkState` (`lib/models/user_drink_state.dart`) hangs
+`rating`, `notes`, and `photoIds` off a *drink*, and records tastings only as a
+bare `List<DateTime>`. Three requirements break that model: (1) a tasting wants
+to carry "how was it" (rating/note/photo) **per pour**, not per drink; (2) the
+diary should capture **non-drink events** — food, a moment, anything — which
+have no drink to hang off; and (3) users must be able to **add entries they
+forgot**, after the fact, with a chosen time. Before building the capture flow
+(#415) and photos/recommend (#416/#417), we need to decide what the **primary
+entity** of My Festival is.
 
 ---
 
 ## Decision
 
-Make the **Tasting a first-class entity** — a "check-in" — and treat My
-Festival as the intersection of two axes:
+Make the **check-in** — a *My Festival log entry* — the primary entity: a
+**festival-scoped, timestamped record that _optionally_ references a drink.**
+The diary is a **timeline of these entries**; the plan is a separate,
+per-drink `wantToTry` intent.
 
-| Axis | Entity | Direction | Field today |
+| Axis | What it is | Scope | Field |
 |---|---|---|---|
-| **Plan** (wishlist) | the drink, flagged | forward-looking intent | `wantToTry: bool` |
-| **Diary** (log) | the **Tasting** | backward-looking record | `tastingEvents: List<DateTime>` → `List<Tasting>` |
+| **Plan** (wishlist) | drink flagged to try | per drink | `wantToTry: bool` |
+| **Diary** (log) | timeline of **check-ins** | per festival | ordered `List<LogEntry>` |
 
-A `Tasting` carries the "how was it" that currently lives at drink level:
+A **tasting is simply the drink-kind check-in.** The entity generalises it:
 
 ```
-Tasting {
-  id: String              // stable UUID — identity (see User Experience)
-  when: DateTime          // the check-in moment, user-editable
-  rating?: int            // 1–5, this pour
-  wouldRecommend?: bool   // #417, this pour
-  note?: String           // this pour
-  photoIds: List<String>  // #416, this pour
+LogEntry {                 // a My Festival check-in
+  id: String               // stable UUID — identity (see User Experience)
+  when: DateTime           // user-editable; defaults to now, can be backdated
+  kind: tasting|food|other // extensible; tasting is the drink-linked kind
+  drinkId?: String         // set for a tasting; null for food / other
+  title?: String           // for non-drink entries ("Scotch egg from the pie stall")
+  rating?: int             // 1–5, any kind
+  wouldRecommend?: bool    // #417, any kind
+  note?: String
+  photoIds: List<String>   // #416
 }
 ```
 
 Consequently:
 
-- **`wantToTry` stays drink-level** — it is intent about a *drink*, not an
-  event. It is the plan axis and is unchanged.
-- **Drink-level `rating`/`notes`/`photoIds` become derived**, not stored: a
-  drink's "your rating" is an aggregate/most-recent view over its tastings.
-- **My Festival's "Tasted" view becomes a timeline of tastings** (check-ins),
-  grouped by day — which is already the direction `vision.md` and #414 took.
-- **"Mark as Tasted" becomes the create action for a check-in**, and the
-  capture flow (rate / recommend / note / photo) attaches to *that* tasting.
+- **The festival timeline is the source of truth** for the diary. Drink-level
+  views derive from it by filtering `entries.where(drinkId == this)`.
+- **`wantToTry` stays a per-drink intent**, separate from the timeline — it is
+  the plan axis, not an event.
+- **Non-drink events are first-class.** Food and other moments are entries with
+  no `drinkId` and a free-text `title`; they appear in the timeline and nowhere
+  drink-specific.
+- **Drink-level `rating`/`notes`/`photoIds` become derived**, not stored — a
+  drink's "your rating" is an aggregate over its tasting entries.
 
-**Local-first boundary (important):** this ADR decides the **local** model
-only. The deployed Review API and the `DrinkEntry` proto contract are
-**per-drink** (`star_rating`, `would_recommend`, `note`, and `pours` as a bare
-count). Per-tasting detail — the timeline, per-pour notes and photos — stays
-**device-local** for now; sync continues to carry the per-drink aggregate. Any
-change to make the *wire* contract per-tasting is a separate, proto-first
-decision (a future ADR), and must not block the local diary. This preserves
-the campaign's local-first / free-tier / low-ops constraints.
+**Local-first boundary (important):** this decides the **local** model only.
+The deployed Review API and the `DrinkEntry` proto are **per-drink**
+(`star_rating`, `would_recommend`, `note`, `pours` as a count). Per-entry detail
+— the timeline, per-pour notes/photos, and **all non-drink entries** (which have
+no wire home at all) — stays **device-local**. Sync continues to carry only the
+per-drink aggregate. Making the wire contract per-entry is a separate,
+proto-first decision (a future ADR) and must not block the local diary. This
+keeps the campaign's local-first / free-tier / low-ops constraints.
 
 ---
 
 ## User Experience
 
-This decision is as much a UX decision as a data one — the model only earns its
-keep if logging a tasting is effortless and forgiving. Three principles, each
+The diary only earns its keep if logging is effortless, forgiving, and able to
+capture the *whole* festival — not just scanned drinks. Four principles, each
 with an architectural consequence.
 
 ### Low-friction, inviting create
-"Mark as Tasted" is **one tap**: it creates a check-in at the current time with
-every other field empty, and the tasting is **persisted before anything else
-happens**. A capture sheet (rate / recommend / note / photo) then slides up —
-**entirely optional and dismissible**. The log-and-move-on user is already
-done; the linger-over-it user can add detail. No required fields, no wizard, no
-blocking spinner between tap and saved. This is the festival-conditions bar:
-one hand, a pint, patchy signal.
+On a drink page, "Mark as Tasted" is **one tap**: it creates+persists a tasting
+check-in at the current time with every other field empty, **before** anything
+else. An optional, dismissible capture sheet (rate / recommend / note / photo)
+then slides up. Log-and-move-on users are already done. No required fields, no
+wizard, no blocking spinner. The festival-conditions bar: one hand, a pint,
+patchy signal.
+
+### Add anything, including things you forgot
+A **"+" on the My Festival timeline** creates a check-in of any kind: pick a
+drink (catalogue search) for a tasting, or type a free-text `title` for food /
+a moment. The time **defaults to now but is freely set** — so "add the pie I
+forgot to log at lunch" is the same flow with an earlier time. Backfill is not a
+special case; it is create-with-a-past-`when`.
 
 ### Everything is editable after the fact
-A diary gets revised. Every field of a tasting — rating, recommend, note,
-photos, **and the timestamp itself** — is editable later, and a tasting is
-deletable (with a confirm, since deletion is the one irreversible action). Log
-now, annotate tonight; fix a mis-tapped time; add the photo you forgot.
+A diary gets revised. Every field of an entry — rating, recommend, note, photos,
+`kind`/`title`, **and the timestamp** — is editable later; an entry is deletable
+(with a confirm, deletion being the one irreversible action).
 
 ### It's private
-My Festival is a **personal** log — not shared, not moderated, no audience.
-That removes a whole class of concerns: no sharing controls, no content
-moderation, no "are you sure this is public", no edit-history/audit trail.
-Edits and deletes are unconstrained and freely reversible; notes and photos can
-be anything and stay device-local (reinforcing the local-first boundary above).
-Design for a personal notebook, not a social feed.
+My Festival is a **personal** log — not shared, not moderated, no audience. That
+removes a whole class of concerns: no sharing controls, no content moderation,
+no "are you sure this is public", no edit-history/audit. Edits and deletes are
+unconstrained and freely reversible; notes/photos can be anything and stay
+device-local. Design for a personal notebook, not a social feed.
 
-### Architectural consequence: tastings need a stable identity
-Editable timestamps **break the current identity scheme**. Today a tasting *is*
-its `DateTime`, and deletion matches by timestamp value — `user_drink_state.dart`
-normalises every event to millisecond precision precisely so an in-memory event
-equals its persisted form for delete-by-match. If the user can **edit the
-time**, the timestamp can no longer be the key: an edit-in-place would look like
-a delete-plus-create, and two events could collide. So a `Tasting` must carry a
-**stable `id`** (a generated UUID) assigned once at creation and never changed;
-**edit and delete key off `id`, not `when`**. This also hands sync (Track B) a
-natural per-tasting key and idempotency handle if the wire contract ever goes
-per-tasting.
+### Architectural consequence: entries need a stable identity
+Editable timestamps and non-drink entries both **break the current identity
+scheme**. Today a tasting *is* its `DateTime`, and deletion matches by timestamp
+value (`user_drink_state.dart` normalises to millisecond precision precisely for
+that delete-by-match). Once the time is user-editable — and once entries aren't
+keyed under a drink at all — the timestamp can't be the key. So every `LogEntry`
+carries a **stable `id`** (a generated UUID) assigned once and never changed;
+**edit and delete key off `id`.** This also hands sync (Track B) a natural
+per-entry key and idempotency handle if the wire contract ever goes per-entry.
 
 ---
 
 ## Alternatives Considered
 
 ### A. Keep the drink-centric model (status quo)
-- Simplest; no migration; `rating`/`notes` already map 1:1 to the deployed
-  per-drink Review API.
-- Rejected because: it cannot express the diary. "Was it better the second
-  time?" forces an overwrite of a single drink-level rating/note; photos and
-  notes have no natural per-moment home. The tasting stays a bare timestamp,
-  which is exactly the limitation #415/#416 would be building around.
+- Simplest; no migration; `rating`/`notes` map 1:1 to the per-drink Review API.
+- Rejected because: it can't express the diary — a tasting is a bare timestamp,
+  per-pour detail overwrites a single drink-level value, and there is **nowhere
+  to put a non-drink event at all**.
 
-### B. Hybrid — keep drink-level "overall" fields *and* add per-tasting fields
-- Both a drink-level `rating`/`note` (syncs, feeds community aggregate) and a
-  richer per-tasting record.
-- Rejected as the *primary* model because it doubles the surface (two places a
-  rating can live), creates an "which one is truth" ambiguity in the UI, and
-  invites drift. A drink-level **aggregate** is still needed for the community
-  rating, but it should be **derived** from tastings (see Decision), not a
-  second stored source of truth.
+### B. Tastings nested inside `UserDrinkState` (the first draft of this ADR)
+- Makes tastings rich (per-pour rating/note/photo) while keeping per-drink
+  storage.
+- Rejected because: it is still drink-keyed, so **non-drink events have no home**
+  — requirement (2) rules it out. Nesting under a drink cannot represent "had a
+  scotch egg." This is the decisive constraint that pushed the model to a
+  festival-scoped timeline.
 
-### C. Tasting as primary, per-tasting fields (**chosen**)
-- The diary becomes first-class; the plan (`wantToTry`) is orthogonal; drink
-  aggregates derive from the log.
-- Accepted despite a real migration cost and a divergence from the per-drink
-  wire contract (see Consequences), because it is the only model that makes My
-  Festival a genuine diary and it resolves the per-pour tension cleanly.
+### C. Check-in / log entry as primary, festival-scoped timeline (**chosen**)
+- The diary is first-class and general (drink and non-drink); the plan
+  (`wantToTry`) is orthogonal; drink aggregates derive from the timeline.
+- Accepted despite a real storage restructure and wire-contract divergence (see
+  Consequences), because it is the only model that captures the whole festival
+  and resolves the per-pour tension by construction.
 
 ---
 
 ## Consequences
 
 ### Positive
-- My Festival becomes a real **diary + plan**, matching how a festival is
-  lived (a sequence of moments, plus a wishlist).
-- Rating, would-recommend, note, and photo attach to a **moment**, resolving
-  the per-pour-vs-per-drink question by construction.
-- The "Tasted" timeline (#414) and the capture flow (#415) sit on a model that
-  fits them, instead of around a flat one.
-- Auto-revert to want-to-try (delete all tastings on a `wantToTry` drink) still
-  falls out of the derived section rule — no special-casing.
+- My Festival becomes a real **diary + plan** for the *whole* festival, not just
+  scanned drinks — matching how a festival is actually lived.
+- Rating/recommend/note/photo attach to a **moment**, resolving per-pour vs
+  per-drink by construction.
+- Backfill and edit fall out of the model (editable `when` + timeline "+"),
+  needing no special code paths.
+- The "Tasted" timeline (#414) and capture flow (#415) sit on a model built for
+  them. Auto-revert to want-to-try still falls out of the derived section rule.
 
 ### Negative
-- **Released-app migration.** `UserDataStore` is at schema v1 with real user
-  data. Moving `rating`/`notes`/`photoIds` onto tastings is a **v1→v2
-  migration**, not an additive field — it must be routed through
-  `UserDataStore.migrate` and cannot silently drop existing ratings/notes.
-- **Divergence from the wire contract.** The local model becomes richer than
-  the deployed per-drink Review API and the `DrinkEntry` proto (`pours` is a
-  count, not a list). Per-tasting detail is not synced under this ADR; cross-
-  device diary history would require a future proto-first contract change.
-- **Rating aggregation semantics.** "Your rating of this beer" must be defined
-  as a derivation (latest tasting? mean? last non-null?). The **community**
-  aggregate (`reviewSummaries`) assumes one rating per device per drink, so the
-  synced value must remain a single per-drink number derived from the log.
-- **#415 must be re-scoped** to build against the Tasting entity rather than the
-  drink-level action bar it currently specifies. Some of #415-as-written would
-  otherwise be interim/throwaway.
-- **Identity scheme changes.** Because the timestamp becomes user-editable,
-  tastings move from delete-by-timestamp-match to a stable `id` (see User
-  Experience). The delete path and the millisecond-precision normalisation in
-  `UserDrinkState` are reworked to key off `id`.
+- **Storage restructure + released-app migration.** Storage moves from
+  per-drink `UserDrinkState` blobs to a **festival-scoped entry collection** plus
+  a small per-drink `wantToTry` set. That is a `UserDataStore` schema **v1→v2**
+  migration over real user data, routed through `UserDataStore.migrate`.
+- **Divergence from the wire contract.** The local model is richer than the
+  per-drink Review API / `DrinkEntry`; non-drink entries have **no** wire home.
+  Per-entry detail is device-local under this ADR; cross-device diary sync needs
+  a future proto-first change.
+- **Rating aggregation semantics.** "Your rating of this beer" must be a
+  derivation over tasting entries (latest? mean?), and the synced/community value
+  (`reviewSummaries` assumes one per device per drink) must stay a single
+  per-drink number.
+- **Identity scheme change.** Entries move from delete-by-timestamp-match to a
+  stable `id`; the delete path and millisecond normalisation in the model are
+  reworked.
+- **#415 must be re-scoped** to build against the check-in entity (drink and
+  non-drink, capture + edit + backfill) rather than the drink-level action bar it
+  currently specifies.
 
 ### Migration approach (open sub-decision)
-On upgrade to schema v2, for each `UserDrinkState`:
-- **every existing tasting** gets a freshly generated stable `id` (they had
-  none — identity was the timestamp); `when` is preserved unchanged.
-- **≥1 tasting:** attach the existing drink-level `rating`/`notes`/`photoIds`
-  to the **most recent** tasting (best-effort; the user recorded them "about"
-  that drink, and the latest pour is the closest moment).
-- **rating/notes but no tasting** (rated without logging a tasting): synthesise
-  a single tasting at `updatedAt` carrying them, **or** retain a drink-level
-  "overall" specifically for the derived/community rating. Recommended:
-  synthesise, to keep one model; flagged as the key migration decision.
-- `wantToTry`, `createdAt`, `updatedAt` are unchanged.
+On upgrade to schema v2, for each existing per-drink `UserDrinkState`:
+- its `wantToTry` flag moves to the per-drink intent set;
+- each existing tasting timestamp becomes a `LogEntry` (kind `tasting`, that
+  `drinkId`, a **freshly generated `id`**, `when` preserved) appended to the
+  festival timeline;
+- the drink-level `rating`/`notes`/`photoIds`, if any, attach to that drink's
+  **most recent** tasting entry — or, if the drink was rated but never tasted,
+  synthesise one tasting at `updatedAt` carrying them.
 
-No data is discarded either way; the choice only affects *where* an existing
-rating lands.
+No data is discarded; the choice only affects *where* an existing rating lands.
 
 ---
 
 ## Implementation (outline — not built by this ADR)
 
-- **Model**: introduce a `Tasting` value object with a stable `id`; change
-  `UserDrinkState.tastingEvents: List<DateTime>` → `tastings: List<Tasting>`;
-  make drink-level `rating`/`notes`/`photoIds` getters that derive from
-  `tastings`. Edit/delete key off `id` (replacing today's delete-by-timestamp).
-  Thread through `copyWith`/`toJson`/`fromJson`/`isEmpty`/`==`.
-- **UX (capture flow)**: one tap creates+persists a minimal `Tasting` at `now`;
-  an optional, dismissible capture sheet edits it; every field (incl. `when`)
-  is editable later; delete confirms. Private log — no share/moderation surface.
-- **Storage**: `UserDataStore` schema `currentSchemaVersion` 1→2 with a
-  `migrate` step per the approach above; pin nothing new in `PreferenceKeys`
-  (the record lives inside the per-drink JSON blob).
-- **Provider/derivation**: `myFestivalEntries` gains a tasting-timeline view;
-  drink aggregates derive from the log.
-- **UI**: #415 re-scoped to create/edit tastings; capture flow attaches
-  rating/recommend/note/photo to the tasting.
-- **Sync**: unchanged under this ADR — continues to carry the per-drink
-  aggregate; per-tasting detail is device-local.
+- **Model**: a `LogEntry` value object with a stable `id`, `kind`, optional
+  `drinkId`/`title`, and `when`/`rating`/`wouldRecommend`/`note`/`photoIds`.
+  Edit/delete key off `id`. Derive drink-level aggregates by filtering the
+  timeline.
+- **Storage**: `UserDataStore` gains a festival-scoped entry collection +
+  per-drink `wantToTry`; `currentSchemaVersion` 1→2 with the migration above.
+- **Provider**: expose the timeline and per-drink derived views; keep
+  `myFestivalEntries`' timeline shape (#414).
+- **UX**: drink-page one-tap tasting fast path; a timeline "+" for
+  any-kind/backfilled entries; edit-any-field; confirm-on-delete.
+- **Sync**: unchanged — per-drink aggregate only; per-entry + non-drink detail
+  stays device-local.
 
 ---
 
@@ -215,15 +211,17 @@ rating lands.
 - `proto/cambeerfestival/festival/v1alpha/drink_entry.proto` — the per-drink
   wire contract this model deliberately diverges from (locally)
 - Skills: `architecture-contract` (storage/versioning invariants),
-  `api-contract` (wire-contract evolution rules), `my-festival-campaign`
-- Issues: #315 (epic), #411 (mutators, done), #414 (timeline screen, done),
-  #415 (detail capture — to be re-scoped), #416 (photos), #417 (would-recommend)
+  `api-contract` (wire-contract evolution), `my-festival-campaign`
+- Issues: #315 (epic), #411 (mutators, done), #414 (timeline, done), #415
+  (detail capture — to be re-scoped), #416 (photos), #417 (would-recommend)
 
 ## Open Questions
 
-1. Migration of a rating that has no tasting: synthesise a tasting, or keep a
-   drink-level "overall"? (Recommended: synthesise.)
-2. Derivation rule for a drink's displayed/synced rating: latest tasting, mean,
-   or last non-null? (Community aggregate constrains this to one per drink.)
-3. When, if ever, does the *wire* contract go per-tasting? (Deferred to a
-   future proto-first ADR; not required for the local diary.)
+1. **Kind taxonomy.** Ship `tasting` + `food` + a generic `other`, or a richer
+   set? Keep it small and extensible; free-text `title` absorbs the long tail.
+2. **Migration of a rating with no tasting**: synthesise a tasting entry, or keep
+   a per-drink "overall"? (Recommended: synthesise, to keep one model.)
+3. **Derivation rule** for a drink's displayed/synced rating: latest tasting,
+   mean, or last non-null? (Community aggregate constrains this to one per drink.)
+4. **When, if ever, does the wire contract go per-entry?** (Deferred to a future
+   proto-first ADR; not required for the local diary.)

--- a/docs/adr/0006-tasting-as-primary-my-festival-entity.md
+++ b/docs/adr/0006-tasting-as-primary-my-festival-entity.md
@@ -1,0 +1,175 @@
+# ADR 0006: Tasting as the Primary My Festival Entity
+
+**Status**: Proposed
+
+**Date**: 2026-07-04
+
+**Deciders**: Maintainer (richardthe3rd)
+
+**Context**: "My Festival" has two jobs for a user: it is a **plan** (a
+forward-looking wishlist of drinks they intend to try) *and* a **diary** (a
+backward-looking record of what they actually drank, when, and what they
+thought). The current data model is **drink-centric**: `UserDrinkState`
+(`lib/models/user_drink_state.dart`) hangs `rating`, `notes`, and `photoIds`
+off the *drink*, and records tastings only as a bare `List<DateTime>`. That
+models the plan well but flattens the diary — a tasting is just a timestamp,
+carrying none of the "how was it" that a diary entry wants. Before building the
+detail-screen capture flow (#415) and the photo/recommend features (#416/#417)
+on top of that flat model, we need to decide what the **primary entity** of My
+Festival actually is.
+
+---
+
+## Decision
+
+Make the **Tasting a first-class entity** — a "check-in" — and treat My
+Festival as the intersection of two axes:
+
+| Axis | Entity | Direction | Field today |
+|---|---|---|---|
+| **Plan** (wishlist) | the drink, flagged | forward-looking intent | `wantToTry: bool` |
+| **Diary** (log) | the **Tasting** | backward-looking record | `tastingEvents: List<DateTime>` → `List<Tasting>` |
+
+A `Tasting` carries the "how was it" that currently lives at drink level:
+
+```
+Tasting {
+  when: DateTime          // the check-in moment (identity)
+  rating?: int            // 1–5, this pour
+  wouldRecommend?: bool   // #417, this pour
+  note?: String           // this pour
+  photoIds: List<String>  // #416, this pour
+}
+```
+
+Consequently:
+
+- **`wantToTry` stays drink-level** — it is intent about a *drink*, not an
+  event. It is the plan axis and is unchanged.
+- **Drink-level `rating`/`notes`/`photoIds` become derived**, not stored: a
+  drink's "your rating" is an aggregate/most-recent view over its tastings.
+- **My Festival's "Tasted" view becomes a timeline of tastings** (check-ins),
+  grouped by day — which is already the direction `vision.md` and #414 took.
+- **"Mark as Tasted" becomes the create action for a check-in**, and the
+  capture flow (rate / recommend / note / photo) attaches to *that* tasting.
+
+**Local-first boundary (important):** this ADR decides the **local** model
+only. The deployed Review API and the `DrinkEntry` proto contract are
+**per-drink** (`star_rating`, `would_recommend`, `note`, and `pours` as a bare
+count). Per-tasting detail — the timeline, per-pour notes and photos — stays
+**device-local** for now; sync continues to carry the per-drink aggregate. Any
+change to make the *wire* contract per-tasting is a separate, proto-first
+decision (a future ADR), and must not block the local diary. This preserves
+the campaign's local-first / free-tier / low-ops constraints.
+
+---
+
+## Alternatives Considered
+
+### A. Keep the drink-centric model (status quo)
+- Simplest; no migration; `rating`/`notes` already map 1:1 to the deployed
+  per-drink Review API.
+- Rejected because: it cannot express the diary. "Was it better the second
+  time?" forces an overwrite of a single drink-level rating/note; photos and
+  notes have no natural per-moment home. The tasting stays a bare timestamp,
+  which is exactly the limitation #415/#416 would be building around.
+
+### B. Hybrid — keep drink-level "overall" fields *and* add per-tasting fields
+- Both a drink-level `rating`/`note` (syncs, feeds community aggregate) and a
+  richer per-tasting record.
+- Rejected as the *primary* model because it doubles the surface (two places a
+  rating can live), creates an "which one is truth" ambiguity in the UI, and
+  invites drift. A drink-level **aggregate** is still needed for the community
+  rating, but it should be **derived** from tastings (see Decision), not a
+  second stored source of truth.
+
+### C. Tasting as primary, per-tasting fields (**chosen**)
+- The diary becomes first-class; the plan (`wantToTry`) is orthogonal; drink
+  aggregates derive from the log.
+- Accepted despite a real migration cost and a divergence from the per-drink
+  wire contract (see Consequences), because it is the only model that makes My
+  Festival a genuine diary and it resolves the per-pour tension cleanly.
+
+---
+
+## Consequences
+
+### Positive
+- My Festival becomes a real **diary + plan**, matching how a festival is
+  lived (a sequence of moments, plus a wishlist).
+- Rating, would-recommend, note, and photo attach to a **moment**, resolving
+  the per-pour-vs-per-drink question by construction.
+- The "Tasted" timeline (#414) and the capture flow (#415) sit on a model that
+  fits them, instead of around a flat one.
+- Auto-revert to want-to-try (delete all tastings on a `wantToTry` drink) still
+  falls out of the derived section rule — no special-casing.
+
+### Negative
+- **Released-app migration.** `UserDataStore` is at schema v1 with real user
+  data. Moving `rating`/`notes`/`photoIds` onto tastings is a **v1→v2
+  migration**, not an additive field — it must be routed through
+  `UserDataStore.migrate` and cannot silently drop existing ratings/notes.
+- **Divergence from the wire contract.** The local model becomes richer than
+  the deployed per-drink Review API and the `DrinkEntry` proto (`pours` is a
+  count, not a list). Per-tasting detail is not synced under this ADR; cross-
+  device diary history would require a future proto-first contract change.
+- **Rating aggregation semantics.** "Your rating of this beer" must be defined
+  as a derivation (latest tasting? mean? last non-null?). The **community**
+  aggregate (`reviewSummaries`) assumes one rating per device per drink, so the
+  synced value must remain a single per-drink number derived from the log.
+- **#415 must be re-scoped** to build against the Tasting entity rather than the
+  drink-level action bar it currently specifies. Some of #415-as-written would
+  otherwise be interim/throwaway.
+
+### Migration approach (open sub-decision)
+On upgrade to schema v2, for each `UserDrinkState`:
+- **≥1 tasting:** attach the existing drink-level `rating`/`notes`/`photoIds`
+  to the **most recent** tasting (best-effort; the user recorded them "about"
+  that drink, and the latest pour is the closest moment).
+- **rating/notes but no tasting** (rated without logging a tasting): synthesise
+  a single tasting at `updatedAt` carrying them, **or** retain a drink-level
+  "overall" specifically for the derived/community rating. Recommended:
+  synthesise, to keep one model; flagged as the key migration decision.
+- `wantToTry`, `createdAt`, `updatedAt` are unchanged.
+
+No data is discarded either way; the choice only affects *where* an existing
+rating lands.
+
+---
+
+## Implementation (outline — not built by this ADR)
+
+- **Model**: introduce a `Tasting` value object; change
+  `UserDrinkState.tastingEvents: List<DateTime>` → `tastings: List<Tasting>`;
+  make drink-level `rating`/`notes`/`photoIds` getters that derive from
+  `tastings`. Thread through `copyWith`/`toJson`/`fromJson`/`isEmpty`/`==`.
+- **Storage**: `UserDataStore` schema `currentSchemaVersion` 1→2 with a
+  `migrate` step per the approach above; pin nothing new in `PreferenceKeys`
+  (the record lives inside the per-drink JSON blob).
+- **Provider/derivation**: `myFestivalEntries` gains a tasting-timeline view;
+  drink aggregates derive from the log.
+- **UI**: #415 re-scoped to create/edit tastings; capture flow attaches
+  rating/recommend/note/photo to the tasting.
+- **Sync**: unchanged under this ADR — continues to carry the per-drink
+  aggregate; per-tasting detail is device-local.
+
+---
+
+## Related Documents
+
+- `docs/planning/my-festival/vision.md` — the multi-phase roadmap (#411–#417)
+- `proto/cambeerfestival/festival/v1alpha/drink_entry.proto` — the per-drink
+  wire contract this model deliberately diverges from (locally)
+- Skills: `architecture-contract` (storage/versioning invariants),
+  `api-contract` (wire-contract evolution rules), `my-festival-campaign`
+- Issues: #315 (epic), #411 (mutators, done), #414 (timeline screen, done),
+  #415 (detail capture — to be re-scoped), #416 (photos), #417 (would-recommend)
+
+## Open Questions
+
+1. Migration of a rating that has no tasting: synthesise a tasting, or keep a
+   drink-level "overall"? (Recommended: synthesise.)
+2. Derivation rule for a drink's displayed/synced rating: latest tasting, mean,
+   or last non-null? (Community aggregate constrains this to one per drink.)
+3. When, if ever, does the *wire* contract go per-tasting? (Deferred to a
+   future proto-first ADR; not required for the local diary.)

--- a/docs/adr/0006-tasting-as-primary-my-festival-entity.md
+++ b/docs/adr/0006-tasting-as-primary-my-festival-entity.md
@@ -39,15 +39,20 @@ A **tasting is simply the drink-kind check-in.** The entity generalises it:
 LogEntry {                 // a My Festival check-in
   id: String               // stable UUID — identity (see User Experience)
   when: DateTime           // user-editable; defaults to now, can be backdated
-  kind: tasting|food|other // extensible; tasting is the drink-linked kind
-  drinkId?: String         // set for a tasting; null for food / other
-  title?: String           // for non-drink entries ("Scotch egg from the pie stall")
-  rating?: int             // 1–5, any kind
-  wouldRecommend?: bool    // #417, any kind
-  note?: String
-  photoIds: List<String>   // #416
+  kind: tasting | other    // tasting = drink check-in; other = freeform
+  drinkId?: String         // set iff kind == tasting
+  title?: String           // freeform label for `other` ("Scotch egg from the pie stall")
+  note?: String            // any kind
+  photoIds: List<String>   // any kind (#416)
+  rating?: int             // tasting only — 1–5
+  wouldRecommend?: bool    // tasting only (#417)
 }
 ```
+
+**Two kinds only.** `tasting` (a drink check-in) carries the full set;
+`other` is freeform — a `title`, an optional `note`, and photos, with a time —
+and carries **no rating or recommend**. A free-text `title` absorbs the long
+tail (food, a band, "arrived"), so there is no per-category kind explosion.
 
 Consequently:
 
@@ -55,9 +60,10 @@ Consequently:
   views derive from it by filtering `entries.where(drinkId == this)`.
 - **`wantToTry` stays a per-drink intent**, separate from the timeline — it is
   the plan axis, not an event.
-- **Non-drink events are first-class.** Food and other moments are entries with
-  no `drinkId` and a free-text `title`; they appear in the timeline and nowhere
-  drink-specific.
+- **Non-drink entries are first-class but minimal.** An `other` entry — food, a
+  moment, anything — has no `drinkId`, a free-text `title`, and optionally a
+  note/photos; it carries **no rating/recommend** and appears in the timeline
+  only (nowhere drink-specific).
 - **Drink-level `rating`/`notes`/`photoIds` become derived**, not stored — a
   drink's "your rating" is an aggregate over its tasting entries.
 
@@ -87,11 +93,12 @@ wizard, no blocking spinner. The festival-conditions bar: one hand, a pint,
 patchy signal.
 
 ### Add anything, including things you forgot
-A **"+" on the My Festival timeline** creates a check-in of any kind: pick a
-drink (catalogue search) for a tasting, or type a free-text `title` for food /
-a moment. The time **defaults to now but is freely set** — so "add the pie I
-forgot to log at lunch" is the same flow with an earlier time. Backfill is not a
-special case; it is create-with-a-past-`when`.
+A **"+" on the My Festival timeline** creates a check-in: pick a drink
+(catalogue search) for a **tasting** (rate / recommend / note / photo), or type
+a free-text `title` for an **other** entry (note / photo only). The time
+**defaults to now but is freely set** — so "add the pie I forgot at lunch" is
+the same flow with an earlier time. Backfill is not a special case; it is
+create-with-a-past-`when`.
 
 ### Everything is editable after the fact
 A diary gets revised. Every field of an entry — rating, recommend, note, photos,
@@ -217,11 +224,12 @@ No data is discarded; the choice only affects *where* an existing rating lands.
 
 ## Open Questions
 
-1. **Kind taxonomy.** Ship `tasting` + `food` + a generic `other`, or a richer
-   set? Keep it small and extensible; free-text `title` absorbs the long tail.
-2. **Migration of a rating with no tasting**: synthesise a tasting entry, or keep
+1. **Migration of a rating with no tasting**: synthesise a tasting entry, or keep
    a per-drink "overall"? (Recommended: synthesise, to keep one model.)
-3. **Derivation rule** for a drink's displayed/synced rating: latest tasting,
+2. **Derivation rule** for a drink's displayed/synced rating: latest tasting,
    mean, or last non-null? (Community aggregate constrains this to one per drink.)
-4. **When, if ever, does the wire contract go per-entry?** (Deferred to a future
+3. **When, if ever, does the wire contract go per-entry?** (Deferred to a future
    proto-first ADR; not required for the local diary.)
+
+_Decided: the kind taxonomy is exactly two — `tasting` (drink) and `other`
+(freeform); rating/recommend apply to tastings only._

--- a/docs/adr/0006-tasting-as-primary-my-festival-entity.md
+++ b/docs/adr/0006-tasting-as-primary-my-festival-entity.md
@@ -34,7 +34,8 @@ A `Tasting` carries the "how was it" that currently lives at drink level:
 
 ```
 Tasting {
-  when: DateTime          // the check-in moment (identity)
+  id: String              // stable UUID — identity (see User Experience)
+  when: DateTime          // the check-in moment, user-editable
   rating?: int            // 1–5, this pour
   wouldRecommend?: bool   // #417, this pour
   note?: String           // this pour
@@ -61,6 +62,49 @@ count). Per-tasting detail — the timeline, per-pour notes and photos — stays
 change to make the *wire* contract per-tasting is a separate, proto-first
 decision (a future ADR), and must not block the local diary. This preserves
 the campaign's local-first / free-tier / low-ops constraints.
+
+---
+
+## User Experience
+
+This decision is as much a UX decision as a data one — the model only earns its
+keep if logging a tasting is effortless and forgiving. Three principles, each
+with an architectural consequence.
+
+### Low-friction, inviting create
+"Mark as Tasted" is **one tap**: it creates a check-in at the current time with
+every other field empty, and the tasting is **persisted before anything else
+happens**. A capture sheet (rate / recommend / note / photo) then slides up —
+**entirely optional and dismissible**. The log-and-move-on user is already
+done; the linger-over-it user can add detail. No required fields, no wizard, no
+blocking spinner between tap and saved. This is the festival-conditions bar:
+one hand, a pint, patchy signal.
+
+### Everything is editable after the fact
+A diary gets revised. Every field of a tasting — rating, recommend, note,
+photos, **and the timestamp itself** — is editable later, and a tasting is
+deletable (with a confirm, since deletion is the one irreversible action). Log
+now, annotate tonight; fix a mis-tapped time; add the photo you forgot.
+
+### It's private
+My Festival is a **personal** log — not shared, not moderated, no audience.
+That removes a whole class of concerns: no sharing controls, no content
+moderation, no "are you sure this is public", no edit-history/audit trail.
+Edits and deletes are unconstrained and freely reversible; notes and photos can
+be anything and stay device-local (reinforcing the local-first boundary above).
+Design for a personal notebook, not a social feed.
+
+### Architectural consequence: tastings need a stable identity
+Editable timestamps **break the current identity scheme**. Today a tasting *is*
+its `DateTime`, and deletion matches by timestamp value — `user_drink_state.dart`
+normalises every event to millisecond precision precisely so an in-memory event
+equals its persisted form for delete-by-match. If the user can **edit the
+time**, the timestamp can no longer be the key: an edit-in-place would look like
+a delete-plus-create, and two events could collide. So a `Tasting` must carry a
+**stable `id`** (a generated UUID) assigned once at creation and never changed;
+**edit and delete key off `id`, not `when`**. This also hands sync (Track B) a
+natural per-tasting key and idempotency handle if the wire contract ever goes
+per-tasting.
 
 ---
 
@@ -120,9 +164,15 @@ the campaign's local-first / free-tier / low-ops constraints.
 - **#415 must be re-scoped** to build against the Tasting entity rather than the
   drink-level action bar it currently specifies. Some of #415-as-written would
   otherwise be interim/throwaway.
+- **Identity scheme changes.** Because the timestamp becomes user-editable,
+  tastings move from delete-by-timestamp-match to a stable `id` (see User
+  Experience). The delete path and the millisecond-precision normalisation in
+  `UserDrinkState` are reworked to key off `id`.
 
 ### Migration approach (open sub-decision)
 On upgrade to schema v2, for each `UserDrinkState`:
+- **every existing tasting** gets a freshly generated stable `id` (they had
+  none — identity was the timestamp); `when` is preserved unchanged.
 - **≥1 tasting:** attach the existing drink-level `rating`/`notes`/`photoIds`
   to the **most recent** tasting (best-effort; the user recorded them "about"
   that drink, and the latest pour is the closest moment).
@@ -139,10 +189,14 @@ rating lands.
 
 ## Implementation (outline — not built by this ADR)
 
-- **Model**: introduce a `Tasting` value object; change
+- **Model**: introduce a `Tasting` value object with a stable `id`; change
   `UserDrinkState.tastingEvents: List<DateTime>` → `tastings: List<Tasting>`;
   make drink-level `rating`/`notes`/`photoIds` getters that derive from
-  `tastings`. Thread through `copyWith`/`toJson`/`fromJson`/`isEmpty`/`==`.
+  `tastings`. Edit/delete key off `id` (replacing today's delete-by-timestamp).
+  Thread through `copyWith`/`toJson`/`fromJson`/`isEmpty`/`==`.
+- **UX (capture flow)**: one tap creates+persists a minimal `Tasting` at `now`;
+  an optional, dismissible capture sheet edits it; every field (incl. `when`)
+  is editable later; delete confirms. Private log — no share/moderation surface.
 - **Storage**: `UserDataStore` schema `currentSchemaVersion` 1→2 with a
   `migrate` step per the approach above; pin nothing new in `PreferenceKeys`
   (the record lives inside the per-drink JSON blob).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ Each ADR follows this structure:
 | [0003](0003-parallel-build-strategy.md) | Parallel Build Strategy for Android Releases | Accepted | 2025-12-27 |
 | [0004](0004-path-based-url-strategy.md) | Path-Based URL Strategy for Deep Linking | Accepted | 2025-12-21 |
 | [0005](0005-e2e-testing-strategy.md) | E2E Testing Strategy (Playwright for URL Smoke Tests) | Accepted | 2025-12-21 |
+| [0006](0006-tasting-as-primary-my-festival-entity.md) | Tasting as the Primary My Festival Entity | Proposed | 2026-07-04 |
 
 ## Creating a New ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,7 +32,7 @@ Each ADR follows this structure:
 | [0003](0003-parallel-build-strategy.md) | Parallel Build Strategy for Android Releases | Accepted | 2025-12-27 |
 | [0004](0004-path-based-url-strategy.md) | Path-Based URL Strategy for Deep Linking | Accepted | 2025-12-21 |
 | [0005](0005-e2e-testing-strategy.md) | E2E Testing Strategy (Playwright for URL Smoke Tests) | Accepted | 2025-12-21 |
-| [0006](0006-tasting-as-primary-my-festival-entity.md) | Tasting as the Primary My Festival Entity | Proposed | 2026-07-04 |
+| [0006](0006-tasting-as-primary-my-festival-entity.md) | The Check-in as the Primary My Festival Entity | Proposed | 2026-07-04 |
 
 ## Creating a New ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,7 +32,7 @@ Each ADR follows this structure:
 | [0003](0003-parallel-build-strategy.md) | Parallel Build Strategy for Android Releases | Accepted | 2025-12-27 |
 | [0004](0004-path-based-url-strategy.md) | Path-Based URL Strategy for Deep Linking | Accepted | 2025-12-21 |
 | [0005](0005-e2e-testing-strategy.md) | E2E Testing Strategy (Playwright for URL Smoke Tests) | Accepted | 2025-12-21 |
-| [0006](0006-tasting-as-primary-my-festival-entity.md) | The Check-in as the Primary My Festival Entity | Proposed | 2026-07-04 |
+| [0006](0006-check-in-as-primary-my-festival-entity.md) | The Check-in as the Primary My Festival Entity | Proposed | 2026-07-04 |
 
 ## Creating a New ADR
 


### PR DESCRIPTION
## What

Adds **ADR 0006 (Proposed)** — *Tasting as the Primary My Festival Entity* — plus the required index updates (`docs/adr/README.md`, `docs/README.md`, stamp bump). No code.

## The decision it proposes

My Festival is **two things**: a **plan** (want-to-try, forward-looking) and a **diary** (a log of what you actually drank, backward-looking). The current model serves the plan but flattens the diary — a tasting is a bare `DateTime`, and `rating`/`notes`/`photoIds` hang off the *drink*.

The ADR proposes making the **Tasting a first-class "check-in"**: rating, would-recommend, note, and photos move onto each tasting; `wantToTry` stays drink-level (it's the plan); drink-level values become **derived** aggregates over the log. "Mark as Tasted" becomes the create-a-check-in action, and the capture flow attaches to that moment.

## Why it's an ADR, not a PR

It reframes the core entity and touches the two things the project guards most — **storage** (a released-app schema v1→v2 migration) and the **API contract** (the deployed Review API + `DrinkEntry` proto are per-drink; `pours` is a count). The ADR draws a **local-first boundary**: the local model goes per-tasting now; the wire contract stays per-drink and per-tasting detail is device-local, deferring any contract change to a future proto-first ADR. That keeps it free-tier / low-ops and doesn't block the diary.

It documents three real alternatives (status quo, hybrid, chosen), states the negative consequences plainly (migration, wire divergence, rating-aggregation semantics), sketches the migration approach, and lists open questions.

## Consequence to flag

**This gates #415.** As currently written, #415 builds a drink-level action bar; under this ADR it should be re-scoped to build against the Tasting entity. So the sequencing is: decide this → re-scope #415 → build.

## Review notes

- Docs-only (`docs/**`), so CI is just `pr-lint`.
- Status is **Proposed** — this PR is the decision surface; nothing is implemented.
- Fresh branch off `main` after #458 merged (per the merged-PR convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoxvqcycziH5Cj62Fu79d1)_