### PR TITLE
docs(adr): mark ADR 0006 Accepted

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Key decisions with context, alternatives considered, and consequences.
 - **[0003](adr/0003-parallel-build-strategy.md)** - Parallel Build Strategy for Android Releases
 - **[0004](adr/0004-path-based-url-strategy.md)** - Path-Based URL Strategy for Deep Linking
 - **[0005](adr/0005-e2e-testing-strategy.md)** - E2E Testing Strategy (Playwright for URL smoke tests)
-- **[0006](adr/0006-check-in-as-primary-my-festival-entity.md)** - The Check-in as the Primary My Festival Entity (Proposed)
+- **[0006](adr/0006-check-in-as-primary-my-festival-entity.md)** - The Check-in as the Primary My Festival Entity
 
 ### 🔄 processes/ - Development & Operational Processes
 
@@ -78,7 +78,7 @@ Bugs, features, and tasks are tracked in [GitHub Issues](https://github.com/rich
 - Shared UI components → [code/ui-components.md](code/ui-components.md)
 
 **Understand a past decision:**
-- Why is a check-in (a drink or non-drink entry) the primary My Festival entity? → [ADR 0006](adr/0006-check-in-as-primary-my-festival-entity.md) (Proposed)
+- Why is a check-in (a drink or non-drink entry) the primary My Festival entity? → [ADR 0006](adr/0006-check-in-as-primary-my-festival-entity.md)
 - Why path-based URLs? → [ADR 0004](adr/0004-path-based-url-strategy.md)
 - Why Playwright for E2E? → [ADR 0005](adr/0005-e2e-testing-strategy.md)
 - Why cache pub/npm but not build artifacts? → [ADR 0001](adr/0001-github-actions-caching-strategy.md)

--- a/docs/adr/0006-check-in-as-primary-my-festival-entity.md
+++ b/docs/adr/0006-check-in-as-primary-my-festival-entity.md
@@ -1,6 +1,6 @@
 # ADR 0006: The Check-in as the Primary My Festival Entity
 
-**Status**: Proposed
+**Status**: Accepted
 
 **Date**: 2026-07-04
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,7 +32,7 @@ Each ADR follows this structure:
 | [0003](0003-parallel-build-strategy.md) | Parallel Build Strategy for Android Releases | Accepted | 2025-12-27 |
 | [0004](0004-path-based-url-strategy.md) | Path-Based URL Strategy for Deep Linking | Accepted | 2025-12-21 |
 | [0005](0005-e2e-testing-strategy.md) | E2E Testing Strategy (Playwright for URL Smoke Tests) | Accepted | 2025-12-21 |
-| [0006](0006-check-in-as-primary-my-festival-entity.md) | The Check-in as the Primary My Festival Entity | Proposed | 2026-07-04 |
+| [0006](0006-check-in-as-primary-my-festival-entity.md) | The Check-in as the Primary My Festival Entity | Accepted | 2026-07-04 |
 
 ## Creating a New ADR
 


### PR DESCRIPTION
Flips **ADR 0006 — The Check-in as the Primary My Festival Entity** from `Proposed` to `Accepted` (per the decision to merge #459), and drops the `(Proposed)` markers from the two doc indexes.

Docs-only; CI is just `pr-lint`. No content change beyond status.

Follow-up work this unblocks (to be filed as issues): the LogEntry model + schema-v2 migration (Phase 1–2, gates everything), the re-scope of #415 to the check-in capture flow (Phase 3), and non-drink `other` entries + the timeline add/backfill (Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoxvqcycziH5Cj62Fu79d1)_