### PR TITLE
fix(drink-detail): make the tasting SnackBar dismissible and less cramped

### DIFF
--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -99,6 +99,9 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
     if (updated == null || updated.tastingEvents.isEmpty) return;
 
     final count = updated.tastingCount;
+    final message = count == 1
+        ? 'Logged your first tasting'
+        : 'Logged — $count tastings';
 
     messenger
       ..hideCurrentSnackBar()
@@ -111,12 +114,13 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
           duration: const Duration(seconds: 3),
           // SnackBars only swipe-dismiss by default, which most users never
           // discover; let a tap on the message itself dismiss it too.
-          content: GestureDetector(
-            onTap: messenger.hideCurrentSnackBar,
-            child: Text(
-              count == 1
-                  ? 'Logged your first tasting'
-                  : 'Logged — $count tastings',
+          content: Semantics(
+            label: message,
+            button: true,
+            hint: 'Double tap to dismiss',
+            child: GestureDetector(
+              onTap: messenger.hideCurrentSnackBar,
+              child: Text(message),
             ),
           ),
           action: SnackBarAction(

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -105,10 +105,19 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
       ..showSnackBar(
         SnackBar(
           behavior: SnackBarBehavior.floating,
-          content: Text(
-            count == 1
-                ? 'Logged your first tasting'
-                : 'Logged — $count tastings',
+          // A small gap above the FAB — by default Flutter floats a SnackBar
+          // flush against a centered FAB with no breathing room at all.
+          margin: const EdgeInsets.only(bottom: 12, left: 16, right: 16),
+          duration: const Duration(seconds: 3),
+          // SnackBars only swipe-dismiss by default, which most users never
+          // discover; let a tap on the message itself dismiss it too.
+          content: GestureDetector(
+            onTap: messenger.hideCurrentSnackBar,
+            child: Text(
+              count == 1
+                  ? 'Logged your first tasting'
+                  : 'Logged — $count tastings',
+            ),
           ),
           action: SnackBarAction(
             label: 'Undo',

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -669,6 +669,40 @@ void main() {
         verify(mockDrinkRepository.removeTasting(any, any, any)).called(1);
       });
 
+      testWidgets('tapping the confirmation message dismisses it early', (
+        WidgetTester tester,
+      ) async {
+        await useTallSurface(tester);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [drink]);
+        await provider.loadDrinks();
+
+        when(
+          mockDrinkRepository.addTasting(any, any, now: anyNamed('now')),
+        ).thenAnswer(
+          (_) async => UserDrinkState(
+            tastingEvents: [now],
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget('drink1'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const ValueKey('tasted-action')));
+        await tester.pumpAndSettle();
+        expect(find.text('Logged your first tasting'), findsOneWidget);
+
+        // A tap on the message dismisses it without waiting for the timeout
+        // or discovering the swipe-to-dismiss gesture.
+        await tester.tap(find.text('Logged your first tasting'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Logged your first tasting'), findsNothing);
+      });
+
       testWidgets('confirmation SnackBar is scoped to this screen', (
         WidgetTester tester,
       ) async {

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -695,6 +695,19 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text('Logged your first tasting'), findsOneWidget);
 
+        // The dismissible message announces as an actionable control with a
+        // dismiss hint, not just as static text.
+        expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Semantics &&
+                widget.properties.label == 'Logged your first tasting' &&
+                widget.properties.button == true &&
+                widget.properties.hint == 'Double tap to dismiss',
+          ),
+          findsOneWidget,
+        );
+
         // A tap on the message dismisses it without waiting for the timeout
         // or discovering the swipe-to-dismiss gesture.
         await tester.tap(find.text('Logged your first tasting'));


### PR DESCRIPTION
By default Flutter floats a SnackBar flush against a centered FAB with
zero gap, and SnackBars only swipe-to-dismiss (undiscoverable) — so the
"Drunk it!" confirmation appeared to sit right on top of the FAB/tasting
log and felt stuck for its full 4s duration. Add breathing-room margin,
let a tap on the message dismiss it early, and trim the duration.

Verified the zero-gap placement with a rect-measurement widget test
before fixing (not committed).