### PR TITLE
fix(router): push detail routes instead of replacing to preserve scroll position

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -50,146 +50,165 @@ String? _festivalScopeRedirect(
 /// - Nested ShellRoute: Adds bottom navigation bar for main screens only
 /// - Direct routes: Detail pages without navigation bar
 /// - Global routes: `/about` (no festival scope)
-final GoRouter appRouter = GoRouter(
-  initialLocation: '/',
-  debugLogDiagnostics: kDebugMode,
-  routes: [
-    // Global routes FIRST (before festival routes)
-    // Must come before /:festivalId to avoid being caught as festival ID
-    GoRoute(path: '/about', builder: (context, state) => const AboutScreen()),
-    // Parent shell - Ensures provider initialization for ALL routes
-    // This fixes deep linking by initializing data before any screen renders
-    ShellRoute(
-      builder: (context, state, child) => ProviderInitializer(child: child),
-      routes: [
-        // Root redirect to current festival
-        GoRoute(
-          path: '/',
-          redirect: (context, state) {
-            final provider = context.read<BeerProvider>();
-            // Wait for provider initialization before redirecting
-            if (!provider.isInitialized) {
-              return null; // ProviderInitializer will show loading screen
-            }
-            return '/${provider.currentFestival.id}';
-          },
-          // The builder is only reached while the provider is initializing
-          // (the redirect above returns null). It must exist: a redirect-only
-          // route that stays put leaves go_router with no page to build, so
-          // it mounts a Navigator with an empty `pages` list and no
-          // `onGenerateRoute`, which crashes with "Null check operator used
-          // on a null value" in release builds (issue #386). Once
-          // initialization completes, _handlePostInitRedirect in main.dart
-          // navigates to the current festival.
-          builder: (context, state) =>
-              const Scaffold(body: Center(child: CircularProgressIndicator())),
-        ),
-        // Festival-scoped routes with navigation bar
-        ShellRoute(
-          builder: (context, state, child) => BeerFestivalHome(child: child),
-          routes: [
-            GoRoute(
-              path: '/:festivalId',
-              redirect: (context, state) => _festivalScopeRedirect(
-                context,
-                state,
-                onInvalidFestival: (currentId) {
-                  final queryString = state.uri.query.isNotEmpty
-                      ? '?${state.uri.query}'
-                      : '';
-                  return '/$currentId$queryString';
+final GoRouter appRouter = _buildRouter();
+
+GoRouter _buildRouter() {
+  // Makes context.push() (used by navigateToRoute()) update the browser URL
+  // bar when pushing a route that isn't nested inside the enclosing
+  // ShellRoute — e.g. a drink detail pushed from the drinks list — matching
+  // what context.go() already does. Without this, go_router leaves the URL
+  // stuck at the shell's route (the bug navigateToRoute() previously worked
+  // around by using go() on web, which had the side effect of disposing the
+  // calling screen and losing its scroll position).
+  //
+  // go_router's own docs caution that this flag isn't always safe because
+  // "the URL of the top-most GoRoute is not always deeplink-able" — that
+  // doesn't apply here: every route this app pushes (drink/brewery/style
+  // detail, festival info, about) is a fully-formed, independently
+  // deep-linkable top-level GoRoute with its own redirect/validation logic.
+  GoRouter.optionURLReflectsImperativeAPIs = true;
+  return GoRouter(
+    initialLocation: '/',
+    debugLogDiagnostics: kDebugMode,
+    routes: [
+      // Global routes FIRST (before festival routes)
+      // Must come before /:festivalId to avoid being caught as festival ID
+      GoRoute(path: '/about', builder: (context, state) => const AboutScreen()),
+      // Parent shell - Ensures provider initialization for ALL routes
+      // This fixes deep linking by initializing data before any screen renders
+      ShellRoute(
+        builder: (context, state, child) => ProviderInitializer(child: child),
+        routes: [
+          // Root redirect to current festival
+          GoRoute(
+            path: '/',
+            redirect: (context, state) {
+              final provider = context.read<BeerProvider>();
+              // Wait for provider initialization before redirecting
+              if (!provider.isInitialized) {
+                return null; // ProviderInitializer will show loading screen
+              }
+              return '/${provider.currentFestival.id}';
+            },
+            // The builder is only reached while the provider is initializing
+            // (the redirect above returns null). It must exist: a redirect-only
+            // route that stays put leaves go_router with no page to build, so
+            // it mounts a Navigator with an empty `pages` list and no
+            // `onGenerateRoute`, which crashes with "Null check operator used
+            // on a null value" in release builds (issue #386). Once
+            // initialization completes, _handlePostInitRedirect in main.dart
+            // navigates to the current festival.
+            builder: (context, state) => const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            ),
+          ),
+          // Festival-scoped routes with navigation bar
+          ShellRoute(
+            builder: (context, state, child) => BeerFestivalHome(child: child),
+            routes: [
+              GoRoute(
+                path: '/:festivalId',
+                redirect: (context, state) => _festivalScopeRedirect(
+                  context,
+                  state,
+                  onInvalidFestival: (currentId) {
+                    final queryString = state.uri.query.isNotEmpty
+                        ? '?${state.uri.query}'
+                        : '';
+                    return '/$currentId$queryString';
+                  },
+                ),
+                pageBuilder: (context, state) {
+                  final festivalId = state.pathParameters['festivalId']!;
+                  return NoTransitionPage(
+                    child: DrinksScreen(festivalId: festivalId),
+                  );
                 },
               ),
-              pageBuilder: (context, state) {
-                final festivalId = state.pathParameters['festivalId']!;
-                return NoTransitionPage(
-                  child: DrinksScreen(festivalId: festivalId),
-                );
-              },
-            ),
-            GoRoute(
-              path: '/:festivalId/favorites',
-              redirect: (context, state) => _festivalScopeRedirect(
-                context,
-                state,
-                onInvalidFestival: (currentId) => '/$currentId/favorites',
+              GoRoute(
+                path: '/:festivalId/favorites',
+                redirect: (context, state) => _festivalScopeRedirect(
+                  context,
+                  state,
+                  onInvalidFestival: (currentId) => '/$currentId/favorites',
+                ),
+                pageBuilder: (context, state) {
+                  final festivalId = state.pathParameters['festivalId']!;
+                  return NoTransitionPage(
+                    child: MyFestivalScreen(festivalId: festivalId),
+                  );
+                },
               ),
-              pageBuilder: (context, state) {
-                final festivalId = state.pathParameters['festivalId']!;
-                return NoTransitionPage(
-                  child: MyFestivalScreen(festivalId: festivalId),
-                );
-              },
+            ],
+          ),
+          // Detail routes - Provider initialized, but no navigation bar
+          GoRoute(
+            path: '/:festivalId/drink/:category/:id',
+            redirect: (context, state) => _festivalScopeRedirect(
+              context,
+              state,
+              onInvalidFestival: (currentId) =>
+                  '/$currentId/drink/${state.pathParameters['category']}/${state.pathParameters['id']}',
             ),
-          ],
-        ),
-        // Detail routes - Provider initialized, but no navigation bar
-        GoRoute(
-          path: '/:festivalId/drink/:category/:id',
-          redirect: (context, state) => _festivalScopeRedirect(
-            context,
-            state,
-            onInvalidFestival: (currentId) =>
-                '/$currentId/drink/${state.pathParameters['category']}/${state.pathParameters['id']}',
+            builder: (context, state) {
+              final festivalId = state.pathParameters['festivalId']!;
+              final id = state.pathParameters['id']!;
+              // Key by drink so navigating drink→drink (e.g. tapping a Similar
+              // Drinks card) rebuilds a fresh screen — resetting scroll to the
+              // top and re-running the "drink viewed" analytics — instead of
+              // reusing the previous drink's State and its scroll offset.
+              return DrinkDetailScreen(
+                key: ValueKey('$festivalId/$id'),
+                festivalId: festivalId,
+                drinkId: id,
+              );
+            },
           ),
-          builder: (context, state) {
-            final festivalId = state.pathParameters['festivalId']!;
-            final id = state.pathParameters['id']!;
-            // Key by drink so navigating drink→drink (e.g. tapping a Similar
-            // Drinks card) rebuilds a fresh screen — resetting scroll to the
-            // top and re-running the "drink viewed" analytics — instead of
-            // reusing the previous drink's State and its scroll offset.
-            return DrinkDetailScreen(
-              key: ValueKey('$festivalId/$id'),
-              festivalId: festivalId,
-              drinkId: id,
-            );
-          },
-        ),
-        GoRoute(
-          path: '/:festivalId/brewery/:id',
-          redirect: (context, state) => _festivalScopeRedirect(
-            context,
-            state,
-            onInvalidFestival: (currentId) =>
-                '/$currentId/brewery/${state.pathParameters['id']}',
+          GoRoute(
+            path: '/:festivalId/brewery/:id',
+            redirect: (context, state) => _festivalScopeRedirect(
+              context,
+              state,
+              onInvalidFestival: (currentId) =>
+                  '/$currentId/brewery/${state.pathParameters['id']}',
+            ),
+            builder: (context, state) {
+              final festivalId = state.pathParameters['festivalId']!;
+              final id = state.pathParameters['id']!;
+              return BreweryScreen(festivalId: festivalId, breweryId: id);
+            },
           ),
-          builder: (context, state) {
-            final festivalId = state.pathParameters['festivalId']!;
-            final id = state.pathParameters['id']!;
-            return BreweryScreen(festivalId: festivalId, breweryId: id);
-          },
-        ),
-        GoRoute(
-          path: '/:festivalId/style/:name',
-          redirect: (context, state) => _festivalScopeRedirect(
-            context,
-            state,
-            onInvalidFestival: (currentId) =>
-                '/$currentId/style/${state.pathParameters['name']}',
+          GoRoute(
+            path: '/:festivalId/style/:name',
+            redirect: (context, state) => _festivalScopeRedirect(
+              context,
+              state,
+              onInvalidFestival: (currentId) =>
+                  '/$currentId/style/${state.pathParameters['name']}',
+            ),
+            builder: (context, state) {
+              final festivalId = state.pathParameters['festivalId']!;
+              final name = state.pathParameters['name']!;
+              return StyleScreen(
+                festivalId: festivalId,
+                style: safeDecodeComponent(name),
+              );
+            },
           ),
-          builder: (context, state) {
-            final festivalId = state.pathParameters['festivalId']!;
-            final name = state.pathParameters['name']!;
-            return StyleScreen(
-              festivalId: festivalId,
-              style: safeDecodeComponent(name),
-            );
-          },
-        ),
-        GoRoute(
-          path: '/:festivalId/info',
-          redirect: (context, state) => _festivalScopeRedirect(
-            context,
-            state,
-            onInvalidFestival: (currentId) => '/$currentId/info',
+          GoRoute(
+            path: '/:festivalId/info',
+            redirect: (context, state) => _festivalScopeRedirect(
+              context,
+              state,
+              onInvalidFestival: (currentId) => '/$currentId/info',
+            ),
+            builder: (context, state) {
+              final festivalId = state.pathParameters['festivalId']!;
+              return FestivalInfoScreen(festivalId: festivalId);
+            },
           ),
-          builder: (context, state) {
-            final festivalId = state.pathParameters['festivalId']!;
-            return FestivalInfoScreen(festivalId: festivalId);
-          },
-        ),
-      ],
-    ),
-  ],
-);
+        ],
+      ),
+    ],
+  );
+}

--- a/lib/utils/navigation_helpers.dart
+++ b/lib/utils/navigation_helpers.dart
@@ -7,7 +7,6 @@
 /// characters safely.
 library;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -225,18 +224,18 @@ bool canPopNavigation(BuildContext context) {
   }
 }
 
-/// Navigates to a detail route in a way that updates the browser URL on web.
+/// Navigates to a detail route by pushing it onto the current Navigator.
 ///
-/// On web, GoRouter's `push` from within a ShellRoute does not update the
-/// browser URL (the URL stays at the shell's route). Using `go` fixes this.
-/// On mobile there is no URL bar, so `push` is preferred to preserve Flutter's
-/// native back-navigation stack.
+/// `push` nests the new route on top of the current Navigator on both
+/// platforms, so the calling screen (and its state — e.g. scroll position)
+/// is never disposed, just covered. On web this also produces a correct
+/// browser URL because `GoRouter.optionURLReflectsImperativeAPIs` is enabled
+/// in `router.dart` — without that flag, `push`ing a route that isn't nested
+/// inside the enclosing `ShellRoute` used to leave the URL bar stuck at the
+/// shell's route, which is why this used to fall back to `go` (and dispose
+/// the calling screen) on web.
 void navigateToRoute(BuildContext context, String path) {
-  if (kIsWeb) {
-    context.go(path);
-  } else {
-    context.push(path);
-  }
+  context.push(path);
 }
 
 /// Decodes a percent-encoded URI component, returning the raw value if it

--- a/test/drinks_screen_scroll_position_test.dart
+++ b/test/drinks_screen_scroll_position_test.dart
@@ -26,7 +26,7 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'provider_test.mocks.dart';
-import 'router_test.dart' show testFestivalId;
+import 'router_test_constants.dart';
 
 /// Generates enough drinks to scroll well past a single screen.
 List<Drink> createSampleDrinks(int count) {

--- a/test/drinks_screen_scroll_position_test.dart
+++ b/test/drinks_screen_scroll_position_test.dart
@@ -1,0 +1,194 @@
+// Regression test for issue #470: navigating from the drinks list to a
+// drink detail screen (and back) used to reset the drinks list's scroll
+// position, because navigateToRoute() used context.go() on web, which
+// disposes DrinksScreen rather than covering it.
+//
+// The fix (see lib/router.dart's _buildRouter() and
+// lib/utils/navigation_helpers.dart's navigateToRoute()) makes
+// navigateToRoute() always context.push(), and enables go_router's
+// GoRouter.optionURLReflectsImperativeAPIs flag so push() still updates the
+// browser URL. push() keeps DrinksScreen mounted (offstage) underneath the
+// pushed route instead of disposing it, so its ScrollPosition survives
+// automatically.
+//
+// This test exercises the real production appRouter (not a stub route
+// table) so it proves the fix end-to-end through the actual ShellRoute
+// nesting that caused the original bug.
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:cambridge_beer_festival/providers/providers.dart';
+import 'package:cambridge_beer_festival/router.dart';
+import 'package:cambridge_beer_festival/screens/screens.dart';
+import 'package:cambridge_beer_festival/services/services.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'provider_test.mocks.dart';
+
+const String testFestivalId = 'cbf2025';
+
+/// Generates enough drinks to scroll well past a single screen.
+List<Drink> _createManyDrinks(int count) {
+  final producer = Producer.fromJson({
+    'id': 'brewery-1',
+    'name': 'Test Brewery',
+    'location': 'Cambridge',
+    'products': [],
+  });
+
+  return List.generate(count, (i) {
+    final product = Product.fromJson({
+      'id': 'drink-$i',
+      'name': 'Test Drink $i',
+      'category': 'beer',
+      'style': 'IPA',
+      'dispense': 'cask',
+      'abv': '5.0',
+    });
+    return Drink(
+      product: product,
+      producer: producer,
+      festivalId: testFestivalId,
+    );
+  });
+}
+
+void main() {
+  group('DrinksScreen scroll position survives push navigation', () {
+    late MockDrinkRepository mockDrinkRepository;
+    late MockFestivalRepository mockFestivalRepository;
+    late MockAnalyticsService mockAnalyticsService;
+    late BeerProvider provider;
+    late List<Drink> drinks;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      mockDrinkRepository = MockDrinkRepository();
+      mockFestivalRepository = MockFestivalRepository();
+      mockAnalyticsService = MockAnalyticsService();
+
+      drinks = _createManyDrinks(40);
+
+      const testFestival = Festival(
+        id: testFestivalId,
+        name: 'Cambridge Beer Festival 2025',
+        dataBaseUrl: 'https://test.example.com/cbf2025',
+      );
+      when(mockFestivalRepository.getFestivals()).thenAnswer(
+        (_) async => FestivalsResponse(
+          festivals: [testFestival],
+          defaultFestivalId: testFestivalId,
+          baseUrl: 'https://example.com',
+          version: '1.0.0',
+        ),
+      );
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
+      when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) async => drinks);
+
+      provider = BeerProvider(
+        drinkRepository: mockDrinkRepository,
+        festivalRepository: mockFestivalRepository,
+        analyticsService: mockAnalyticsService,
+      );
+      await provider.initialize();
+      await provider.loadDrinks();
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    Future<void> pumpApp(WidgetTester tester) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BeerProvider>.value(
+          value: provider,
+          child: MaterialApp.router(routerConfig: appRouter),
+        ),
+      );
+      appRouter.go('/$testFestivalId');
+      await tester.pumpAndSettle();
+    }
+
+    double drinksListScrollPixels(WidgetTester tester) {
+      final scrollable = find.descendant(
+        of: find.byType(CustomScrollView),
+        matching: find.byType(Scrollable),
+      );
+      return tester.state<ScrollableState>(scrollable.first).position.pixels;
+    }
+
+    /// Drags the drinks list down in small steps until [target] is built
+    /// (and therefore hit-testable). A single large fling can leave the
+    /// widget only within the sliver's cacheExtent — present in the tree
+    /// but off-screen and un-tappable — so small steps that stop as soon as
+    /// the target appears are used instead.
+    Future<void> scrollDownUntilVisible(
+      WidgetTester tester,
+      Finder target,
+    ) async {
+      for (var i = 0; i < 40; i++) {
+        if (target.evaluate().isNotEmpty) return;
+        await tester.drag(find.byType(CustomScrollView), const Offset(0, -300));
+        await tester.pump();
+      }
+      fail('Target widget never became visible after scrolling');
+    }
+
+    testWidgets(
+      'scroll position is preserved after navigating to drink detail and back',
+      (tester) async {
+        await pumpApp(tester);
+
+        // Sanity check: starts at the top.
+        expect(drinksListScrollPixels(tester), 0);
+
+        // Scroll the drinks list until a drink card well past the first
+        // screen (SliverList only builds items near the viewport, so a
+        // blind fling + "tap the first built DrinkCard" can hit a card
+        // that's in the tree via cacheExtent but not actually on-screen —
+        // scrolling in small steps until the target appears guarantees
+        // it's actually hit-testable before we tap it).
+        const targetKey = ValueKey('drink-30');
+        await scrollDownUntilVisible(tester, find.byKey(targetKey));
+        await tester.pumpAndSettle();
+
+        final scrolledPosition = drinksListScrollPixels(tester);
+        expect(
+          scrolledPosition,
+          greaterThan(0),
+          reason: 'Test setup check: the list must actually have scrolled',
+        );
+
+        // Tap the now-visible drink card — this exercises
+        // navigateToRoute() -> context.push().
+        await tester.tap(find.byKey(targetKey));
+        await tester.pumpAndSettle();
+
+        // The drink detail screen is now showing.
+        expect(find.byType(DrinkDetailScreen), findsOneWidget);
+
+        // Pop back to the drinks list.
+        appRouter.pop();
+        await tester.pumpAndSettle();
+
+        // The drinks list is showing again...
+        expect(find.byType(DrinksScreen), findsOneWidget);
+        // ...and its scroll position was never reset, because DrinksScreen
+        // was pushed-under (offstage), not disposed and recreated.
+        expect(drinksListScrollPixels(tester), scrolledPosition);
+      },
+    );
+
+    testWidgets('a freshly-loaded drinks list starts at scroll offset zero', (
+      tester,
+    ) async {
+      await pumpApp(tester);
+
+      expect(drinksListScrollPixels(tester), 0);
+    });
+  });
+}

--- a/test/drinks_screen_scroll_position_test.dart
+++ b/test/drinks_screen_scroll_position_test.dart
@@ -26,11 +26,10 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'provider_test.mocks.dart';
-
-const String testFestivalId = 'cbf2025';
+import 'router_test.dart' show testFestivalId;
 
 /// Generates enough drinks to scroll well past a single screen.
-List<Drink> _createManyDrinks(int count) {
+List<Drink> createSampleDrinks(int count) {
   final producer = Producer.fromJson({
     'id': 'brewery-1',
     'name': 'Test Brewery',
@@ -69,7 +68,7 @@ void main() {
       mockFestivalRepository = MockFestivalRepository();
       mockAnalyticsService = MockAnalyticsService();
 
-      drinks = _createManyDrinks(40);
+      drinks = createSampleDrinks(40);
 
       const testFestival = Festival(
         id: testFestivalId,
@@ -126,6 +125,12 @@ void main() {
     /// widget only within the sliver's cacheExtent — present in the tree
     /// but off-screen and un-tappable — so small steps that stop as soon as
     /// the target appears are used instead.
+    ///
+    /// WidgetTester.scrollUntilVisible() was tried here and rejected: it
+    /// requires its `scrollable` finder to resolve to exactly one
+    /// `Scrollable`, but this screen's subtree matches more than one (see
+    /// `drinksListScrollPixels()`'s `.first` above), so it throws
+    /// "Bad state: Too many elements" — confirmed by running it.
     Future<void> scrollDownUntilVisible(
       WidgetTester tester,
       Finder target,
@@ -182,13 +187,5 @@ void main() {
         expect(drinksListScrollPixels(tester), scrolledPosition);
       },
     );
-
-    testWidgets('a freshly-loaded drinks list starts at scroll offset zero', (
-      tester,
-    ) async {
-      await pumpApp(tester);
-
-      expect(drinksListScrollPixels(tester), 0);
-    });
   });
 }

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -1036,6 +1036,55 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'push()ing a drink detail route updates the URL via optionURLReflectsImperativeAPIs',
+      (tester) async {
+        // Proves the fix on the production appRouter (not just a standalone
+        // fixture): appRouter is built by _buildRouter() in router.dart,
+        // which sets GoRouter.optionURLReflectsImperativeAPIs = true before
+        // construction, so a real context.push() (what navigateToRoute()
+        // now always calls) updates the browser URL from inside the
+        // ShellRoute the same way context.go() used to.
+        await provider.initialize();
+
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: MaterialApp.router(routerConfig: appRouter),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Start at drinks list
+        appRouter.go('/$testFestivalId');
+        await tester.pumpAndSettle();
+
+        const category = 'beer';
+        appRouter.push('/$testFestivalId/drink/$category/$testDrinkId');
+        await tester.pumpAndSettle();
+
+        // routeInformationProvider.value.uri is what actually drives the
+        // browser URL bar for imperative navigation (push/pop), unlike
+        // routerDelegate.currentConfiguration.uri used above for go().
+        final uri = appRouter.routeInformationProvider.value.uri;
+        expect(
+          uri.pathSegments.length,
+          4,
+          reason:
+              'Drink detail URL must include festivalId, "drink", category, and drinkId',
+        );
+        expect(uri.pathSegments[0], testFestivalId);
+        expect(uri.pathSegments[1], 'drink');
+        expect(uri.pathSegments[2], category);
+        expect(
+          uri.pathSegments[3],
+          testDrinkId,
+          reason:
+              'URL must match deep-link format so shared/bookmarked links work',
+        );
+      },
+    );
   });
 
   group('Router Navigation Paths (Phase 1 - Festival-scoped)', () {

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -1009,8 +1009,10 @@ void main() {
         appRouter.go('/$testFestivalId');
         await tester.pumpAndSettle();
 
-        // On web, navigateToRoute() uses context.go so the URL updates.
-        // Simulate this by calling appRouter.go (equivalent on web).
+        // Exercises go()'s URL-update behavior directly (used for root/tab
+        // navigation, e.g. bottom nav in main.dart) — NOT what navigateToRoute()
+        // calls today; navigateToRoute() always uses push(), covered by the
+        // 'push()ing a drink detail route...' test below.
         const category = 'beer';
         appRouter.go('/$testFestivalId/drink/$category/$testDrinkId');
         await tester.pumpAndSettle();

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -13,9 +13,9 @@ import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'provider_test.mocks.dart';
+import 'router_test_constants.dart';
 
 // Test constants - single source of truth
-const String testFestivalId = 'cbf2025';
 const String testFestivalId2 = 'cbf2024';
 const String invalidFestivalId = 'invalid-festival-123';
 const String testDrinkId = 'test-drink-123';

--- a/test/router_test_constants.dart
+++ b/test/router_test_constants.dart
@@ -1,0 +1,9 @@
+/// Shared test constants used by multiple test files that exercise the real
+/// `appRouter` (e.g. router_test.dart, drinks_screen_scroll_position_test.dart).
+///
+/// Kept in a dedicated file (rather than one test importing another) so
+/// pulling in a shared value doesn't read as one test file depending on
+/// another's test suite.
+library;
+
+const String testFestivalId = 'cbf2025';

--- a/test/utils/navigation_helpers_test.dart
+++ b/test/utils/navigation_helpers_test.dart
@@ -277,41 +277,9 @@ void main() {
     });
 
     group('navigateToRoute', () {
-      testWidgets('navigates to the specified path', (tester) async {
-        bool detailVisited = false;
-        final router = GoRouter(
-          initialLocation: '/',
-          routes: [
-            GoRoute(
-              path: '/',
-              builder: (context, state) => Scaffold(
-                body: Builder(
-                  builder: (context) => ElevatedButton(
-                    onPressed: () => navigateToRoute(context, '/detail'),
-                    child: const Text('Navigate'),
-                  ),
-                ),
-              ),
-            ),
-            GoRoute(
-              path: '/detail',
-              builder: (context, state) {
-                detailVisited = true;
-                return const Scaffold(body: Text('Detail'));
-              },
-            ),
-          ],
-        );
-
-        await tester.pumpWidget(MaterialApp.router(routerConfig: router));
-        await tester.tap(find.text('Navigate'));
-        await tester.pumpAndSettle();
-
-        expect(detailVisited, isTrue);
-      });
-
       testWidgets(
-        'push() updates the URL and keeps the base route mounted underneath',
+        'navigates to the specified path, updates the URL, and keeps the '
+        'base route mounted underneath',
         (tester) async {
           // This is a standalone fixture GoRouter, separate from the app's
           // `appRouter`, so it must set the flag itself rather than relying
@@ -320,6 +288,7 @@ void main() {
           // another test (or router.dart's _buildRouter()) already set it.
           GoRouter.optionURLReflectsImperativeAPIs = true;
 
+          bool detailVisited = false;
           final baseKey = GlobalKey();
           final router = GoRouter(
             initialLocation: '/',
@@ -338,8 +307,10 @@ void main() {
               ),
               GoRoute(
                 path: '/detail',
-                builder: (context, state) =>
-                    const Scaffold(body: Text('Detail')),
+                builder: (context, state) {
+                  detailVisited = true;
+                  return const Scaffold(body: Text('Detail'));
+                },
               ),
             ],
           );
@@ -347,6 +318,8 @@ void main() {
           await tester.pumpWidget(MaterialApp.router(routerConfig: router));
           await tester.tap(find.text('Navigate'));
           await tester.pumpAndSettle();
+
+          expect(detailVisited, isTrue);
 
           // The URL bar reflects the pushed route rather than staying stuck
           // at '/' — this is the property that drives the real browser URL

--- a/test/utils/navigation_helpers_test.dart
+++ b/test/utils/navigation_helpers_test.dart
@@ -309,6 +309,60 @@ void main() {
 
         expect(detailVisited, isTrue);
       });
+
+      testWidgets(
+        'push() updates the URL and keeps the base route mounted underneath',
+        (tester) async {
+          // This is a standalone fixture GoRouter, separate from the app's
+          // `appRouter`, so it must set the flag itself rather than relying
+          // on router.dart's side effect. The flag is a process-global
+          // static; setting it to true here is safe and idempotent even if
+          // another test (or router.dart's _buildRouter()) already set it.
+          GoRouter.optionURLReflectsImperativeAPIs = true;
+
+          final baseKey = GlobalKey();
+          final router = GoRouter(
+            initialLocation: '/',
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (context, state) => Scaffold(
+                  key: baseKey,
+                  body: Builder(
+                    builder: (context) => ElevatedButton(
+                      onPressed: () => navigateToRoute(context, '/detail'),
+                      child: const Text('Navigate'),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: '/detail',
+                builder: (context, state) =>
+                    const Scaffold(body: Text('Detail')),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+          await tester.tap(find.text('Navigate'));
+          await tester.pumpAndSettle();
+
+          // The URL bar reflects the pushed route rather than staying stuck
+          // at '/' — this is the property that drives the real browser URL
+          // bar (NOT routerDelegate.currentConfiguration.uri, which does not
+          // reflect imperative pushes the same way).
+          expect(
+            router.routeInformationProvider.value.uri.toString(),
+            '/detail',
+          );
+
+          // The base route's widget is still present in the tree underneath
+          // the pushed route (offstage, not disposed) — proving push()
+          // preserves the calling screen's state instead of replacing it.
+          expect(find.byKey(baseKey, skipOffstage: false), findsOneWidget);
+        },
+      );
     });
 
     group('canPopNavigation', () {


### PR DESCRIPTION
## Summary

Fixes #470, but not via the approach the issue originally proposed. The issue asked to replace a provider-held scroll-offset workaround with Flutter state restoration — that workaround was never actually merged to `main` (it only exists on an unrelated, unmerged branch), and state restoration itself doesn't solve the problem: `RestorationBucket` data is destroyed when the owning widget disposes, which is exactly what happens when `context.go()` tears down `DrinksScreen` on web. Verified this empirically with a throwaway widget test before ruling it out.

The actual fix: `navigateToRoute()` used `context.go()` on web only because `context.push()` didn't update the browser URL bar from inside a `ShellRoute`. go_router has a documented (if under-advertised) flag for exactly this — `GoRouter.optionURLReflectsImperativeAPIs` — verified working against this app's real route structure. With it enabled:

- `lib/router.dart`: `appRouter` is now built by a `_buildRouter()` function that sets the flag before constructing the router. Every route this app ever pushes is a fully-formed, independently deep-linkable top-level `GoRoute`, so the upstream caution about non-deep-linkable top routes doesn't apply here (documented in the code comment).
- `lib/utils/navigation_helpers.dart`: `navigateToRoute()` now always calls `context.push()` instead of branching on `kIsWeb`.

Since `push()` nests the new route on top of the current Navigator instead of replacing it, `DrinksScreen` is never disposed during drill-down navigation — its scroll position (and all other state) survives automatically. No provider field, no `restorationId`, no route restructuring needed. This also benefits `BreweryScreen`/`StyleScreen`/`FestivalInfoScreen` the same way, not just the drinks list.

## Review findings and how they were handled

A multi-angle code review surfaced three real, architecturally-significant side effects of switching web to `push()`-always (all of them: web now simply matches behavior mobile has always had, since mobile's `navigateToRoute` already used `push()` unconditionally):

- **Home-button UX** (`lib/utils/widget_builders.dart`'s `buildHomeLeadingButton`) no longer shows on web detail screens, since `canPopNavigation()` is now true there too → filed #476 (low priority) for a deliberate design pass.
- **Navigator stack growth** for chained navigation (e.g. several "Similar Drinks" taps in a row) — more back-taps needed, buried screens keep their `context.watch` subscriptions alive → filed #477 (medium priority) to investigate a cap/pruning strategy.
- **Analytics**: `MyFestivalScreen`'s `logFestivalLogViewed()` no longer re-fires on a drink-detail round trip from My Festival on web, since the screen isn't remounted. Likely a metric correction (previously inflated by `go()`'s dispose/recreate cycle), not a bug — flagging here so nobody's surprised by a step-change in that event's volume in Firebase Analytics.

Confirmed lower-priority test-quality findings (stale comment, duplicated fixtures/constants, a test-factory naming-convention miss) were fixed directly in a follow-up commit on this branch.

## Test plan

- [x] `./bin/mise run check` (generate → analyze → test) — clean, all 1222 tests pass
- [x] New regression test (`test/drinks_screen_scroll_position_test.dart`): scrolls the real `DrinksScreen` (mounted under the real `appRouter`), navigates to a drink detail via a tap, pops back, asserts the scroll `ScrollPosition.pixels` is unchanged
- [x] New test in `test/router_test.dart` proving the production `appRouter` correctly updates the URL on `push()`, not just a standalone fixture
- [x] New test in `test/utils/navigation_helpers_test.dart` proving `navigateToRoute` updates the URL and keeps the calling screen mounted
- [ ] Manual browser verification (back/forward, bookmarking a pushed URL) — not something an agent can perform; flagging as outstanding


---
_Generated by [Claude Code](https://claude.ai/code/session_01SXt3CgRcijPh1WgYdjFo7H)_