### PR TITLE
fix(drinks): make drink card text areas tappable

### DIFF
--- a/lib/widgets/drink_card.dart
+++ b/lib/widgets/drink_card.dart
@@ -51,14 +51,17 @@ class DrinkCard extends StatelessWidget {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            SelectableText(
+                            // Plain Text, not SelectableText: the whole card
+                            // is a tap target, and text selection would
+                            // swallow the tap (see _SimilarDrinkCard below).
+                            Text(
                               drink.name,
                               style: theme.textTheme.titleMedium?.copyWith(
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
                             const SizedBox(height: 4),
-                            SelectableText(
+                            Text(
                               drink.breweryLocation.isNotEmpty
                                   ? '${drink.breweryName} • ${drink.breweryLocation}'
                                   : drink.breweryName,

--- a/lib/widgets/drink_card.dart
+++ b/lib/widgets/drink_card.dart
@@ -53,7 +53,8 @@ class DrinkCard extends StatelessWidget {
                           children: [
                             // Plain Text, not SelectableText: the whole card
                             // is a tap target, and text selection would
-                            // swallow the tap (see _SimilarDrinkCard below).
+                            // swallow the tap (same rationale as
+                            // _SimilarDrinkCard in drink_detail_screen.dart).
                             Text(
                               drink.name,
                               style: theme.textTheme.titleMedium?.copyWith(

--- a/test/widgets/drink_card_test.dart
+++ b/test/widgets/drink_card_test.dart
@@ -146,6 +146,34 @@ void main() {
       expect(tapped, isTrue);
     });
 
+    testWidgets('calls onTap when the drink name text is tapped', (
+      WidgetTester tester,
+    ) async {
+      bool tapped = false;
+      await tester.pumpWidget(
+        createTestWidget(drink: testDrink, onTap: () => tapped = true),
+      );
+
+      await tester.tap(find.text('Test IPA'));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('calls onTap when the brewery text is tapped', (
+      WidgetTester tester,
+    ) async {
+      bool tapped = false;
+      await tester.pumpWidget(
+        createTestWidget(drink: testDrink, onTap: () => tapped = true),
+      );
+
+      await tester.tap(find.textContaining('Test Brewery'));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isTrue);
+    });
+
     testWidgets('does not show style chip when style is null', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
## Problem

On web (and, less noticeably, on mobile), tapping a drink card in the main list sometimes highlights the card but never navigates to the detail screen — it feels slow or stuck, and varies from card to card.

Root cause: the drink name and brewery line in `DrinkCard` were rendered as `SelectableText` inside the card's `InkWell`. `SelectableText` installs its own tap recognizer (for cursor placement), which wins the gesture arena for any tap landing on the text glyphs — so the `InkWell` shows its highlight but `onTap` never fires. Taps on the padding/chips worked, which is why the behaviour seemed intermittent and worse on cards with long names (bigger text dead-zone). On web with a mouse, users click precisely on the drink name, making it most visible there.

The repo already documents this exact tradeoff: `_SimilarDrinkCard` in `drink_detail_screen.dart` deliberately uses plain `Text` because the card is a tap target.

## Change

- `lib/widgets/drink_card.dart` — drink-name and brewery-line `SelectableText` → plain `Text` (same styles), with a comment explaining why.
- `test/widgets/drink_card_test.dart` — two regression tests that tap the drink name and brewery text specifically. Both fail against the old code and pass now. (The pre-existing card-tap test only tapped the card centre, which lands on padding — that's why it never caught this.)

## Verification

- All 39 drink-card widget tests pass, including the 2 new regression tests.
- Drinks-screen test files pass (18 tests, including the card-tap navigation test).
- `dart format` clean; `analyze` shows zero issues in touched files.
- No goldens cover `DrinkCard`, so no golden updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdgM1RqJfHMZwsHiW5A7kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdgM1RqJfHMZwsHiW5A7kf)_