### PR TITLE
feat(web): set route-aware browser tab titles

### DIFF
--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -6,6 +6,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import '../constants.dart';
 import '../providers/providers.dart';
 import '../utils/utils.dart';
+import '../widgets/widgets.dart';
 
 /// Screen showing app information, version, and links
 class AboutScreen extends StatefulWidget {
@@ -81,29 +82,33 @@ class _AboutScreenState extends State<AboutScreen> {
   Widget build(BuildContext context) {
     final provider = context.watch<BeerProvider>();
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('About'),
-        leading: canPopNavigation(context)
-            ? null
-            : IconButton(
-                icon: const Icon(Icons.home),
-                tooltip: 'Home',
-                onPressed: () => context.go('/'),
-              ),
-      ),
-      body: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildHeader(context),
-            _buildAppInfo(context),
-            _buildBuildInfo(context),
-            _buildSettings(context, provider),
-            _buildLinks(context),
-            _buildLegalInfo(context),
-            const SizedBox(height: 32),
-          ],
+    return PageTitle(
+      pageTitle: 'About',
+      contextLabel: appName,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('About'),
+          leading: canPopNavigation(context)
+              ? null
+              : IconButton(
+                  icon: const Icon(Icons.home),
+                  tooltip: 'Home',
+                  onPressed: () => context.go('/'),
+                ),
+        ),
+        body: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildHeader(context),
+              _buildAppInfo(context),
+              _buildBuildInfo(context),
+              _buildSettings(context, provider),
+              _buildLinks(context),
+              _buildLegalInfo(context),
+              const SizedBox(height: 32),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/brewery_screen.dart
+++ b/lib/screens/brewery_screen.dart
@@ -79,37 +79,41 @@ class _BreweryScreenState extends State<BreweryScreen> {
         .toSet()
         .length;
 
-    return Scaffold(
-      body: CustomScrollView(
-        controller: _scrollController,
-        slivers: [
-          // Pinned bar: festival name at the top, fading to the brewery name
-          // once the hero card below scrolls off.
-          CollapsingDetailAppBar(
-            scrollController: _scrollController,
-            contextTitle: provider.currentFestival.name,
-            collapsedTitle: producer.name,
-            leading: buildHomeLeadingButton(context, widget.festivalId),
-          ),
-          // Identity hero
-          SliverToBoxAdapter(
-            child: BreweryHeroPanel(
-              producer: producer,
-              drinkCount: breweryDrinks.length,
-              styleCount: styleCount,
-              accentCategory: CategoryColorHelper.dominantCategory(
-                breweryDrinks,
+    return PageTitle(
+      pageTitle: producer.name,
+      contextLabel: provider.currentFestival.name,
+      child: Scaffold(
+        body: CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            // Pinned bar: festival name at the top, fading to the brewery name
+            // once the hero card below scrolls off.
+            CollapsingDetailAppBar(
+              scrollController: _scrollController,
+              contextTitle: provider.currentFestival.name,
+              collapsedTitle: producer.name,
+              leading: buildHomeLeadingButton(context, widget.festivalId),
+            ),
+            // Identity hero
+            SliverToBoxAdapter(
+              child: BreweryHeroPanel(
+                producer: producer,
+                drinkCount: breweryDrinks.length,
+                styleCount: styleCount,
+                accentCategory: CategoryColorHelper.dominantCategory(
+                  breweryDrinks,
+                ),
               ),
             ),
-          ),
-          // Drinks list
-          ...DrinkListSection.buildSlivers(
-            context: context,
-            festivalId: widget.festivalId,
-            title: 'Drinks',
-            drinks: breweryDrinks,
-          ),
-        ],
+            // Drinks list
+            ...DrinkListSection.buildSlivers(
+              context: context,
+              festivalId: widget.festivalId,
+              title: 'Drinks',
+              drinks: breweryDrinks,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -156,69 +156,75 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
 
     final theme = Theme.of(context);
 
-    return ScaffoldMessenger(
-      key: _messengerKey,
-      child: Scaffold(
-        // The one repeated action — logging a pour — floats; want-to-try,
-        // rating and share have moved to the hero / "Your take" card. Centred so
-        // it doesn't sit over the right-aligned tasting-log delete buttons.
-        floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-        floatingActionButton: ScaleTransition(
-          scale: _pulseScale,
-          child: FloatingActionButton.extended(
-            key: const ValueKey('tasted-action'),
-            onPressed: () => unawaited(_logTasting(provider, drink)),
-            icon: const Icon(Icons.add_circle_outline),
-            label: const Text('Drunk it!'),
-            tooltip: 'Log a tasting of ${drink.name}',
+    return PageTitle(
+      pageTitle: drink.name,
+      contextLabel: provider.currentFestival.name,
+      child: ScaffoldMessenger(
+        key: _messengerKey,
+        child: Scaffold(
+          // The one repeated action — logging a pour — floats; want-to-try,
+          // rating and share have moved to the hero / "Your take" card. Centred so
+          // it doesn't sit over the right-aligned tasting-log delete buttons.
+          floatingActionButtonLocation:
+              FloatingActionButtonLocation.centerFloat,
+          floatingActionButton: ScaleTransition(
+            scale: _pulseScale,
+            child: FloatingActionButton.extended(
+              key: const ValueKey('tasted-action'),
+              onPressed: () => unawaited(_logTasting(provider, drink)),
+              icon: const Icon(Icons.add_circle_outline),
+              label: const Text('Drunk it!'),
+              tooltip: 'Log a tasting of ${drink.name}',
+            ),
           ),
-        ),
-        body: CustomScrollView(
-          controller: _scrollController,
-          slivers: [
-            // Pinned bar: festival name at the top, fading to the drink name
-            // and brewery once the hero card below scrolls off.
-            CollapsingDetailAppBar(
-              scrollController: _scrollController,
-              contextTitle: provider.currentFestival.name,
-              collapsedTitle: drink.name,
-              collapsedSubtitle: drink.breweryName,
-              leading: buildHomeLeadingButton(context, widget.festivalId),
-            ),
-            // Identity hero — name, brewery link, ABV, facts strip, share.
-            SliverToBoxAdapter(
-              child: DrinkHeroPanel(
-                drink: drink,
-                onShareTap: () => unawaited(_shareDrink(context, drink)),
-                onBreweryTap: () => navigateToRoute(
-                  context,
-                  buildBreweryPath(widget.festivalId, drink.producerId),
+          body: CustomScrollView(
+            controller: _scrollController,
+            slivers: [
+              // Pinned bar: festival name at the top, fading to the drink name
+              // and brewery once the hero card below scrolls off.
+              CollapsingDetailAppBar(
+                scrollController: _scrollController,
+                contextTitle: provider.currentFestival.name,
+                collapsedTitle: drink.name,
+                collapsedSubtitle: drink.breweryName,
+                leading: buildHomeLeadingButton(context, widget.festivalId),
+              ),
+              // Identity hero — name, brewery link, ABV, facts strip, share.
+              SliverToBoxAdapter(
+                child: DrinkHeroPanel(
+                  drink: drink,
+                  onShareTap: () => unawaited(_shareDrink(context, drink)),
+                  onBreweryTap: () => navigateToRoute(
+                    context,
+                    buildBreweryPath(widget.festivalId, drink.producerId),
+                  ),
+                  onStyleTap: drink.style != null
+                      ? () => _navigateToStyleScreen(context, drink.style!)
+                      : null,
                 ),
-                onStyleTap: drink.style != null
-                    ? () => _navigateToStyleScreen(context, drink.style!)
-                    : null,
               ),
-            ),
-            // Your take — the user's own relationship to the drink (want-to-try,
-            // rating, note). Below the drink's content so ownership reads in two
-            // clean blocks: the drink, then you.
-            SliverToBoxAdapter(
-              child: YourTakeCard(
-                drink: drink,
-                onWantToTryTap: () => provider.toggleFavorite(drink),
-                onRatingChanged: (rating) => provider.setRating(drink, rating),
-                onEditNote: () => _editNotes(context, drink, provider),
+              // Your take — the user's own relationship to the drink (want-to-try,
+              // rating, note). Below the drink's content so ownership reads in two
+              // clean blocks: the drink, then you.
+              SliverToBoxAdapter(
+                child: YourTakeCard(
+                  drink: drink,
+                  onWantToTryTap: () => provider.toggleFavorite(drink),
+                  onRatingChanged: (rating) =>
+                      provider.setRating(drink, rating),
+                  onEditNote: () => _editNotes(context, drink, provider),
+                ),
               ),
-            ),
-            // Your tasting log — the record of pours.
-            SliverToBoxAdapter(
-              child: _buildTastingLog(context, drink, provider, theme),
-            ),
-            // Similar drinks — discovery content, kept last.
-            ..._buildSimilarDrinksSlivers(context, drink, provider),
-            // Extra bottom room so the floating button never covers content.
-            const SliverPadding(padding: EdgeInsets.only(bottom: 88)),
-          ],
+              // Your tasting log — the record of pours.
+              SliverToBoxAdapter(
+                child: _buildTastingLog(context, drink, provider, theme),
+              ),
+              // Similar drinks — discovery content, kept last.
+              ..._buildSimilarDrinksSlivers(context, drink, provider),
+              // Extra bottom room so the floating button never covers content.
+              const SliverPadding(padding: EdgeInsets.only(bottom: 88)),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -41,41 +41,44 @@ class _DrinksScreenState extends State<DrinksScreen> {
   Widget build(BuildContext context) {
     final provider = context.watch<BeerProvider>();
 
-    return Scaffold(
-      body: Column(
-        children: [
-          Expanded(
-            child: RefreshIndicator(
-              onRefresh: provider.loadDrinks,
-              child: CustomScrollView(
-                slivers: [
-                  SliverAppBar(
-                    floating: true,
-                    snap: true,
-                    title: FestivalHeader(provider: provider),
-                    actions: [buildOverflowMenu(context)],
-                  ),
-                  SliverToBoxAdapter(
-                    child: FestivalBanner(
-                      provider: provider,
-                      festivalId: widget.festivalId,
+    return PageTitle(
+      pageTitle: provider.currentFestival.name,
+      child: Scaffold(
+        body: Column(
+          children: [
+            Expanded(
+              child: RefreshIndicator(
+                onRefresh: provider.loadDrinks,
+                child: CustomScrollView(
+                  slivers: [
+                    SliverAppBar(
+                      floating: true,
+                      snap: true,
+                      title: FestivalHeader(provider: provider),
+                      actions: [buildOverflowMenu(context)],
                     ),
-                  ),
-                  SliverToBoxAdapter(
-                    child: _buildRefreshStatus(context, provider),
-                  ),
-                  if (_showSearch)
                     SliverToBoxAdapter(
-                      child: _buildSearchBar(context, provider),
+                      child: FestivalBanner(
+                        provider: provider,
+                        festivalId: widget.festivalId,
+                      ),
                     ),
-                  _buildDrinksListSliver(context, provider),
-                ],
+                    SliverToBoxAdapter(
+                      child: _buildRefreshStatus(context, provider),
+                    ),
+                    if (_showSearch)
+                      SliverToBoxAdapter(
+                        child: _buildSearchBar(context, provider),
+                      ),
+                    _buildDrinksListSliver(context, provider),
+                  ],
+                ),
               ),
             ),
-          ),
-          // Bottom controls for filtering, sorting, and search - thumb friendly
-          _buildBottomControls(context, provider),
-        ],
+            // Bottom controls for filtering, sorting, and search - thumb friendly
+            _buildBottomControls(context, provider),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/festival_info_screen.dart
+++ b/lib/screens/festival_info_screen.dart
@@ -5,6 +5,7 @@ import '../constants.dart';
 import '../models/models.dart';
 import '../providers/providers.dart';
 import '../utils/utils.dart';
+import '../widgets/widgets.dart';
 
 /// Screen showing detailed festival information
 class FestivalInfoScreen extends StatelessWidget {
@@ -16,32 +17,36 @@ class FestivalInfoScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final festival = context.watch<BeerProvider>().currentFestival;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Festival Info'),
-        leading: canPopNavigation(context)
-            ? null
-            : IconButton(
-                icon: const Icon(Icons.home),
-                tooltip: 'Home',
-                onPressed: () => context.go('/'),
-              ),
-      ),
-      body: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildHeader(context, festival),
-            _buildOverview(context, festival),
-            if (festival.location != null || festival.address != null)
-              _buildLocation(context, festival),
-            if (festival.hours != null && festival.hours!.isNotEmpty)
-              _buildHours(context, festival),
-            if (festival.description != null)
-              _buildDescription(context, festival),
-            _buildActions(context, festival),
-            const SizedBox(height: 32),
-          ],
+    return PageTitle(
+      pageTitle: 'Festival Info',
+      contextLabel: festival.name,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Festival Info'),
+          leading: canPopNavigation(context)
+              ? null
+              : IconButton(
+                  icon: const Icon(Icons.home),
+                  tooltip: 'Home',
+                  onPressed: () => context.go('/'),
+                ),
+        ),
+        body: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildHeader(context, festival),
+              _buildOverview(context, festival),
+              if (festival.location != null || festival.address != null)
+                _buildLocation(context, festival),
+              if (festival.hours != null && festival.hours!.isNotEmpty)
+                _buildHours(context, festival),
+              if (festival.description != null)
+                _buildDescription(context, festival),
+              _buildActions(context, festival),
+              const SizedBox(height: 32),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/my_festival_screen.dart
+++ b/lib/screens/my_festival_screen.dart
@@ -90,33 +90,37 @@ class _MyFestivalScreenState extends State<MyFestivalScreen> {
     final theme = Theme.of(context);
     final totalCount = wantToTry.length + tasted.length;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              provider.currentFestival.name,
-              style: theme.textTheme.titleMedium,
-            ),
-            Text(
-              '$totalCount in My Festival',
-              style: theme.textTheme.bodySmall,
-            ),
-          ],
+    return PageTitle(
+      pageTitle: 'My Festival',
+      contextLabel: provider.currentFestival.name,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                provider.currentFestival.name,
+                style: theme.textTheme.titleMedium,
+              ),
+              Text(
+                '$totalCount in My Festival',
+                style: theme.textTheme.bodySmall,
+              ),
+            ],
+          ),
+          actions: [buildOverflowMenu(context)],
         ),
-        actions: [buildOverflowMenu(context)],
+        body: wantToTry.isEmpty && tasted.isEmpty
+            ? _buildEmptyState(theme)
+            : ListView(
+                padding: const EdgeInsets.only(bottom: 16),
+                children: [
+                  ..._buildWantToTrySection(context, festivalId, wantToTry),
+                  const Divider(height: 32, thickness: 1),
+                  ..._buildTastedSection(context, festivalId, tasted, theme),
+                ],
+              ),
       ),
-      body: wantToTry.isEmpty && tasted.isEmpty
-          ? _buildEmptyState(theme)
-          : ListView(
-              padding: const EdgeInsets.only(bottom: 16),
-              children: [
-                ..._buildWantToTrySection(context, festivalId, wantToTry),
-                const Divider(height: 32, thickness: 1),
-                ..._buildTastedSection(context, festivalId, tasted, theme),
-              ],
-            ),
     );
   }
 

--- a/lib/screens/style_screen.dart
+++ b/lib/screens/style_screen.dart
@@ -75,42 +75,48 @@ class _StyleScreenState extends State<StyleScreen> {
         styleDrinks.map((d) => d.abv).reduce((a, b) => a + b) /
         styleDrinks.length;
 
-    return Scaffold(
-      body: CustomScrollView(
-        controller: _scrollController,
-        slivers: [
-          // Pinned bar: festival name at the top, fading to the style name once
-          // the hero card below scrolls off.
-          CollapsingDetailAppBar(
-            scrollController: _scrollController,
-            contextTitle: provider.currentFestival.name,
-            collapsedTitle: displayStyle,
-            leading: buildHomeLeadingButton(context, widget.festivalId),
-          ),
-          // Identity hero — the description slots into the same card once the
-          // future resolves, so the about section appears in place.
-          SliverToBoxAdapter(
-            child: FutureBuilder<String?>(
-              future: StyleDescriptionHelper.getStyleDescription(widget.style),
-              builder: (context, snapshot) {
-                return StyleHeroPanel(
-                  styleName: displayStyle,
-                  category: category,
-                  drinkCount: styleDrinks.length,
-                  averageAbv: avgABV,
-                  description: snapshot.data,
-                );
-              },
+    return PageTitle(
+      pageTitle: displayStyle,
+      contextLabel: provider.currentFestival.name,
+      child: Scaffold(
+        body: CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            // Pinned bar: festival name at the top, fading to the style name once
+            // the hero card below scrolls off.
+            CollapsingDetailAppBar(
+              scrollController: _scrollController,
+              contextTitle: provider.currentFestival.name,
+              collapsedTitle: displayStyle,
+              leading: buildHomeLeadingButton(context, widget.festivalId),
             ),
-          ),
-          // Drinks list
-          ...DrinkListSection.buildSlivers(
-            context: context,
-            festivalId: widget.festivalId,
-            title: 'Drinks',
-            drinks: styleDrinks,
-          ),
-        ],
+            // Identity hero — the description slots into the same card once the
+            // future resolves, so the about section appears in place.
+            SliverToBoxAdapter(
+              child: FutureBuilder<String?>(
+                future: StyleDescriptionHelper.getStyleDescription(
+                  widget.style,
+                ),
+                builder: (context, snapshot) {
+                  return StyleHeroPanel(
+                    styleName: displayStyle,
+                    category: category,
+                    drinkCount: styleDrinks.length,
+                    averageAbv: avgABV,
+                    description: snapshot.data,
+                  );
+                },
+              ),
+            ),
+            // Drinks list
+            ...DrinkListSection.buildSlivers(
+              context: context,
+              festivalId: widget.festivalId,
+              title: 'Drinks',
+              drinks: styleDrinks,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/page_title.dart
+++ b/lib/widgets/page_title.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Sets the browser tab / OS task-switcher title for the screen it wraps.
+///
+/// On web this drives `document.title`, so the browser tab reads something
+/// useful (e.g. "Adnams Ghost Ship · Cambridge Beer Festival 2025") instead of
+/// falling back to the raw URL. On mobile it updates the app's entry in the OS
+/// task switcher. It renders no visual output of its own — it only wraps [child]
+/// in a [Title] widget — so it has no effect on goldens.
+///
+/// [pageTitle] is the page-specific part. When [contextLabel] is non-empty it is
+/// appended after a middot separator, giving a consistent
+/// "{page} · {context}" shape across screens; pass the festival name as
+/// [contextLabel] on festival-scoped screens.
+class PageTitle extends StatelessWidget {
+  const PageTitle({
+    required this.pageTitle,
+    this.contextLabel,
+    required this.child,
+    super.key,
+  });
+
+  /// The page-specific part of the title (drink name, "My Festival", etc.).
+  final String pageTitle;
+
+  /// Optional trailing context appended after a separator — typically the
+  /// festival name. When null or empty, only [pageTitle] is shown.
+  final String? contextLabel;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final suffix = contextLabel;
+    final title = (suffix == null || suffix.isEmpty)
+        ? pageTitle
+        : '$pageTitle · $suffix';
+    return Title(
+      title: title,
+      color: Theme.of(context).colorScheme.primary,
+      child: child,
+    );
+  }
+}

--- a/lib/widgets/page_title.dart
+++ b/lib/widgets/page_title.dart
@@ -35,6 +35,9 @@ class PageTitle extends StatelessWidget {
     final title = (suffix == null || suffix.isEmpty)
         ? pageTitle
         : '$pageTitle · $suffix';
+    // Colour is used only for the OS task-switcher tint on mobile (ignored on
+    // web). Theme.of never returns null — it falls back to a default theme when
+    // no ancestor is present — so this is safe even in a minimal test tree.
     return Title(
       title: title,
       color: Theme.of(context).colorScheme.primary,

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -15,6 +15,7 @@ export 'festival_header.dart';
 export 'festival_menu_sheets.dart';
 export 'info_chip.dart';
 export 'overflow_menu.dart';
+export 'page_title.dart';
 export 'section_header.dart';
 export 'star_rating.dart';
 export 'style_hero_panel.dart';

--- a/test/widgets/page_title_test.dart
+++ b/test/widgets/page_title_test.dart
@@ -2,14 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cambridge_beer_festival/widgets/widgets.dart';
 
-/// Finds the [Title] whose composed [Title.title] equals [expected].
+/// The composed titles of every [Title] widget in the tree.
 ///
-/// A [MaterialApp] inserts its own [Title] widget, so we can't just grab the
-/// first — we assert on the specific title our widget composed.
-Title _titleWith(WidgetTester tester, String expected) {
-  return tester
-      .widgetList<Title>(find.byType(Title))
-      .firstWhere((t) => t.title == expected);
+/// A [MaterialApp] inserts its own [Title], so we assert that our composed
+/// title is present among them rather than assuming ours is the only one.
+/// Returning the full list lets `contains(...)` report every actual title on
+/// failure, which is clearer than a `firstWhere` that throws before the
+/// expectation runs.
+Iterable<String> _titles(WidgetTester tester) {
+  return tester.widgetList<Title>(find.byType(Title)).map((t) => t.title);
 }
 
 void main() {
@@ -24,7 +25,7 @@ void main() {
         ),
       );
 
-      expect(_titleWith(tester, 'Cambridge Beer Festival 2025'), isNotNull);
+      expect(_titles(tester), contains('Cambridge Beer Festival 2025'));
     });
 
     testWidgets('joins pageTitle and contextLabel with a separator', (
@@ -41,8 +42,8 @@ void main() {
       );
 
       expect(
-        _titleWith(tester, 'Adnams Ghost Ship · Cambridge Beer Festival 2025'),
-        isNotNull,
+        _titles(tester),
+        contains('Adnams Ghost Ship · Cambridge Beer Festival 2025'),
       );
     });
 
@@ -57,7 +58,7 @@ void main() {
         ),
       );
 
-      expect(_titleWith(tester, 'About'), isNotNull);
+      expect(_titles(tester), contains('About'));
     });
 
     testWidgets('renders its child', (tester) async {

--- a/test/widgets/page_title_test.dart
+++ b/test/widgets/page_title_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cambridge_beer_festival/widgets/widgets.dart';
+
+/// Finds the [Title] whose composed [Title.title] equals [expected].
+///
+/// A [MaterialApp] inserts its own [Title] widget, so we can't just grab the
+/// first — we assert on the specific title our widget composed.
+Title _titleWith(WidgetTester tester, String expected) {
+  return tester
+      .widgetList<Title>(find.byType(Title))
+      .firstWhere((t) => t.title == expected);
+}
+
+void main() {
+  group('PageTitle', () {
+    testWidgets('shows only pageTitle when no contextLabel', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: PageTitle(
+            pageTitle: 'Cambridge Beer Festival 2025',
+            child: Scaffold(),
+          ),
+        ),
+      );
+
+      expect(_titleWith(tester, 'Cambridge Beer Festival 2025'), isNotNull);
+    });
+
+    testWidgets('joins pageTitle and contextLabel with a separator', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: PageTitle(
+            pageTitle: 'Adnams Ghost Ship',
+            contextLabel: 'Cambridge Beer Festival 2025',
+            child: Scaffold(),
+          ),
+        ),
+      );
+
+      expect(
+        _titleWith(tester, 'Adnams Ghost Ship · Cambridge Beer Festival 2025'),
+        isNotNull,
+      );
+    });
+
+    testWidgets('treats an empty contextLabel like no context', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: PageTitle(
+            pageTitle: 'About',
+            contextLabel: '',
+            child: Scaffold(),
+          ),
+        ),
+      );
+
+      expect(_titleWith(tester, 'About'), isNotNull);
+    });
+
+    testWidgets('renders its child', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: PageTitle(
+            pageTitle: 'About',
+            child: Scaffold(body: Text('body content')),
+          ),
+        ),
+      );
+
+      expect(find.text('body content'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
The browser tab previously fell back to showing the raw URL because the
app set a single static MaterialApp title and no route updated
document.title per screen.

Add a small PageTitle widget (a Title wrapper that composes
"{page} · {festival}") and wrap each screen so the tab reads useful
context:

- Drinks (home)   -> festival name
- Drink detail    -> "{drink} · {festival}"
- Brewery         -> "{brewery} · {festival}"
- Style           -> "{style} · {festival}"
- My Festival     -> "My Festival · {festival}"
- Festival Info   -> "Festival Info · {festival}"
- About           -> "About · Cambridge Beer Festival"

PageTitle renders no visual output (it returns its child), so goldens
and semantics are unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XE8qosCiYsoxqyyh8m8mEb