### PR TITLE
feat(drink-detail): inline autosaving notes and undo for tasting delete

### DIFF
--- a/lib/domain/services/drink_filter_service.dart
+++ b/lib/domain/services/drink_filter_service.dart
@@ -101,12 +101,18 @@ class DrinkFilterService {
   Iterable<Drink> filterBySearch(Iterable<Drink> drinks, String query) {
     if (query.isEmpty) return drinks;
     final lowerQuery = query.toLowerCase();
-    return drinks.where((d) {
-      return d.name.toLowerCase().contains(lowerQuery) ||
-          d.breweryName.toLowerCase().contains(lowerQuery) ||
-          (d.style?.toLowerCase().contains(lowerQuery) ?? false) ||
-          (d.notes?.toLowerCase().contains(lowerQuery) ?? false);
-    });
+    return drinks.where((d) => _matchesSearch(d, lowerQuery));
+  }
+
+  /// Whether a drink matches an already-lowercased search query. Covers the
+  /// catalogue fields (name, brewery, style, description) and the user's own
+  /// note, so a personal marker like a friend's name finds the drink again.
+  bool _matchesSearch(Drink d, String lowerQuery) {
+    return d.name.toLowerCase().contains(lowerQuery) ||
+        d.breweryName.toLowerCase().contains(lowerQuery) ||
+        (d.style?.toLowerCase().contains(lowerQuery) ?? false) ||
+        (d.notes?.toLowerCase().contains(lowerQuery) ?? false) ||
+        (d.userNotes?.toLowerCase().contains(lowerQuery) ?? false);
   }
 
   /// Filter drinks with multiple criteria
@@ -164,12 +170,7 @@ class DrinkFilterService {
 
     if (searchQuery.isNotEmpty) {
       final lowerQuery = searchQuery.toLowerCase();
-      result = result.where((d) {
-        return d.name.toLowerCase().contains(lowerQuery) ||
-            d.breweryName.toLowerCase().contains(lowerQuery) ||
-            (d.style?.toLowerCase().contains(lowerQuery) ?? false) ||
-            (d.notes?.toLowerCase().contains(lowerQuery) ?? false);
-      });
+      result = result.where((d) => _matchesSearch(d, lowerQuery));
     }
 
     return result.toList();

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -807,7 +807,9 @@ class BeerProvider extends ChangeNotifier {
   /// Record a new tasting event for a drink, returning the timestamp of the
   /// pour that was logged. The provider owns the timestamp (rather than letting
   /// the store generate it) so callers can offer a precise Undo that removes
-  /// exactly this pour, not merely the newest one.
+  /// exactly this pour, not merely the newest one. Pass [at] to restore a
+  /// previously removed pour with its original timestamp (an Undo), which is
+  /// not counted as a new tasting in analytics.
   Future<DateTime> addTasting(Drink drink, {DateTime? at}) async {
     final event = at ?? DateTime.now();
     if (_drinkRepository == null) return event;
@@ -824,11 +826,17 @@ class BeerProvider extends ChangeNotifier {
 
     notifyListeners();
 
-    // Log analytics event
-    unawaited(_analyticsService.logFestivalLogMarkTasted(drink));
-    final count = newState?.tastingCount ?? 0;
-    if (count > 1) {
-      unawaited(_analyticsService.logFestivalLogMultipleTasting(drink, count));
+    // Only a genuinely new pour is an analytics event — restoring a deleted
+    // one via Undo (at != null) would double-count tastings that already
+    // happened.
+    if (at == null) {
+      unawaited(_analyticsService.logFestivalLogMarkTasted(drink));
+      final count = newState?.tastingCount ?? 0;
+      if (count > 1) {
+        unawaited(
+          _analyticsService.logFestivalLogMultipleTasting(drink, count),
+        );
+      }
     }
     return event;
   }

--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -808,8 +808,8 @@ class BeerProvider extends ChangeNotifier {
   /// pour that was logged. The provider owns the timestamp (rather than letting
   /// the store generate it) so callers can offer a precise Undo that removes
   /// exactly this pour, not merely the newest one.
-  Future<DateTime> addTasting(Drink drink) async {
-    final event = DateTime.now();
+  Future<DateTime> addTasting(Drink drink, {DateTime? at}) async {
+    final event = at ?? DateTime.now();
     if (_drinkRepository == null) return event;
 
     final newState = _personalState.apply(

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -46,6 +46,10 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
   // the hero card scrolls under it.
   final ScrollController _scrollController = ScrollController();
 
+  // Whether the inline note in YourTakeCard is being edited — the FAB hides
+  // while it is, so it can't sit over the field when the keyboard is up.
+  bool _isEditingNote = false;
+
   @override
   void initState() {
     super.initState();
@@ -178,16 +182,20 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
           // it doesn't sit over the right-aligned tasting-log delete buttons.
           floatingActionButtonLocation:
               FloatingActionButtonLocation.centerFloat,
-          floatingActionButton: ScaleTransition(
-            scale: _pulseScale,
-            child: FloatingActionButton.extended(
-              key: const ValueKey('tasted-action'),
-              onPressed: () => unawaited(_logTasting(provider, drink)),
-              icon: const Icon(Icons.add_circle_outline),
-              label: const Text('Drunk it!'),
-              tooltip: 'Log a tasting of ${drink.name}',
-            ),
-          ),
+          // Hidden while the inline note is being edited — with the keyboard
+          // up, a centre-floating FAB lands exactly on top of the note field.
+          floatingActionButton: _isEditingNote
+              ? null
+              : ScaleTransition(
+                  scale: _pulseScale,
+                  child: FloatingActionButton.extended(
+                    key: const ValueKey('tasted-action'),
+                    onPressed: () => unawaited(_logTasting(provider, drink)),
+                    icon: const Icon(Icons.add_circle_outline),
+                    label: const Text('Drunk it!'),
+                    tooltip: 'Log a tasting of ${drink.name}',
+                  ),
+                ),
           body: CustomScrollView(
             controller: _scrollController,
             slivers: [
@@ -226,6 +234,8 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
                       provider.setRating(drink, rating),
                   onNotesChanged: (notes) =>
                       provider.setUserNotes(drink, notes),
+                  onEditingChanged: (editing) =>
+                      setState(() => _isEditingNote = editing),
                 ),
               ),
               // Your tasting log — the record of pours.

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -213,7 +213,8 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
                   onWantToTryTap: () => provider.toggleFavorite(drink),
                   onRatingChanged: (rating) =>
                       provider.setRating(drink, rating),
-                  onEditNote: () => _editNotes(context, drink, provider),
+                  onNotesChanged: (notes) =>
+                      provider.setUserNotes(drink, notes),
                 ),
               ),
               // Your tasting log — the record of pours.
@@ -302,12 +303,14 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
           Semantics(
             label: 'Remove tasting ${index + 1} of $count, $label',
             button: true,
+            hint: 'Double tap to remove immediately. Undo available after.',
             child: IconButton(
               key: ValueKey('delete-tasting-$index'),
               icon: const Icon(Icons.delete_outline, size: 20),
               tooltip: 'Remove this tasting',
-              onPressed: () =>
-                  _confirmDeleteTasting(context, drink, provider, event),
+              onPressed: () => unawaited(
+                _deleteTastingWithUndo(context, drink, provider, event),
+              ),
             ),
           ),
         ],
@@ -315,58 +318,44 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
     );
   }
 
-  Future<void> _confirmDeleteTasting(
+  /// Remove a tasting immediately (no confirmation dialog) and offer Undo,
+  /// mirroring [_logTasting]'s SnackBar shape and Undo pattern.
+  Future<void> _deleteTastingWithUndo(
     BuildContext context,
     Drink drink,
     BeerProvider provider,
     DateTime event,
   ) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Remove this tasting?'),
-        content: Text(
-          'This removes the tasting recorded on '
-          '${_tastingRowFormat.format(event)}.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: const Text('Remove'),
-          ),
-        ],
-      ),
-    );
-    if (confirmed ?? false) {
-      await provider.removeTasting(drink, event);
-    }
-  }
+    final messenger = _messengerKey.currentState;
+    unawaited(HapticFeedback.mediumImpact());
 
-  Future<void> _editNotes(
-    BuildContext context,
-    Drink drink,
-    BeerProvider provider,
-  ) async {
-    // The sheet owns its TextEditingController lifecycle (see
-    // [_NotesEditorSheet]) so the controller outlives the route's exit
-    // animation — disposing it here would crash mid-transition.
-    final result = await showModalBottomSheet<String?>(
-      context: context,
-      isScrollControlled: true,
-      builder: (sheetContext) => _NotesEditorSheet(
-        drinkName: drink.name,
-        initialText: drink.userNotes ?? '',
-      ),
-    );
-    // A null result means "cancelled"; only persist on an explicit save.
-    if (result != null) {
-      final trimmed = result.trim();
-      await provider.setUserNotes(drink, trimmed.isEmpty ? null : trimmed);
-    }
+    await provider.removeTasting(drink, event);
+    if (!mounted || messenger == null) return;
+
+    final message = 'Removed — ${_tastingRowFormat.format(event)}';
+
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          behavior: SnackBarBehavior.floating,
+          margin: const EdgeInsets.only(bottom: 12, left: 16, right: 16),
+          duration: const Duration(seconds: 3),
+          content: Semantics(
+            label: message,
+            button: true,
+            hint: 'Double tap to dismiss',
+            child: GestureDetector(
+              onTap: messenger.hideCurrentSnackBar,
+              child: Text(message),
+            ),
+          ),
+          action: SnackBarAction(
+            label: 'Undo',
+            onPressed: () => unawaited(provider.addTasting(drink, at: event)),
+          ),
+        ),
+      );
   }
 
   List<Widget> _buildSimilarDrinksSlivers(
@@ -624,105 +613,5 @@ class _SimilarDrinkCard extends StatelessWidget {
       buffer.write(' Added to want to try.');
     }
     return buffer.toString();
-  }
-}
-
-/// A roomy bottom sheet for editing a drink's personal notes. It owns its
-/// [TextEditingController] so the controller is disposed only when the sheet is
-/// unmounted — after the route's exit animation — avoiding a "used after being
-/// disposed" crash. Pops the entered text on Save, or `null` on Cancel/dismiss.
-class _NotesEditorSheet extends StatefulWidget {
-  final String drinkName;
-  final String initialText;
-
-  const _NotesEditorSheet({required this.drinkName, required this.initialText});
-
-  @override
-  State<_NotesEditorSheet> createState() => _NotesEditorSheetState();
-}
-
-class _NotesEditorSheetState extends State<_NotesEditorSheet> {
-  late final TextEditingController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = TextEditingController(text: widget.initialText);
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    // Grow with the keyboard so the field and actions stay visible.
-    return Padding(
-      padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
-      ),
-      child: SafeArea(
-        top: false,
-        // Scrollable so the field + actions never overflow when the keyboard
-        // leaves little vertical room (e.g. landscape, or large text scale).
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Center(
-                child: Container(
-                  width: 36,
-                  height: 4,
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.outlineVariant,
-                    borderRadius: BorderRadius.circular(2),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 14),
-              Text(
-                'Notes for ${widget.drinkName}',
-                style: theme.textTheme.titleMedium,
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                key: const ValueKey('user-notes-field'),
-                controller: _controller,
-                autofocus: true,
-                maxLines: 6,
-                minLines: 3,
-                textCapitalization: TextCapitalization.sentences,
-                decoration: const InputDecoration(
-                  hintText: 'What did you think?',
-                  border: OutlineInputBorder(),
-                ),
-              ),
-              const SizedBox(height: 12),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(null),
-                    child: const Text('Cancel'),
-                  ),
-                  const SizedBox(width: 8),
-                  FilledButton(
-                    onPressed: () =>
-                        Navigator.of(context).pop(_controller.text),
-                    child: const Text('Save'),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -236,6 +236,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
                       provider.setUserNotes(drink, notes),
                   onEditingChanged: (editing) =>
                       setState(() => _isEditingNote = editing),
+                  onLogTasting: () => unawaited(_logTasting(provider, drink)),
                 ),
               ),
               // Your tasting log — the record of pours.

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -236,7 +236,6 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
                       provider.setUserNotes(drink, notes),
                   onEditingChanged: (editing) =>
                       setState(() => _isEditingNote = editing),
-                  onLogTasting: () => unawaited(_logTasting(provider, drink)),
                 ),
               ),
               // Your tasting log — the record of pours.

--- a/lib/screens/drink_detail_screen.dart
+++ b/lib/screens/drink_detail_screen.dart
@@ -108,6 +108,20 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
         ? 'Logged your first tasting'
         : 'Logged — $count tastings';
 
+    _showUndoSnackBar(
+      messenger,
+      message: message,
+      onUndo: () => unawaited(provider.removeTasting(updated, event)),
+    );
+  }
+
+  /// The shared confirmation shape for reversible tasting mutations: a
+  /// floating SnackBar whose message dismisses on tap, with an Undo action.
+  void _showUndoSnackBar(
+    ScaffoldMessengerState messenger, {
+    required String message,
+    required VoidCallback onUndo,
+  }) {
     messenger
       ..hideCurrentSnackBar()
       ..showSnackBar(
@@ -128,10 +142,7 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
               child: Text(message),
             ),
           ),
-          action: SnackBarAction(
-            label: 'Undo',
-            onPressed: () => unawaited(provider.removeTasting(updated, event)),
-          ),
+          action: SnackBarAction(label: 'Undo', onPressed: onUndo),
         ),
       );
   }
@@ -332,30 +343,11 @@ class _DrinkDetailScreenState extends State<DrinkDetailScreen>
     await provider.removeTasting(drink, event);
     if (!mounted || messenger == null) return;
 
-    final message = 'Removed — ${_tastingRowFormat.format(event)}';
-
-    messenger
-      ..hideCurrentSnackBar()
-      ..showSnackBar(
-        SnackBar(
-          behavior: SnackBarBehavior.floating,
-          margin: const EdgeInsets.only(bottom: 12, left: 16, right: 16),
-          duration: const Duration(seconds: 3),
-          content: Semantics(
-            label: message,
-            button: true,
-            hint: 'Double tap to dismiss',
-            child: GestureDetector(
-              onTap: messenger.hideCurrentSnackBar,
-              child: Text(message),
-            ),
-          ),
-          action: SnackBarAction(
-            label: 'Undo',
-            onPressed: () => unawaited(provider.addTasting(drink, at: event)),
-          ),
-        ),
-      );
+    _showUndoSnackBar(
+      messenger,
+      message: 'Removed — ${_tastingRowFormat.format(event)}',
+      onUndo: () => unawaited(provider.addTasting(drink, at: event)),
+    );
   }
 
   List<Widget> _buildSimilarDrinksSlivers(

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -140,7 +140,10 @@ class _YourTakeCardState extends State<YourTakeCard> {
       _hasPendingEdit = true;
       return;
     }
-    if (!mounted) return;
+    // If the user typed again while this save was in flight, the newest text
+    // is not persisted yet — claiming "Saved" now would be a lie. The pending
+    // edit's own flush will show the indicator when it lands.
+    if (!mounted || _hasPendingEdit) return;
     _savedIndicatorTimer?.cancel();
     setState(() => _showSaved = true);
     _savedIndicatorTimer = Timer(YourTakeCard.savedIndicatorDuration, () {
@@ -293,18 +296,22 @@ class _YourTakeCardState extends State<YourTakeCard> {
             ),
             SizedBox(
               height: 16,
-              child: Semantics(
-                liveRegion: true,
-                label: _showSaved ? 'Saved' : '',
-                child: _showSaved
-                    ? Text(
+              // Only mount the live region while it has something to say —
+              // the same conditional pattern as the refresh indicator in
+              // drinks_screen.dart. A persistent node with an empty label
+              // would sit in the semantics tree saying nothing.
+              child: _showSaved
+                  ? Semantics(
+                      liveRegion: true,
+                      label: 'Saved',
+                      child: Text(
                         'Saved',
                         style: theme.textTheme.labelSmall?.copyWith(
                           color: theme.colorScheme.primary,
                         ),
-                      )
-                    : const SizedBox.shrink(),
-              ),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
             ),
           ],
         ),

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import '../models/models.dart';
 import 'star_rating.dart';
@@ -9,7 +10,12 @@ import 'star_rating.dart';
 /// The drink's own facts live in the hero; nothing here describes the drink
 /// itself. Actions are delegated to callbacks so the screen keeps ownership of
 /// the provider and analytics.
-class YourTakeCard extends StatelessWidget {
+///
+/// Notes are edited in place: tapping the note row opens an inline, borderless
+/// [TextField]. Typing debounces to an autosave (no explicit Save/Cancel), and
+/// losing focus flushes immediately so a save is never lost to a stray tap
+/// elsewhere on the screen.
+class YourTakeCard extends StatefulWidget {
   final Drink drink;
 
   /// Toggle the want-to-try flag.
@@ -18,16 +24,114 @@ class YourTakeCard extends StatelessWidget {
   /// Set (or clear, with null) the star rating.
   final ValueChanged<int?> onRatingChanged;
 
-  /// Open the note editor.
-  final VoidCallback onEditNote;
+  /// Persist the note text (trimmed; empty becomes null).
+  final Future<void> Function(String? notes) onNotesChanged;
 
   const YourTakeCard({
     required this.drink,
     required this.onWantToTryTap,
     required this.onRatingChanged,
-    required this.onEditNote,
+    required this.onNotesChanged,
     super.key,
   });
+
+  /// How long to wait after the last keystroke before autosaving. Exposed for
+  /// tests so they can advance virtual time deterministically instead of
+  /// guessing at a real-world delay.
+  @visibleForTesting
+  static const Duration notesDebounceDuration = Duration(milliseconds: 600);
+
+  /// How long the "Saved" indicator stays visible after a successful save.
+  @visibleForTesting
+  static const Duration savedIndicatorDuration = Duration(seconds: 2);
+
+  @override
+  State<YourTakeCard> createState() => _YourTakeCardState();
+}
+
+class _YourTakeCardState extends State<YourTakeCard> {
+  late final TextEditingController _notesController;
+  final FocusNode _notesFocusNode = FocusNode();
+  Timer? _debounceTimer;
+  Timer? _savedIndicatorTimer;
+  bool _isEditing = false;
+  bool _showSaved = false;
+  String? _lastSavedNotes;
+  String? _pendingNotes;
+
+  @override
+  void initState() {
+    super.initState();
+    _lastSavedNotes = widget.drink.userNotes;
+    _notesController = TextEditingController(text: _lastSavedNotes ?? '');
+    _notesFocusNode.addListener(_handleFocusChange);
+  }
+
+  @override
+  void didUpdateWidget(covariant YourTakeCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // An autosave's own provider rebuild must not stomp text the user is
+    // actively typing — only resync from upstream while not editing.
+    if (!_isEditing && widget.drink.userNotes != oldWidget.drink.userNotes) {
+      _lastSavedNotes = widget.drink.userNotes;
+      _notesController.text = _lastSavedNotes ?? '';
+    }
+  }
+
+  @override
+  void dispose() {
+    _debounceTimer?.cancel();
+    _savedIndicatorTimer?.cancel();
+    // Best-effort flush: if there's a debounced save that hasn't landed yet,
+    // fire it now rather than silently dropping the user's last edit.
+    if (_pendingNotes != null && _pendingNotes != _lastSavedNotes) {
+      unawaited(widget.onNotesChanged(_pendingNotes));
+    }
+    _notesFocusNode
+      ..removeListener(_handleFocusChange)
+      ..dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  void _handleFocusChange() {
+    if (!_notesFocusNode.hasFocus && _isEditing) {
+      unawaited(_flushSave());
+      setState(() => _isEditing = false);
+    }
+  }
+
+  void _beginEditing() {
+    setState(() => _isEditing = true);
+    _notesFocusNode.requestFocus();
+  }
+
+  void _onFieldChanged(String value) {
+    final trimmed = value.trim();
+    _pendingNotes = trimmed.isEmpty ? null : trimmed;
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(
+      YourTakeCard.notesDebounceDuration,
+      () => unawaited(_flushSave()),
+    );
+  }
+
+  Future<void> _flushSave() async {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    final trimmed = _notesController.text.trim();
+    final normalized = trimmed.isEmpty ? null : trimmed;
+    _pendingNotes = null;
+    if (normalized == _lastSavedNotes) return;
+    _lastSavedNotes = normalized;
+    await widget.onNotesChanged(normalized);
+    if (!mounted) return;
+    _savedIndicatorTimer?.cancel();
+    setState(() => _showSaved = true);
+    _savedIndicatorTimer = Timer(YourTakeCard.savedIndicatorDuration, () {
+      if (mounted) setState(() => _showSaved = false);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -62,7 +166,7 @@ class YourTakeCard extends StatelessWidget {
             const SizedBox(height: 12),
             _buildRating(theme),
             const SizedBox(height: 12),
-            _buildNoteRow(theme),
+            _buildNoteSection(theme),
           ],
         ),
       ),
@@ -70,19 +174,19 @@ class YourTakeCard extends StatelessWidget {
   }
 
   Widget _buildWantToTry(ThemeData theme) {
-    final active = drink.isFavorite;
+    final active = widget.drink.isFavorite;
     final color = active
         ? theme.colorScheme.primary
         : theme.colorScheme.onSurfaceVariant;
 
     return Semantics(
       label: active
-          ? 'Remove ${drink.name} from want to try'
-          : 'Add ${drink.name} to want to try',
+          ? 'Remove ${widget.drink.name} from want to try'
+          : 'Add ${widget.drink.name} to want to try',
       button: true,
       toggled: active,
       child: InkWell(
-        onTap: onWantToTryTap,
+        onTap: widget.onWantToTryTap,
         borderRadius: BorderRadius.circular(999),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
@@ -124,12 +228,12 @@ class YourTakeCard extends StatelessWidget {
     return Row(
       children: [
         StarRating(
-          rating: drink.rating,
+          rating: widget.drink.rating,
           isEditable: true,
           starSize: 30,
-          onRatingChanged: onRatingChanged,
+          onRatingChanged: widget.onRatingChanged,
         ),
-        if (drink.rating == null) ...[
+        if (widget.drink.rating == null) ...[
           const SizedBox(width: 10),
           Expanded(
             child: Text(
@@ -144,18 +248,66 @@ class YourTakeCard extends StatelessWidget {
     );
   }
 
-  Widget _buildNoteRow(ThemeData theme) {
-    final notes = drink.userNotes;
+  Widget _buildNoteSection(ThemeData theme) {
+    if (_isEditing) {
+      return Container(
+        padding: const EdgeInsets.only(top: 12),
+        decoration: BoxDecoration(
+          border: Border(
+            top: BorderSide(color: theme.colorScheme.outlineVariant),
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              key: const ValueKey('user-notes-field'),
+              controller: _notesController,
+              focusNode: _notesFocusNode,
+              autofocus: true,
+              minLines: 1,
+              maxLines: null,
+              textCapitalization: TextCapitalization.sentences,
+              decoration: const InputDecoration(
+                hintText: 'What did you think?',
+                border: InputBorder.none,
+                isDense: true,
+                contentPadding: EdgeInsets.zero,
+              ),
+              onChanged: _onFieldChanged,
+            ),
+            SizedBox(
+              height: 16,
+              child: Semantics(
+                liveRegion: true,
+                label: _showSaved ? 'Saved' : '',
+                child: _showSaved
+                    ? Text(
+                        'Saved',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.primary,
+                        ),
+                      )
+                    : const SizedBox.shrink(),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final notes = widget.drink.userNotes;
     final hasNotes = notes != null && notes.isNotEmpty;
 
     return Semantics(
       label: hasNotes
-          ? 'Edit your notes for ${drink.name}'
-          : 'Add your notes for ${drink.name}',
+          ? 'Edit your notes for ${widget.drink.name}'
+          : 'Add your notes for ${widget.drink.name}',
       button: true,
+      hint: 'Double tap to edit in place. Autosaves as you type.',
       child: InkWell(
         key: const ValueKey('user-notes-editor'),
-        onTap: onEditNote,
+        onTap: _beginEditing,
         borderRadius: BorderRadius.circular(8),
         child: Container(
           padding: const EdgeInsets.only(top: 12),

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -69,6 +69,9 @@ class _YourTakeCardState extends State<YourTakeCard> {
   bool _showSaved = false;
   String? _lastSavedNotes;
   bool _hasPendingEdit = false;
+  // Whether the in-progress draft has any non-whitespace text; drives the
+  // My Festival nudge while editing (the saved note isn't current yet).
+  bool _hasDraftText = false;
 
   @override
   void initState() {
@@ -122,13 +125,20 @@ class _YourTakeCardState extends State<YourTakeCard> {
   }
 
   void _beginEditing() {
-    setState(() => _isEditing = true);
+    setState(() {
+      _isEditing = true;
+      _hasDraftText = _normalizedControllerText != null;
+    });
     _notesFocusNode.requestFocus();
     widget.onEditingChanged?.call(true);
   }
 
   void _onFieldChanged(String value) {
     _hasPendingEdit = true;
+    final hasText = value.trim().isNotEmpty;
+    if (hasText != _hasDraftText) {
+      setState(() => _hasDraftText = hasText);
+    }
     _debounceTimer?.cancel();
     _debounceTimer = Timer(
       YourTakeCard.notesDebounceDuration,
@@ -280,6 +290,14 @@ class _YourTakeCardState extends State<YourTakeCard> {
   }
 
   Widget _buildNoteSection(ThemeData theme) {
+    // A note alone doesn't say whether this is a tip ("Dave said try it") or
+    // a memory ("loved it"), so it can't place the drink in My Festival.
+    // Rather than guess, prompt for the explicit signal — only while neither
+    // exists. The prompt must appear at writing time too: someone who types a
+    // note and navigates straight away would otherwise never see it.
+    final unsignalled =
+        !widget.drink.isFavorite && widget.drink.tastingCount == 0;
+
     if (_isEditing) {
       return Container(
         padding: const EdgeInsets.only(top: 12),
@@ -326,6 +344,7 @@ class _YourTakeCardState extends State<YourTakeCard> {
                     )
                   : const SizedBox.shrink(),
             ),
+            if (unsignalled && _hasDraftText) _buildMyFestivalNudge(theme),
           ],
         ),
       );
@@ -338,12 +357,7 @@ class _YourTakeCardState extends State<YourTakeCard> {
     final notes = _lastSavedNotes;
     final hasNotes = notes != null && notes.isNotEmpty;
 
-    // A note alone doesn't say whether this is a tip ("Dave said try it") or
-    // a memory ("loved it"), so it can't place the drink in My Festival.
-    // Rather than guess, prompt for the explicit signal — only while neither
-    // exists.
-    final showNudge =
-        hasNotes && !widget.drink.isFavorite && widget.drink.tastingCount == 0;
+    final showNudge = hasNotes && unsignalled;
 
     final noteRow = Semantics(
       label: hasNotes

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -32,12 +32,17 @@ class YourTakeCard extends StatefulWidget {
   /// that would otherwise sit over the field once the keyboard is up.
   final ValueChanged<bool>? onEditingChanged;
 
+  /// Log a pour (the screen's "Drunk it!" action). When provided, the
+  /// note-only nudge offers it alongside want-to-try.
+  final VoidCallback? onLogTasting;
+
   const YourTakeCard({
     required this.drink,
     required this.onWantToTryTap,
     required this.onRatingChanged,
     required this.onNotesChanged,
     this.onEditingChanged,
+    this.onLogTasting,
     super.key,
   });
 
@@ -333,7 +338,14 @@ class _YourTakeCardState extends State<YourTakeCard> {
     final notes = _lastSavedNotes;
     final hasNotes = notes != null && notes.isNotEmpty;
 
-    return Semantics(
+    // A note alone doesn't say whether this is a tip ("Dave said try it") or
+    // a memory ("loved it"), so it can't place the drink in My Festival.
+    // Rather than guess, prompt for the explicit signal — only while neither
+    // exists.
+    final showNudge =
+        hasNotes && !widget.drink.isFavorite && widget.drink.tastingCount == 0;
+
+    final noteRow = Semantics(
       label: hasNotes
           ? 'Edit your notes for ${widget.drink.name}'
           : 'Add your notes for ${widget.drink.name}',
@@ -369,6 +381,90 @@ class _YourTakeCardState extends State<YourTakeCard> {
                 Icons.edit,
                 size: 20,
                 color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    if (!showNudge) return noteRow;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [noteRow, _buildMyFestivalNudge(theme)],
+    );
+  }
+
+  Widget _buildMyFestivalNudge(ThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 10),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          Text(
+            'Show it in My Festival?',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          _buildNudgeChip(
+            theme,
+            key: const ValueKey('nudge-want-to-try'),
+            icon: Icons.bookmark_border,
+            label: 'Want to Try',
+            semanticLabel:
+                'Add ${widget.drink.name} to My Festival as want to try',
+            onTap: widget.onWantToTryTap,
+          ),
+          if (widget.onLogTasting != null)
+            _buildNudgeChip(
+              theme,
+              key: const ValueKey('nudge-drunk-it'),
+              icon: Icons.add_circle_outline,
+              label: 'Drunk it!',
+              semanticLabel: 'Log a tasting of ${widget.drink.name}',
+              onTap: widget.onLogTasting!,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNudgeChip(
+    ThemeData theme, {
+    required Key key,
+    required IconData icon,
+    required String label,
+    required String semanticLabel,
+    required VoidCallback onTap,
+  }) {
+    return Semantics(
+      label: semanticLabel,
+      button: true,
+      child: InkWell(
+        key: key,
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(999),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(999),
+            border: Border.all(color: theme.colorScheme.outlineVariant),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 16, color: theme.colorScheme.primary),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ],
           ),

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -27,11 +27,17 @@ class YourTakeCard extends StatefulWidget {
   /// Persist the note text (trimmed; empty becomes null).
   final Future<void> Function(String? notes) onNotesChanged;
 
+  /// Called when inline note editing starts (true) or ends (false), so the
+  /// host screen can clear competing chrome — e.g. a floating action button
+  /// that would otherwise sit over the field once the keyboard is up.
+  final ValueChanged<bool>? onEditingChanged;
+
   const YourTakeCard({
     required this.drink,
     required this.onWantToTryTap,
     required this.onRatingChanged,
     required this.onNotesChanged,
+    this.onEditingChanged,
     super.key,
   });
 
@@ -106,12 +112,14 @@ class _YourTakeCardState extends State<YourTakeCard> {
     if (!_notesFocusNode.hasFocus && _isEditing) {
       unawaited(_flushSave());
       setState(() => _isEditing = false);
+      widget.onEditingChanged?.call(false);
     }
   }
 
   void _beginEditing() {
     setState(() => _isEditing = true);
     _notesFocusNode.requestFocus();
+    widget.onEditingChanged?.call(true);
   }
 
   void _onFieldChanged(String value) {

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -69,9 +69,6 @@ class _YourTakeCardState extends State<YourTakeCard> {
   bool _showSaved = false;
   String? _lastSavedNotes;
   bool _hasPendingEdit = false;
-  // Whether the in-progress draft has any non-whitespace text; drives the
-  // My Festival nudge while editing (the saved note isn't current yet).
-  bool _hasDraftText = false;
 
   @override
   void initState() {
@@ -125,20 +122,13 @@ class _YourTakeCardState extends State<YourTakeCard> {
   }
 
   void _beginEditing() {
-    setState(() {
-      _isEditing = true;
-      _hasDraftText = _normalizedControllerText != null;
-    });
+    setState(() => _isEditing = true);
     _notesFocusNode.requestFocus();
     widget.onEditingChanged?.call(true);
   }
 
   void _onFieldChanged(String value) {
     _hasPendingEdit = true;
-    final hasText = value.trim().isNotEmpty;
-    if (hasText != _hasDraftText) {
-      setState(() => _hasDraftText = hasText);
-    }
     _debounceTimer?.cancel();
     _debounceTimer = Timer(
       YourTakeCard.notesDebounceDuration,
@@ -215,18 +205,34 @@ class _YourTakeCardState extends State<YourTakeCard> {
   }
 
   Widget _buildWantToTry(ThemeData theme) {
+    return _buildWantToTryPill(
+      theme,
+      semanticLabel: widget.drink.isFavorite
+          ? 'Remove ${widget.drink.name} from want to try'
+          : 'Add ${widget.drink.name} to want to try',
+    );
+  }
+
+  /// The want-to-try pill — the app's one visual for that signal. Shared by
+  /// the card header and the My Festival nudge so the nudge speaks the same
+  /// language; only the semantic label differs (to keep the two nodes
+  /// distinguishable for assistive tech and tests).
+  Widget _buildWantToTryPill(
+    ThemeData theme, {
+    required String semanticLabel,
+    Key? pillKey,
+  }) {
     final active = widget.drink.isFavorite;
     final color = active
         ? theme.colorScheme.primary
         : theme.colorScheme.onSurfaceVariant;
 
     return Semantics(
-      label: active
-          ? 'Remove ${widget.drink.name} from want to try'
-          : 'Add ${widget.drink.name} to want to try',
+      label: semanticLabel,
       button: true,
       toggled: active,
       child: InkWell(
+        key: pillKey,
         onTap: widget.onWantToTryTap,
         borderRadius: BorderRadius.circular(999),
         child: Container(
@@ -309,6 +315,14 @@ class _YourTakeCardState extends State<YourTakeCard> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            // The prompt sits ABOVE the field: with the keyboard up, only
+            // the focused field and what's above it are reliably on screen —
+            // anything below is clipped (seen on the PR preview on a phone).
+            if (unsignalled)
+              _buildMyFestivalNudge(
+                theme,
+                padding: const EdgeInsets.only(bottom: 10),
+              ),
             TextField(
               key: const ValueKey('user-notes-field'),
               controller: _notesController,
@@ -344,7 +358,6 @@ class _YourTakeCardState extends State<YourTakeCard> {
                     )
                   : const SizedBox.shrink(),
             ),
-            if (unsignalled && _hasDraftText) _buildMyFestivalNudge(theme),
           ],
         ),
       );
@@ -406,13 +419,19 @@ class _YourTakeCardState extends State<YourTakeCard> {
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: [noteRow, _buildMyFestivalNudge(theme)],
+      children: [
+        noteRow,
+        _buildMyFestivalNudge(theme, padding: const EdgeInsets.only(top: 10)),
+      ],
     );
   }
 
-  Widget _buildMyFestivalNudge(ThemeData theme) {
+  /// The classification prompt for a note-only drink, speaking the app's
+  /// existing visual language: the same want-to-try pill as the card header,
+  /// and a "Drunk it!" button in the FAB's filled style.
+  Widget _buildMyFestivalNudge(ThemeData theme, {required EdgeInsets padding}) {
     return Padding(
-      padding: const EdgeInsets.only(top: 10),
+      padding: padding,
       child: Wrap(
         spacing: 8,
         runSpacing: 8,
@@ -424,65 +443,51 @@ class _YourTakeCardState extends State<YourTakeCard> {
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
-          _buildNudgeChip(
+          _buildWantToTryPill(
             theme,
-            key: const ValueKey('nudge-want-to-try'),
-            icon: Icons.bookmark_border,
-            label: 'Want to Try',
+            pillKey: const ValueKey('nudge-want-to-try'),
             semanticLabel:
                 'Add ${widget.drink.name} to My Festival as want to try',
-            onTap: widget.onWantToTryTap,
           ),
           if (widget.onLogTasting != null)
-            _buildNudgeChip(
-              theme,
-              key: const ValueKey('nudge-drunk-it'),
-              icon: Icons.add_circle_outline,
-              label: 'Drunk it!',
-              semanticLabel: 'Log a tasting of ${widget.drink.name}',
-              onTap: widget.onLogTasting!,
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildNudgeChip(
-    ThemeData theme, {
-    required Key key,
-    required IconData icon,
-    required String label,
-    required String semanticLabel,
-    required VoidCallback onTap,
-  }) {
-    return Semantics(
-      label: semanticLabel,
-      button: true,
-      child: InkWell(
-        key: key,
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(999),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(999),
-            border: Border.all(color: theme.colorScheme.outlineVariant),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(icon, size: 16, color: theme.colorScheme.primary),
-              const SizedBox(width: 6),
-              Text(
-                label,
-                style: theme.textTheme.labelMedium?.copyWith(
-                  color: theme.colorScheme.primary,
-                  fontWeight: FontWeight.w600,
+            Semantics(
+              label: 'Log a tasting of ${widget.drink.name}',
+              button: true,
+              child: InkWell(
+                key: const ValueKey('nudge-drunk-it'),
+                onTap: widget.onLogTasting,
+                borderRadius: BorderRadius.circular(16),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 6,
+                  ),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(16),
+                    color: theme.colorScheme.primaryContainer,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.add_circle_outline,
+                        size: 16,
+                        color: theme.colorScheme.onPrimaryContainer,
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        'Drunk it!',
+                        style: theme.textTheme.labelMedium?.copyWith(
+                          color: theme.colorScheme.onPrimaryContainer,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ],
-          ),
-        ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -280,19 +280,6 @@ class _YourTakeCardState extends State<YourTakeCard> {
   }
 
   Widget _buildNoteSection(ThemeData theme) {
-    // A note alone doesn't say whether this is a tip ("Dave said try it") or
-    // a memory ("loved it"), so it can't place the drink in My Festival.
-    // Rather than guess, prompt for the explicit signal — only while neither
-    // exists. The prompt must appear at writing time too: someone who types a
-    // note and navigates straight away would otherwise never see it.
-    // Without a log callback the nudge would be a question with no action
-    // next to it (the want-to-try pill lives in the card header), so it only
-    // renders when logging is wired up.
-    final unsignalled =
-        widget.onLogTasting != null &&
-        !widget.drink.isFavorite &&
-        widget.drink.tastingCount == 0;
-
     // Render the optimistic local value, not widget.drink.userNotes — on blur
     // the card returns to display mode before the async save (and the
     // provider rebuild it triggers) has landed, and the note the user just
@@ -300,16 +287,24 @@ class _YourTakeCardState extends State<YourTakeCard> {
     final notes = _lastSavedNotes;
     final hasNotes = notes != null && notes.isNotEmpty;
 
-    // The nudge occupies the SAME slot (first, under the divider) in both
-    // modes. On a phone, tapping it while the field is focused blurs the
-    // input mid-gesture and collapses edit mode before the finger lifts —
-    // if the button moved between modes, the tap would land on whatever
-    // shifted into its place and silently do the wrong thing. It also has
-    // to sit above the field: with the keyboard up, anything below the
-    // focused field is clipped. In display mode it additionally needs a
-    // note to exist — without one, the placeholder row is the capture
-    // entry point and the prompt would be noise.
-    final showNudge = unsignalled && (_isEditing || hasNotes);
+    // A note alone doesn't say whether this is a tip ("Dave said try it") or
+    // a memory ("loved it"), so it can't place the drink in My Festival.
+    // Rather than guess, prompt for the explicit signal while neither exists.
+    //
+    // NEVER while editing: with the software keyboard up, any tap outside
+    // the field blurs it mid-gesture and reflows the page — buttons in that
+    // context misfire no matter where they sit (verified on the PR preview,
+    // twice). The prompt renders only in display mode, in the slot where the
+    // field just was, so it greets the user the instant editing ends — the
+    // first moment a tap is actually safe. Without a log callback there
+    // would be no action beside the question (the want-to-try pill lives in
+    // the card header), so it also requires one.
+    final showNudge =
+        !_isEditing &&
+        hasNotes &&
+        widget.onLogTasting != null &&
+        !widget.drink.isFavorite &&
+        widget.drink.tastingCount == 0;
 
     return Container(
       padding: const EdgeInsets.only(top: 12),

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -57,7 +57,7 @@ class _YourTakeCardState extends State<YourTakeCard> {
   bool _isEditing = false;
   bool _showSaved = false;
   String? _lastSavedNotes;
-  String? _pendingNotes;
+  bool _hasPendingEdit = false;
 
   @override
   void initState() {
@@ -82,16 +82,24 @@ class _YourTakeCardState extends State<YourTakeCard> {
   void dispose() {
     _debounceTimer?.cancel();
     _savedIndicatorTimer?.cancel();
-    // Best-effort flush: if there's a debounced save that hasn't landed yet,
-    // fire it now rather than silently dropping the user's last edit.
-    if (_pendingNotes != null && _pendingNotes != _lastSavedNotes) {
-      unawaited(widget.onNotesChanged(_pendingNotes));
+    // Best-effort flush: if there's an edit whose save hasn't landed yet
+    // (including clearing the note to empty), fire it now rather than
+    // silently dropping the user's last edit.
+    final normalized = _normalizedControllerText;
+    if (_hasPendingEdit && normalized != _lastSavedNotes) {
+      unawaited(widget.onNotesChanged(normalized));
     }
     _notesFocusNode
       ..removeListener(_handleFocusChange)
       ..dispose();
     _notesController.dispose();
     super.dispose();
+  }
+
+  /// The controller text as it would be persisted: trimmed, empty → null.
+  String? get _normalizedControllerText {
+    final trimmed = _notesController.text.trim();
+    return trimmed.isEmpty ? null : trimmed;
   }
 
   void _handleFocusChange() {
@@ -107,8 +115,7 @@ class _YourTakeCardState extends State<YourTakeCard> {
   }
 
   void _onFieldChanged(String value) {
-    final trimmed = value.trim();
-    _pendingNotes = trimmed.isEmpty ? null : trimmed;
+    _hasPendingEdit = true;
     _debounceTimer?.cancel();
     _debounceTimer = Timer(
       YourTakeCard.notesDebounceDuration,
@@ -119,12 +126,20 @@ class _YourTakeCardState extends State<YourTakeCard> {
   Future<void> _flushSave() async {
     _debounceTimer?.cancel();
     _debounceTimer = null;
-    final trimmed = _notesController.text.trim();
-    final normalized = trimmed.isEmpty ? null : trimmed;
-    _pendingNotes = null;
+    final normalized = _normalizedControllerText;
+    _hasPendingEdit = false;
     if (normalized == _lastSavedNotes) return;
+    final previous = _lastSavedNotes;
     _lastSavedNotes = normalized;
-    await widget.onNotesChanged(normalized);
+    try {
+      await widget.onNotesChanged(normalized);
+    } catch (_) {
+      // The write failed — keep the edit pending so the next flush (debounce,
+      // blur, or dispose) retries it, and don't claim "Saved".
+      _lastSavedNotes = previous;
+      _hasPendingEdit = true;
+      return;
+    }
     if (!mounted) return;
     _savedIndicatorTimer?.cancel();
     setState(() => _showSaved = true);
@@ -296,7 +311,11 @@ class _YourTakeCardState extends State<YourTakeCard> {
       );
     }
 
-    final notes = widget.drink.userNotes;
+    // Render the optimistic local value, not widget.drink.userNotes — on blur
+    // the card returns to display mode before the async save (and the
+    // provider rebuild it triggers) has landed, and the note the user just
+    // typed must not flash back to its previous state in that window.
+    final notes = _lastSavedNotes;
     final hasNotes = notes != null && notes.isNotEmpty;
 
     return Semantics(

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -205,34 +205,18 @@ class _YourTakeCardState extends State<YourTakeCard> {
   }
 
   Widget _buildWantToTry(ThemeData theme) {
-    return _buildWantToTryPill(
-      theme,
-      semanticLabel: widget.drink.isFavorite
-          ? 'Remove ${widget.drink.name} from want to try'
-          : 'Add ${widget.drink.name} to want to try',
-    );
-  }
-
-  /// The want-to-try pill — the app's one visual for that signal. Shared by
-  /// the card header and the My Festival nudge so the nudge speaks the same
-  /// language; only the semantic label differs (to keep the two nodes
-  /// distinguishable for assistive tech and tests).
-  Widget _buildWantToTryPill(
-    ThemeData theme, {
-    required String semanticLabel,
-    Key? pillKey,
-  }) {
     final active = widget.drink.isFavorite;
     final color = active
         ? theme.colorScheme.primary
         : theme.colorScheme.onSurfaceVariant;
 
     return Semantics(
-      label: semanticLabel,
+      label: active
+          ? 'Remove ${widget.drink.name} from want to try'
+          : 'Add ${widget.drink.name} to want to try',
       button: true,
       toggled: active,
       child: InkWell(
-        key: pillKey,
         onTap: widget.onWantToTryTap,
         borderRadius: BorderRadius.circular(999),
         child: Container(
@@ -301,8 +285,13 @@ class _YourTakeCardState extends State<YourTakeCard> {
     // Rather than guess, prompt for the explicit signal — only while neither
     // exists. The prompt must appear at writing time too: someone who types a
     // note and navigates straight away would otherwise never see it.
-    final unsignalled =
-        !widget.drink.isFavorite && widget.drink.tastingCount == 0;
+    // Without a log callback the nudge would be a question with no action
+    // next to it (the want-to-try pill lives in the card header), so it only
+    // renders when logging is wired up.
+    final showNudge =
+        widget.onLogTasting != null &&
+        !widget.drink.isFavorite &&
+        widget.drink.tastingCount == 0;
 
     if (_isEditing) {
       return Container(
@@ -318,7 +307,7 @@ class _YourTakeCardState extends State<YourTakeCard> {
             // The prompt sits ABOVE the field: with the keyboard up, only
             // the focused field and what's above it are reliably on screen —
             // anything below is clipped (seen on the PR preview on a phone).
-            if (unsignalled)
+            if (showNudge)
               _buildMyFestivalNudge(
                 theme,
                 padding: const EdgeInsets.only(bottom: 10),
@@ -370,8 +359,6 @@ class _YourTakeCardState extends State<YourTakeCard> {
     final notes = _lastSavedNotes;
     final hasNotes = notes != null && notes.isNotEmpty;
 
-    final showNudge = hasNotes && unsignalled;
-
     final noteRow = Semantics(
       label: hasNotes
           ? 'Edit your notes for ${widget.drink.name}'
@@ -415,7 +402,9 @@ class _YourTakeCardState extends State<YourTakeCard> {
       ),
     );
 
-    if (!showNudge) return noteRow;
+    // In display mode the prompt is only about classifying an existing note;
+    // without one, the placeholder row is already the capture entry point.
+    if (!showNudge || !hasNotes) return noteRow;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -426,9 +415,10 @@ class _YourTakeCardState extends State<YourTakeCard> {
     );
   }
 
-  /// The classification prompt for a note-only drink, speaking the app's
-  /// existing visual language: the same want-to-try pill as the card header,
-  /// and a "Drunk it!" button in the FAB's filled style.
+  /// The classification prompt for a note-only drink: a "Drunk it!" button in
+  /// the FAB's filled style. Want-to-try is deliberately NOT repeated here —
+  /// the card header's pill is the app's one control for that signal and is
+  /// visible a line or two above; duplicating it read as clutter.
   Widget _buildMyFestivalNudge(ThemeData theme, {required EdgeInsets padding}) {
     return Padding(
       padding: padding,
@@ -443,50 +433,43 @@ class _YourTakeCardState extends State<YourTakeCard> {
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
-          _buildWantToTryPill(
-            theme,
-            pillKey: const ValueKey('nudge-want-to-try'),
-            semanticLabel:
-                'Add ${widget.drink.name} to My Festival as want to try',
-          ),
-          if (widget.onLogTasting != null)
-            Semantics(
-              label: 'Log a tasting of ${widget.drink.name}',
-              button: true,
-              child: InkWell(
-                key: const ValueKey('nudge-drunk-it'),
-                onTap: widget.onLogTasting,
-                borderRadius: BorderRadius.circular(16),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 6,
-                  ),
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(16),
-                    color: theme.colorScheme.primaryContainer,
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Icons.add_circle_outline,
-                        size: 16,
+          Semantics(
+            label: 'Log a tasting of ${widget.drink.name}',
+            button: true,
+            child: InkWell(
+              key: const ValueKey('nudge-drunk-it'),
+              onTap: widget.onLogTasting,
+              borderRadius: BorderRadius.circular(16),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(16),
+                  color: theme.colorScheme.primaryContainer,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.add_circle_outline,
+                      size: 16,
+                      color: theme.colorScheme.onPrimaryContainer,
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      'Drunk it!',
+                      style: theme.textTheme.labelMedium?.copyWith(
                         color: theme.colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.w600,
                       ),
-                      const SizedBox(width: 6),
-                      Text(
-                        'Drunk it!',
-                        style: theme.textTheme.labelMedium?.copyWith(
-                          color: theme.colorScheme.onPrimaryContainer,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
             ),
+          ),
         ],
       ),
     );

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -288,30 +288,45 @@ class _YourTakeCardState extends State<YourTakeCard> {
     // Without a log callback the nudge would be a question with no action
     // next to it (the want-to-try pill lives in the card header), so it only
     // renders when logging is wired up.
-    final showNudge =
+    final unsignalled =
         widget.onLogTasting != null &&
         !widget.drink.isFavorite &&
         widget.drink.tastingCount == 0;
 
-    if (_isEditing) {
-      return Container(
-        padding: const EdgeInsets.only(top: 12),
-        decoration: BoxDecoration(
-          border: Border(
-            top: BorderSide(color: theme.colorScheme.outlineVariant),
-          ),
+    // Render the optimistic local value, not widget.drink.userNotes — on blur
+    // the card returns to display mode before the async save (and the
+    // provider rebuild it triggers) has landed, and the note the user just
+    // typed must not flash back to its previous state in that window.
+    final notes = _lastSavedNotes;
+    final hasNotes = notes != null && notes.isNotEmpty;
+
+    // The nudge occupies the SAME slot (first, under the divider) in both
+    // modes. On a phone, tapping it while the field is focused blurs the
+    // input mid-gesture and collapses edit mode before the finger lifts —
+    // if the button moved between modes, the tap would land on whatever
+    // shifted into its place and silently do the wrong thing. It also has
+    // to sit above the field: with the keyboard up, anything below the
+    // focused field is clipped. In display mode it additionally needs a
+    // note to exist — without one, the placeholder row is the capture
+    // entry point and the prompt would be noise.
+    final showNudge = unsignalled && (_isEditing || hasNotes);
+
+    return Container(
+      padding: const EdgeInsets.only(top: 12),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(color: theme.colorScheme.outlineVariant),
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // The prompt sits ABOVE the field: with the keyboard up, only
-            // the focused field and what's above it are reliably on screen —
-            // anything below is clipped (seen on the PR preview on a phone).
-            if (showNudge)
-              _buildMyFestivalNudge(
-                theme,
-                padding: const EdgeInsets.only(bottom: 10),
-              ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (showNudge)
+            _buildMyFestivalNudge(
+              theme,
+              padding: const EdgeInsets.only(bottom: 10),
+            ),
+          if (_isEditing) ...[
             TextField(
               key: const ValueKey('user-notes-field'),
               controller: _notesController,
@@ -347,71 +362,45 @@ class _YourTakeCardState extends State<YourTakeCard> {
                     )
                   : const SizedBox.shrink(),
             ),
-          ],
-        ),
-      );
-    }
-
-    // Render the optimistic local value, not widget.drink.userNotes — on blur
-    // the card returns to display mode before the async save (and the
-    // provider rebuild it triggers) has landed, and the note the user just
-    // typed must not flash back to its previous state in that window.
-    final notes = _lastSavedNotes;
-    final hasNotes = notes != null && notes.isNotEmpty;
-
-    final noteRow = Semantics(
-      label: hasNotes
-          ? 'Edit your notes for ${widget.drink.name}'
-          : 'Add your notes for ${widget.drink.name}',
-      button: true,
-      hint: 'Double tap to edit in place. Autosaves as you type.',
-      child: InkWell(
-        key: const ValueKey('user-notes-editor'),
-        onTap: _beginEditing,
-        borderRadius: BorderRadius.circular(8),
-        child: Container(
-          padding: const EdgeInsets.only(top: 12),
-          decoration: BoxDecoration(
-            border: Border(
-              top: BorderSide(color: theme.colorScheme.outlineVariant),
-            ),
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Text(
-                  hasNotes ? notes : 'Tap to add your notes',
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: hasNotes
-                        ? theme.colorScheme.onSurface
-                        : theme.colorScheme.onSurfaceVariant,
-                    fontStyle: hasNotes ? FontStyle.normal : FontStyle.italic,
-                  ),
+          ] else
+            Semantics(
+              label: hasNotes
+                  ? 'Edit your notes for ${widget.drink.name}'
+                  : 'Add your notes for ${widget.drink.name}',
+              button: true,
+              hint: 'Double tap to edit in place. Autosaves as you type.',
+              child: InkWell(
+                key: const ValueKey('user-notes-editor'),
+                onTap: _beginEditing,
+                borderRadius: BorderRadius.circular(8),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        hasNotes ? notes : 'Tap to add your notes',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: hasNotes
+                              ? theme.colorScheme.onSurface
+                              : theme.colorScheme.onSurfaceVariant,
+                          fontStyle: hasNotes
+                              ? FontStyle.normal
+                              : FontStyle.italic,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Icon(
+                      Icons.edit,
+                      size: 20,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(width: 8),
-              Icon(
-                Icons.edit,
-                size: 20,
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ],
-          ),
-        ),
+            ),
+        ],
       ),
-    );
-
-    // In display mode the prompt is only about classifying an existing note;
-    // without one, the placeholder row is already the capture entry point.
-    if (!showNudge || !hasNotes) return noteRow;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        noteRow,
-        _buildMyFestivalNudge(theme, padding: const EdgeInsets.only(top: 10)),
-      ],
     );
   }
 

--- a/lib/widgets/your_take_card.dart
+++ b/lib/widgets/your_take_card.dart
@@ -32,17 +32,12 @@ class YourTakeCard extends StatefulWidget {
   /// that would otherwise sit over the field once the keyboard is up.
   final ValueChanged<bool>? onEditingChanged;
 
-  /// Log a pour (the screen's "Drunk it!" action). When provided, the
-  /// note-only nudge offers it alongside want-to-try.
-  final VoidCallback? onLogTasting;
-
   const YourTakeCard({
     required this.drink,
     required this.onWantToTryTap,
     required this.onRatingChanged,
     required this.onNotesChanged,
     this.onEditingChanged,
-    this.onLogTasting,
     super.key,
   });
 
@@ -287,25 +282,6 @@ class _YourTakeCardState extends State<YourTakeCard> {
     final notes = _lastSavedNotes;
     final hasNotes = notes != null && notes.isNotEmpty;
 
-    // A note alone doesn't say whether this is a tip ("Dave said try it") or
-    // a memory ("loved it"), so it can't place the drink in My Festival.
-    // Rather than guess, prompt for the explicit signal while neither exists.
-    //
-    // NEVER while editing: with the software keyboard up, any tap outside
-    // the field blurs it mid-gesture and reflows the page — buttons in that
-    // context misfire no matter where they sit (verified on the PR preview,
-    // twice). The prompt renders only in display mode, in the slot where the
-    // field just was, so it greets the user the instant editing ends — the
-    // first moment a tap is actually safe. Without a log callback there
-    // would be no action beside the question (the want-to-try pill lives in
-    // the card header), so it also requires one.
-    final showNudge =
-        !_isEditing &&
-        hasNotes &&
-        widget.onLogTasting != null &&
-        !widget.drink.isFavorite &&
-        widget.drink.tastingCount == 0;
-
     return Container(
       padding: const EdgeInsets.only(top: 12),
       decoration: BoxDecoration(
@@ -313,52 +289,48 @@ class _YourTakeCardState extends State<YourTakeCard> {
           top: BorderSide(color: theme.colorScheme.outlineVariant),
         ),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (showNudge)
-            _buildMyFestivalNudge(
-              theme,
-              padding: const EdgeInsets.only(bottom: 10),
-            ),
-          if (_isEditing) ...[
-            TextField(
-              key: const ValueKey('user-notes-field'),
-              controller: _notesController,
-              focusNode: _notesFocusNode,
-              autofocus: true,
-              minLines: 1,
-              maxLines: null,
-              textCapitalization: TextCapitalization.sentences,
-              decoration: const InputDecoration(
-                hintText: 'What did you think?',
-                border: InputBorder.none,
-                isDense: true,
-                contentPadding: EdgeInsets.zero,
-              ),
-              onChanged: _onFieldChanged,
-            ),
-            SizedBox(
-              height: 16,
-              // Only mount the live region while it has something to say —
-              // the same conditional pattern as the refresh indicator in
-              // drinks_screen.dart. A persistent node with an empty label
-              // would sit in the semantics tree saying nothing.
-              child: _showSaved
-                  ? Semantics(
-                      liveRegion: true,
-                      label: 'Saved',
-                      child: Text(
-                        'Saved',
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: theme.colorScheme.primary,
-                        ),
-                      ),
-                    )
-                  : const SizedBox.shrink(),
-            ),
-          ] else
-            Semantics(
+      child: _isEditing
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextField(
+                  key: const ValueKey('user-notes-field'),
+                  controller: _notesController,
+                  focusNode: _notesFocusNode,
+                  autofocus: true,
+                  minLines: 1,
+                  maxLines: null,
+                  textCapitalization: TextCapitalization.sentences,
+                  decoration: const InputDecoration(
+                    hintText: 'What did you think?',
+                    border: InputBorder.none,
+                    isDense: true,
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                  onChanged: _onFieldChanged,
+                ),
+                SizedBox(
+                  height: 16,
+                  // Only mount the live region while it has something to say —
+                  // the same conditional pattern as the refresh indicator in
+                  // drinks_screen.dart. A persistent node with an empty label
+                  // would sit in the semantics tree saying nothing.
+                  child: _showSaved
+                      ? Semantics(
+                          liveRegion: true,
+                          label: 'Saved',
+                          child: Text(
+                            'Saved',
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: theme.colorScheme.primary,
+                            ),
+                          ),
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              ],
+            )
+          : Semantics(
               label: hasNotes
                   ? 'Edit your notes for ${widget.drink.name}'
                   : 'Add your notes for ${widget.drink.name}',
@@ -394,68 +366,6 @@ class _YourTakeCardState extends State<YourTakeCard> {
                 ),
               ),
             ),
-        ],
-      ),
-    );
-  }
-
-  /// The classification prompt for a note-only drink: a "Drunk it!" button in
-  /// the FAB's filled style. Want-to-try is deliberately NOT repeated here —
-  /// the card header's pill is the app's one control for that signal and is
-  /// visible a line or two above; duplicating it read as clutter.
-  Widget _buildMyFestivalNudge(ThemeData theme, {required EdgeInsets padding}) {
-    return Padding(
-      padding: padding,
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          Text(
-            'Show it in My Festival?',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-          Semantics(
-            label: 'Log a tasting of ${widget.drink.name}',
-            button: true,
-            child: InkWell(
-              key: const ValueKey('nudge-drunk-it'),
-              onTap: widget.onLogTasting,
-              borderRadius: BorderRadius.circular(16),
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 6,
-                ),
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(16),
-                  color: theme.colorScheme.primaryContainer,
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      Icons.add_circle_outline,
-                      size: 16,
-                      color: theme.colorScheme.onPrimaryContainer,
-                    ),
-                    const SizedBox(width: 6),
-                    Text(
-                      'Drunk it!',
-                      style: theme.textTheme.labelMedium?.copyWith(
-                        color: theme.colorScheme.onPrimaryContainer,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -3018,6 +3018,12 @@ void main() {
           verify(
             mockDrinkRepository.addTasting(any, any, now: original),
           ).called(1);
+          // Restoring a removed pour is not a new tasting — it must not
+          // inflate the tasting analytics.
+          verifyNever(mockAnalyticsService.logFestivalLogMarkTasted(any));
+          verifyNever(
+            mockAnalyticsService.logFestivalLogMultipleTasting(any, any),
+          );
         },
       );
 

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -2987,6 +2987,41 @@ void main() {
       );
 
       test(
+        'addTasting uses the provided "at" timestamp instead of now',
+        () async {
+          provider = BeerProvider(
+            drinkRepository: mockDrinkRepository,
+            festivalRepository: mockFestivalRepository,
+            analyticsService: mockAnalyticsService,
+          );
+          await provider.initialize();
+          when(
+            mockDrinkRepository.getDrinks(any),
+          ).thenAnswer((_) async => createSampleDrinks());
+          await provider.loadDrinks();
+          final drink = provider.allDrinks.first;
+          final original = DateTime(2025, 6, 11, 18, 45);
+
+          when(
+            mockDrinkRepository.addTasting(any, any, now: anyNamed('now')),
+          ).thenAnswer(
+            (_) async => UserDrinkState(
+              tastingEvents: [original],
+              createdAt: original,
+              updatedAt: original,
+            ),
+          );
+
+          final returned = await provider.addTasting(drink, at: original);
+
+          expect(returned, original);
+          verify(
+            mockDrinkRepository.addTasting(any, any, now: original),
+          ).called(1);
+        },
+      );
+
+      test(
         'removeTasting updates the drink userState and logs delete_timestamp',
         () async {
           provider = BeerProvider(

--- a/test/domain/services/drink_filter_service_test.dart
+++ b/test/domain/services/drink_filter_service_test.dart
@@ -405,6 +405,41 @@ void main() {
         expect(result[0].notes, contains('hoppy'));
       });
 
+      test("searches the user's own note content (case insensitive)", () {
+        final noted = testDrinks[1].copyWith(
+          userState: UserDrinkState(
+            notes: 'Dave said try this',
+            createdAt: DateTime(2025, 6, 10),
+            updatedAt: DateTime(2025, 6, 10),
+          ),
+        );
+        final drinks = [testDrinks[0], noted, testDrinks[2]];
+
+        final result = service.filterBySearch(drinks, 'dave').toList();
+
+        expect(result, hasLength(1));
+        expect(result[0].id, noted.id);
+      });
+
+      test('filterDrinks search also matches user notes', () {
+        final noted = testDrinks[1].copyWith(
+          userState: UserDrinkState(
+            notes: 'Dave said try this',
+            createdAt: DateTime(2025, 6, 10),
+            updatedAt: DateTime(2025, 6, 10),
+          ),
+        );
+
+        final result = service.filterDrinks([
+          testDrinks[0],
+          noted,
+          testDrinks[2],
+        ], searchQuery: 'Dave');
+
+        expect(result, hasLength(1));
+        expect(result[0].id, noted.id);
+      });
+
       test('returns all drinks when query is empty', () {
         final result = service.filterBySearch(testDrinks, '').toList();
         expect(result, hasLength(5));

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -971,6 +971,52 @@ void main() {
         expect(find.byKey(const ValueKey('tasted-action')), findsOneWidget);
       });
 
+      testWidgets('note-only drink shows the My Festival nudge and logging '
+          'from it records a pour', (WidgetTester tester) async {
+        await useTallSurface(tester);
+        when(mockDrinkRepository.getDrinks(any)).thenAnswer(
+          (_) async => [
+            drink.copyWith(
+              userState: UserDrinkState(
+                notes: 'Dave said try this',
+                createdAt: now,
+                updatedAt: now,
+              ),
+            ),
+          ],
+        );
+        await provider.loadDrinks();
+
+        when(
+          mockDrinkRepository.addTasting(any, any, now: anyNamed('now')),
+        ).thenAnswer(
+          (_) async => UserDrinkState(
+            notes: 'Dave said try this',
+            tastingEvents: [now],
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget('drink1'));
+        await tester.pumpAndSettle();
+
+        // A note alone can't place the drink in My Festival, so the card
+        // prompts for an explicit signal.
+        expect(find.text('Show it in My Festival?'), findsOneWidget);
+
+        await tester.tap(find.byKey(const ValueKey('nudge-drunk-it')));
+        await tester.pumpAndSettle();
+
+        verify(
+          mockDrinkRepository.addTasting(any, any, now: anyNamed('now')),
+        ).called(1);
+        expect(provider.getDrinkById('drink1')!.tastingCount, 1);
+        expect(find.text('Logged your first tasting'), findsOneWidget);
+        // The signal now exists, so the nudge retires.
+        expect(find.text('Show it in My Festival?'), findsNothing);
+      });
+
       testWidgets('existing user notes are shown and prefilled for editing', (
         WidgetTester tester,
       ) async {

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -945,6 +945,32 @@ void main() {
         expect(find.text('Lovely and hoppy'), findsOneWidget);
       });
 
+      testWidgets('the Drunk it! FAB hides while the note is being edited', (
+        WidgetTester tester,
+      ) async {
+        await useTallSurface(tester);
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => [drink]);
+        await provider.loadDrinks();
+
+        await tester.pumpWidget(createTestWidget('drink1'));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const ValueKey('tasted-action')), findsOneWidget);
+
+        // Editing the note raises the keyboard; the centre-floating FAB
+        // would sit directly over the field, so it must get out of the way.
+        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+        await tester.pumpAndSettle();
+        expect(find.byKey(const ValueKey('tasted-action')), findsNothing);
+
+        // Blur ends editing and brings the FAB back.
+        FocusManager.instance.primaryFocus?.unfocus();
+        await tester.pumpAndSettle();
+        expect(find.byKey(const ValueKey('tasted-action')), findsOneWidget);
+      });
+
       testWidgets('existing user notes are shown and prefilled for editing', (
         WidgetTester tester,
       ) async {

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -856,7 +856,7 @@ void main() {
         expect(find.byKey(const ValueKey('delete-tasting-1')), findsOneWidget);
       });
 
-      testWidgets('delete tasting asks for confirmation then removes the row', (
+      testWidgets('delete tasting removes immediately and offers Undo', (
         WidgetTester tester,
       ) async {
         await useTallSurface(tester);
@@ -867,10 +867,18 @@ void main() {
         );
         await provider.loadDrinks();
 
-        // Removing the only tasting prunes the record to null.
         when(
           mockDrinkRepository.removeTasting(any, any, any),
         ).thenAnswer((_) async => null);
+        when(
+          mockDrinkRepository.addTasting(any, any, now: anyNamed('now')),
+        ).thenAnswer(
+          (_) async => UserDrinkState(
+            tastingEvents: [now],
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
 
         await tester.pumpWidget(createTestWidget('drink1'));
         await tester.pumpAndSettle();
@@ -880,23 +888,21 @@ void main() {
         await tester.tap(find.byKey(const ValueKey('delete-tasting-0')));
         await tester.pumpAndSettle();
 
-        // Confirm dialog appears; cancelling leaves the tasting in place.
-        expect(find.text('Remove this tasting?'), findsOneWidget);
-        await tester.tap(find.text('Cancel'));
-        await tester.pumpAndSettle();
-        expect(provider.getDrinkById('drink1')!.tastingCount, 1);
-
-        // Re-open and confirm this time.
-        await tester.tap(find.byKey(const ValueKey('delete-tasting-0')));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Remove'));
-        await tester.pumpAndSettle();
-
+        // No confirmation dialog — removed immediately.
+        expect(find.text('Remove this tasting?'), findsNothing);
         expect(provider.getDrinkById('drink1')!.tastingCount, 0);
         expect(find.text('Your Tastings (1)'), findsNothing);
+
+        // Undo SnackBar restores the exact same pour.
+        expect(find.text('Undo'), findsOneWidget);
+        await tester.tap(find.text('Undo'));
+        await tester.pumpAndSettle();
+
+        verify(mockDrinkRepository.addTasting(any, any, now: now)).called(1);
+        expect(provider.getDrinkById('drink1')!.tastingCount, 1);
       });
 
-      testWidgets('notes editor shows a placeholder and saves user notes', (
+      testWidgets('notes editor autosaves user notes typed in place', (
         WidgetTester tester,
       ) async {
         await useTallSurface(tester);
@@ -927,7 +933,9 @@ void main() {
           find.byKey(const ValueKey('user-notes-field')),
           'Lovely and hoppy',
         );
-        await tester.tap(find.text('Save'));
+        await tester.pump(
+          YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+        );
         await tester.pumpAndSettle();
 
         verify(
@@ -958,7 +966,7 @@ void main() {
         await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
         await tester.pumpAndSettle();
 
-        // Dialog is prefilled with the existing note.
+        // The field is prefilled with the existing note.
         final field = tester.widget<TextField>(
           find.byKey(const ValueKey('user-notes-field')),
         );

--- a/test/drink_detail_screen_test.dart
+++ b/test/drink_detail_screen_test.dart
@@ -971,52 +971,6 @@ void main() {
         expect(find.byKey(const ValueKey('tasted-action')), findsOneWidget);
       });
 
-      testWidgets('note-only drink shows the My Festival nudge and logging '
-          'from it records a pour', (WidgetTester tester) async {
-        await useTallSurface(tester);
-        when(mockDrinkRepository.getDrinks(any)).thenAnswer(
-          (_) async => [
-            drink.copyWith(
-              userState: UserDrinkState(
-                notes: 'Dave said try this',
-                createdAt: now,
-                updatedAt: now,
-              ),
-            ),
-          ],
-        );
-        await provider.loadDrinks();
-
-        when(
-          mockDrinkRepository.addTasting(any, any, now: anyNamed('now')),
-        ).thenAnswer(
-          (_) async => UserDrinkState(
-            notes: 'Dave said try this',
-            tastingEvents: [now],
-            createdAt: now,
-            updatedAt: now,
-          ),
-        );
-
-        await tester.pumpWidget(createTestWidget('drink1'));
-        await tester.pumpAndSettle();
-
-        // A note alone can't place the drink in My Festival, so the card
-        // prompts for an explicit signal.
-        expect(find.text('Show it in My Festival?'), findsOneWidget);
-
-        await tester.tap(find.byKey(const ValueKey('nudge-drunk-it')));
-        await tester.pumpAndSettle();
-
-        verify(
-          mockDrinkRepository.addTasting(any, any, now: anyNamed('now')),
-        ).called(1);
-        expect(provider.getDrinkById('drink1')!.tastingCount, 1);
-        expect(find.text('Logged your first tasting'), findsOneWidget);
-        // The signal now exists, so the nudge retires.
-        expect(find.text('Show it in My Festival?'), findsNothing);
-      });
-
       testWidgets('existing user notes are shown and prefilled for editing', (
         WidgetTester tester,
       ) async {

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -22,15 +22,22 @@ void main() {
     products: [],
   );
 
-  Drink createSampleDrink({String? notes}) {
+  Drink createSampleDrink({
+    String? notes,
+    bool wantToTry = false,
+    List<DateTime>? tastingEvents,
+  }) {
+    final hasState = notes != null || wantToTry || tastingEvents != null;
     return Drink(
       product: product,
       producer: producer,
       festivalId: 'cbf2025',
-      userState: notes == null
+      userState: !hasState
           ? null
           : UserDrinkState(
               notes: notes,
+              wantToTry: wantToTry,
+              tastingEvents: tastingEvents ?? const [],
               createdAt: DateTime(2025, 6, 10),
               updatedAt: DateTime(2025, 6, 10),
             ),
@@ -43,6 +50,7 @@ void main() {
     ValueChanged<int?>? onRatingChanged,
     Future<void> Function(String? notes)? onNotesChanged,
     ValueChanged<bool>? onEditingChanged,
+    VoidCallback? onLogTasting,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -52,6 +60,7 @@ void main() {
           onRatingChanged: onRatingChanged ?? (_) {},
           onNotesChanged: onNotesChanged ?? (_) async {},
           onEditingChanged: onEditingChanged,
+          onLogTasting: onLogTasting,
         ),
       ),
     );
@@ -362,6 +371,115 @@ void main() {
       await tester.pump();
 
       expect(find.text('Saved'), findsNothing);
+    });
+  });
+
+  group('YourTakeCard My Festival nudge', () {
+    testWidgets('appears for a note-only drink and offers both signals', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(
+          drink: createSampleDrink(notes: 'Dave said try this'),
+          onLogTasting: () {},
+        ),
+      );
+
+      expect(find.text('Show it in My Festival?'), findsOneWidget);
+      expect(find.byKey(const ValueKey('nudge-want-to-try')), findsOneWidget);
+      expect(find.byKey(const ValueKey('nudge-drunk-it')), findsOneWidget);
+    });
+
+    testWidgets('is absent when there is no note', (tester) async {
+      await tester.pumpWidget(buildWidget(onLogTasting: () {}));
+      expect(find.text('Show it in My Festival?'), findsNothing);
+    });
+
+    testWidgets('is absent once the drink is want-to-try', (tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          drink: createSampleDrink(
+            notes: 'Dave said try this',
+            wantToTry: true,
+          ),
+          onLogTasting: () {},
+        ),
+      );
+      expect(find.text('Show it in My Festival?'), findsNothing);
+    });
+
+    testWidgets('is absent once the drink has a tasting', (tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          drink: createSampleDrink(
+            notes: 'Loved it',
+            tastingEvents: [DateTime(2025, 6, 11, 18, 45)],
+          ),
+          onLogTasting: () {},
+        ),
+      );
+      expect(find.text('Show it in My Festival?'), findsNothing);
+    });
+
+    testWidgets('chips invoke the want-to-try and log-tasting callbacks', (
+      tester,
+    ) async {
+      var wantToTryTaps = 0;
+      var logTastingTaps = 0;
+      await tester.pumpWidget(
+        buildWidget(
+          drink: createSampleDrink(notes: 'Dave said try this'),
+          onWantToTryTap: () => wantToTryTaps++,
+          onLogTasting: () => logTastingTaps++,
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('nudge-want-to-try')));
+      await tester.tap(find.byKey(const ValueKey('nudge-drunk-it')));
+
+      expect(wantToTryTaps, 1);
+      expect(logTastingTaps, 1);
+    });
+
+    testWidgets('omits the Drunk it! chip when no log callback is given', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(drink: createSampleDrink(notes: 'Dave said try this')),
+      );
+
+      expect(find.text('Show it in My Festival?'), findsOneWidget);
+      expect(find.byKey(const ValueKey('nudge-want-to-try')), findsOneWidget);
+      expect(find.byKey(const ValueKey('nudge-drunk-it')), findsNothing);
+    });
+
+    testWidgets('chips are labelled buttons', (tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          drink: createSampleDrink(notes: 'Dave said try this'),
+          onLogTasting: () {},
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label ==
+                  'Add Test Beer to My Festival as want to try' &&
+              widget.properties.button == true,
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label == 'Log a tasting of Test Beer' &&
+              widget.properties.button == true,
+        ),
+        findsOneWidget,
+      );
     });
   });
 

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -453,6 +453,64 @@ void main() {
       },
     );
 
+    testWidgets('the Drunk it! button can be tapped while editing', (
+      tester,
+    ) async {
+      var logTastingTaps = 0;
+      await tester.pumpWidget(
+        buildWidget(onLogTasting: () => logTastingTaps++),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('user-notes-field')),
+        'Great beer',
+      );
+
+      await tester.tap(find.byKey(const ValueKey('nudge-drunk-it')));
+      await tester.pump();
+
+      expect(logTastingTaps, 1);
+
+      // Let the pending autosave and indicator timers resolve.
+      await tester.pump(
+        YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+      );
+      await tester.pump(YourTakeCard.savedIndicatorDuration);
+    });
+
+    testWidgets('the Drunk it! button keeps its position when editing ends', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWidget(onLogTasting: () {}));
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('user-notes-field')),
+        'Great beer',
+      );
+      await tester.pump();
+
+      final before = tester.getTopLeft(
+        find.byKey(const ValueKey('nudge-drunk-it')),
+      );
+
+      // On a phone, tapping the button blurs the field mid-gesture and
+      // collapses edit mode before the finger lifts. The button must not
+      // move in that transition, or the tap lands on something else.
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+
+      final after = tester.getTopLeft(
+        find.byKey(const ValueKey('nudge-drunk-it')),
+      );
+      expect(after, before);
+
+      await tester.pump(YourTakeCard.savedIndicatorDuration);
+    });
+
     testWidgets('the Drunk it! button invokes the log-tasting callback', (
       tester,
     ) async {

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -276,6 +276,55 @@ void main() {
       },
     );
 
+    testWidgets(
+      'the Saved indicator is suppressed while a newer edit is pending',
+      (tester) async {
+        final completers = <Completer<void>>[];
+        await tester.pumpWidget(
+          buildWidget(
+            onNotesChanged: (_) {
+              final completer = Completer<void>();
+              completers.add(completer);
+              return completer.future;
+            },
+          ),
+        );
+
+        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+        await tester.pump();
+        await tester.enterText(
+          find.byKey(const ValueKey('user-notes-field')),
+          'First',
+        );
+        await tester.pump(
+          YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+        );
+        expect(completers, hasLength(1));
+
+        // Type again while the first save is still in flight, then let the
+        // first save complete — 'Saved' would misrepresent the newest text.
+        await tester.enterText(
+          find.byKey(const ValueKey('user-notes-field')),
+          'First and second',
+        );
+        completers[0].complete();
+        await tester.pump();
+        expect(find.text('Saved'), findsNothing);
+
+        // Once the newer edit's own save lands, the indicator shows.
+        await tester.pump(
+          YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+        );
+        expect(completers, hasLength(2));
+        completers[1].complete();
+        await tester.pump();
+        await tester.pump();
+        expect(find.text('Saved'), findsOneWidget);
+
+        await tester.pump(YourTakeCard.savedIndicatorDuration);
+      },
+    );
+
     testWidgets('the Saved indicator appears after a save and clears itself', (
       tester,
     ) async {

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -22,22 +22,15 @@ void main() {
     products: [],
   );
 
-  Drink createSampleDrink({
-    String? notes,
-    bool wantToTry = false,
-    List<DateTime>? tastingEvents,
-  }) {
-    final hasState = notes != null || wantToTry || tastingEvents != null;
+  Drink createSampleDrink({String? notes}) {
     return Drink(
       product: product,
       producer: producer,
       festivalId: 'cbf2025',
-      userState: !hasState
+      userState: notes == null
           ? null
           : UserDrinkState(
               notes: notes,
-              wantToTry: wantToTry,
-              tastingEvents: tastingEvents ?? const [],
               createdAt: DateTime(2025, 6, 10),
               updatedAt: DateTime(2025, 6, 10),
             ),
@@ -50,7 +43,6 @@ void main() {
     ValueChanged<int?>? onRatingChanged,
     Future<void> Function(String? notes)? onNotesChanged,
     ValueChanged<bool>? onEditingChanged,
-    VoidCallback? onLogTasting,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -60,7 +52,6 @@ void main() {
           onRatingChanged: onRatingChanged ?? (_) {},
           onNotesChanged: onNotesChanged ?? (_) async {},
           onEditingChanged: onEditingChanged,
-          onLogTasting: onLogTasting,
         ),
       ),
     );
@@ -371,132 +362,6 @@ void main() {
       await tester.pump();
 
       expect(find.text('Saved'), findsNothing);
-    });
-  });
-
-  group('YourTakeCard My Festival nudge', () {
-    testWidgets('appears for a note-only drink with a Drunk it! action', (
-      tester,
-    ) async {
-      await tester.pumpWidget(
-        buildWidget(
-          drink: createSampleDrink(notes: 'Dave said try this'),
-          onLogTasting: () {},
-        ),
-      );
-
-      expect(find.text('Show it in My Festival?'), findsOneWidget);
-      expect(find.byKey(const ValueKey('nudge-drunk-it')), findsOneWidget);
-      // Want-to-try is NOT repeated in the nudge — the header pill is the
-      // one control for that signal, so exactly one exists in the card.
-      expect(find.text('Want to Try'), findsOneWidget);
-    });
-
-    testWidgets('is absent when there is no note', (tester) async {
-      await tester.pumpWidget(buildWidget(onLogTasting: () {}));
-      expect(find.text('Show it in My Festival?'), findsNothing);
-    });
-
-    testWidgets('is absent once the drink is want-to-try', (tester) async {
-      await tester.pumpWidget(
-        buildWidget(
-          drink: createSampleDrink(
-            notes: 'Dave said try this',
-            wantToTry: true,
-          ),
-          onLogTasting: () {},
-        ),
-      );
-      expect(find.text('Show it in My Festival?'), findsNothing);
-    });
-
-    testWidgets('is absent once the drink has a tasting', (tester) async {
-      await tester.pumpWidget(
-        buildWidget(
-          drink: createSampleDrink(
-            notes: 'Loved it',
-            tastingEvents: [DateTime(2025, 6, 11, 18, 45)],
-          ),
-          onLogTasting: () {},
-        ),
-      );
-      expect(find.text('Show it in My Festival?'), findsNothing);
-    });
-
-    testWidgets(
-      'is never shown while editing, and appears the moment editing ends',
-      (tester) async {
-        await tester.pumpWidget(buildWidget(onLogTasting: () {}));
-
-        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
-        await tester.pump();
-        await tester.enterText(
-          find.byKey(const ValueKey('user-notes-field')),
-          'Dave said try this',
-        );
-        await tester.pump();
-
-        // With the keyboard up, taps outside the field blur it mid-gesture
-        // and reflow the page — no buttons may compete with it.
-        expect(find.text('Show it in My Festival?'), findsNothing);
-
-        FocusManager.instance.primaryFocus?.unfocus();
-        await tester.pump();
-
-        // Editing over: the prompt takes the slot where the field was —
-        // the first moment a tap is actually safe.
-        expect(find.byKey(const ValueKey('user-notes-field')), findsNothing);
-        expect(find.text('Show it in My Festival?'), findsOneWidget);
-        expect(find.byKey(const ValueKey('nudge-drunk-it')), findsOneWidget);
-
-        await tester.pump(YourTakeCard.savedIndicatorDuration);
-      },
-    );
-
-    testWidgets('the Drunk it! button invokes the log-tasting callback', (
-      tester,
-    ) async {
-      var logTastingTaps = 0;
-      await tester.pumpWidget(
-        buildWidget(
-          drink: createSampleDrink(notes: 'Dave said try this'),
-          onLogTasting: () => logTastingTaps++,
-        ),
-      );
-
-      await tester.tap(find.byKey(const ValueKey('nudge-drunk-it')));
-
-      expect(logTastingTaps, 1);
-    });
-
-    testWidgets('is absent entirely when no log callback is given', (
-      tester,
-    ) async {
-      await tester.pumpWidget(
-        buildWidget(drink: createSampleDrink(notes: 'Dave said try this')),
-      );
-
-      expect(find.text('Show it in My Festival?'), findsNothing);
-      expect(find.byKey(const ValueKey('nudge-drunk-it')), findsNothing);
-    });
-
-    testWidgets('the Drunk it! button is a labelled button', (tester) async {
-      await tester.pumpWidget(
-        buildWidget(
-          drink: createSampleDrink(notes: 'Dave said try this'),
-          onLogTasting: () {},
-        ),
-      );
-
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is Semantics &&
-              widget.properties.label == 'Log a tasting of Test Beer' &&
-              widget.properties.button == true,
-        ),
-        findsOneWidget,
-      );
     });
   });
 

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -42,6 +42,7 @@ void main() {
     VoidCallback? onWantToTryTap,
     ValueChanged<int?>? onRatingChanged,
     Future<void> Function(String? notes)? onNotesChanged,
+    ValueChanged<bool>? onEditingChanged,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -50,6 +51,7 @@ void main() {
           onWantToTryTap: onWantToTryTap ?? () {},
           onRatingChanged: onRatingChanged ?? (_) {},
           onNotesChanged: onNotesChanged ?? (_) async {},
+          onEditingChanged: onEditingChanged,
         ),
       ),
     );
@@ -170,6 +172,19 @@ void main() {
       await tester.pump();
 
       expect(calls, ['Quick save']);
+    });
+
+    testWidgets('reports editing state changes to the host', (tester) async {
+      final changes = <bool>[];
+      await tester.pumpWidget(buildWidget(onEditingChanged: changes.add));
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+      expect(changes, [true]);
+
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+      expect(changes, [true, false]);
     });
 
     testWidgets(

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -170,6 +172,110 @@ void main() {
       expect(calls, ['Quick save']);
     });
 
+    testWidgets(
+      'clearing an existing note is persisted even when the widget is '
+      'disposed before the debounce fires',
+      (tester) async {
+        final calls = <String?>[];
+        await tester.pumpWidget(
+          buildWidget(
+            drink: createSampleDrink(notes: 'Existing'),
+            onNotesChanged: (notes) async => calls.add(notes),
+          ),
+        );
+
+        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+        await tester.pump();
+        await tester.enterText(
+          find.byKey(const ValueKey('user-notes-field')),
+          '',
+        );
+
+        // Dispose the card before the debounce window elapses — the cleared
+        // note must still be flushed exactly once, not silently dropped.
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+        expect(calls, [null]);
+      },
+    );
+
+    testWidgets('a failed save is not reported as Saved and is retried', (
+      tester,
+    ) async {
+      var shouldFail = true;
+      var attempts = 0;
+      final saved = <String?>[];
+      await tester.pumpWidget(
+        buildWidget(
+          onNotesChanged: (notes) async {
+            attempts++;
+            if (shouldFail) throw Exception('write failed');
+            saved.add(notes);
+          },
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('user-notes-field')),
+        'Nice IPA',
+      );
+      await tester.pump(
+        YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+      );
+      await tester.pump();
+
+      expect(attempts, 1);
+      expect(find.text('Saved'), findsNothing);
+
+      // The edit stays pending: the next keystroke's flush retries it.
+      shouldFail = false;
+      await tester.enterText(
+        find.byKey(const ValueKey('user-notes-field')),
+        'Nice IPA indeed',
+      );
+      await tester.pump(
+        YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+      );
+      await tester.pump();
+
+      expect(saved, ['Nice IPA indeed']);
+      expect(find.text('Saved'), findsOneWidget);
+
+      await tester.pump(YourTakeCard.savedIndicatorDuration);
+    });
+
+    testWidgets(
+      'the note just typed stays visible after blur while the save is '
+      'still in flight',
+      (tester) async {
+        final completer = Completer<void>();
+        await tester.pumpWidget(
+          buildWidget(onNotesChanged: (_) => completer.future),
+        );
+
+        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+        await tester.pump();
+        await tester.enterText(
+          find.byKey(const ValueKey('user-notes-field')),
+          'Great beer',
+        );
+        FocusManager.instance.primaryFocus?.unfocus();
+        await tester.pump();
+
+        // Back in display mode with the save unresolved — the new text must
+        // not flash back to the placeholder while the write is in flight.
+        expect(find.byKey(const ValueKey('user-notes-field')), findsNothing);
+        expect(find.text('Great beer'), findsOneWidget);
+        expect(find.text('Tap to add your notes'), findsNothing);
+
+        completer.complete();
+        await tester.pump();
+        await tester.pump(YourTakeCard.savedIndicatorDuration);
+      },
+    );
+
     testWidgets('the Saved indicator appears after a save and clears itself', (
       tester,
     ) async {
@@ -228,6 +334,22 @@ void main() {
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets('the inline note field exposes a text-field semantics node', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(buildWidget());
+
+        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+        await tester.pump();
+
+        expect(find.semantics.byFlag(SemanticsFlag.isTextField), findsOne);
+      } finally {
+        handle.dispose();
+      }
     });
 
     testWidgets('the Saved indicator is announced as a live region', (

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -375,7 +375,7 @@ void main() {
   });
 
   group('YourTakeCard My Festival nudge', () {
-    testWidgets('appears for a note-only drink and offers both signals', (
+    testWidgets('appears for a note-only drink with a Drunk it! action', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -386,8 +386,10 @@ void main() {
       );
 
       expect(find.text('Show it in My Festival?'), findsOneWidget);
-      expect(find.byKey(const ValueKey('nudge-want-to-try')), findsOneWidget);
       expect(find.byKey(const ValueKey('nudge-drunk-it')), findsOneWidget);
+      // Want-to-try is NOT repeated in the nudge — the header pill is the
+      // one control for that signal, so exactly one exists in the card.
+      expect(find.text('Want to Try'), findsOneWidget);
     });
 
     testWidgets('is absent when there is no note', (tester) async {
@@ -451,39 +453,34 @@ void main() {
       },
     );
 
-    testWidgets('chips invoke the want-to-try and log-tasting callbacks', (
+    testWidgets('the Drunk it! button invokes the log-tasting callback', (
       tester,
     ) async {
-      var wantToTryTaps = 0;
       var logTastingTaps = 0;
       await tester.pumpWidget(
         buildWidget(
           drink: createSampleDrink(notes: 'Dave said try this'),
-          onWantToTryTap: () => wantToTryTaps++,
           onLogTasting: () => logTastingTaps++,
         ),
       );
 
-      await tester.tap(find.byKey(const ValueKey('nudge-want-to-try')));
       await tester.tap(find.byKey(const ValueKey('nudge-drunk-it')));
 
-      expect(wantToTryTaps, 1);
       expect(logTastingTaps, 1);
     });
 
-    testWidgets('omits the Drunk it! chip when no log callback is given', (
+    testWidgets('is absent entirely when no log callback is given', (
       tester,
     ) async {
       await tester.pumpWidget(
         buildWidget(drink: createSampleDrink(notes: 'Dave said try this')),
       );
 
-      expect(find.text('Show it in My Festival?'), findsOneWidget);
-      expect(find.byKey(const ValueKey('nudge-want-to-try')), findsOneWidget);
+      expect(find.text('Show it in My Festival?'), findsNothing);
       expect(find.byKey(const ValueKey('nudge-drunk-it')), findsNothing);
     });
 
-    testWidgets('chips are labelled buttons', (tester) async {
+    testWidgets('the Drunk it! button is a labelled button', (tester) async {
       await tester.pumpWidget(
         buildWidget(
           drink: createSampleDrink(notes: 'Dave said try this'),
@@ -491,16 +488,6 @@ void main() {
         ),
       );
 
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is Semantics &&
-              widget.properties.label ==
-                  'Add Test Beer to My Festival as want to try' &&
-              widget.properties.button == true,
-        ),
-        findsOneWidget,
-      );
       expect(
         find.byWidgetPredicate(
           (widget) =>

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -423,93 +423,35 @@ void main() {
       expect(find.text('Show it in My Festival?'), findsNothing);
     });
 
-    testWidgets('appears as soon as note editing begins', (tester) async {
-      await tester.pumpWidget(buildWidget(onLogTasting: () {}));
-
-      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
-      await tester.pump();
-
-      // The prompt is offered at writing time, above the field (below the
-      // field it would be clipped by the keyboard on a phone), so a
-      // note-only capture is classifiable in the moment.
-      expect(find.byKey(const ValueKey('user-notes-field')), findsOneWidget);
-      expect(find.text('Show it in My Festival?'), findsOneWidget);
-    });
-
     testWidgets(
-      'is absent while editing a note on an already-signalled drink',
+      'is never shown while editing, and appears the moment editing ends',
       (tester) async {
-        await tester.pumpWidget(
-          buildWidget(
-            drink: createSampleDrink(notes: 'Loved it', wantToTry: true),
-            onLogTasting: () {},
-          ),
-        );
+        await tester.pumpWidget(buildWidget(onLogTasting: () {}));
 
         await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
         await tester.pump();
+        await tester.enterText(
+          find.byKey(const ValueKey('user-notes-field')),
+          'Dave said try this',
+        );
+        await tester.pump();
 
+        // With the keyboard up, taps outside the field blur it mid-gesture
+        // and reflow the page — no buttons may compete with it.
         expect(find.text('Show it in My Festival?'), findsNothing);
+
+        FocusManager.instance.primaryFocus?.unfocus();
+        await tester.pump();
+
+        // Editing over: the prompt takes the slot where the field was —
+        // the first moment a tap is actually safe.
+        expect(find.byKey(const ValueKey('user-notes-field')), findsNothing);
+        expect(find.text('Show it in My Festival?'), findsOneWidget);
+        expect(find.byKey(const ValueKey('nudge-drunk-it')), findsOneWidget);
+
+        await tester.pump(YourTakeCard.savedIndicatorDuration);
       },
     );
-
-    testWidgets('the Drunk it! button can be tapped while editing', (
-      tester,
-    ) async {
-      var logTastingTaps = 0;
-      await tester.pumpWidget(
-        buildWidget(onLogTasting: () => logTastingTaps++),
-      );
-
-      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
-      await tester.pump();
-      await tester.enterText(
-        find.byKey(const ValueKey('user-notes-field')),
-        'Great beer',
-      );
-
-      await tester.tap(find.byKey(const ValueKey('nudge-drunk-it')));
-      await tester.pump();
-
-      expect(logTastingTaps, 1);
-
-      // Let the pending autosave and indicator timers resolve.
-      await tester.pump(
-        YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
-      );
-      await tester.pump(YourTakeCard.savedIndicatorDuration);
-    });
-
-    testWidgets('the Drunk it! button keeps its position when editing ends', (
-      tester,
-    ) async {
-      await tester.pumpWidget(buildWidget(onLogTasting: () {}));
-
-      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
-      await tester.pump();
-      await tester.enterText(
-        find.byKey(const ValueKey('user-notes-field')),
-        'Great beer',
-      );
-      await tester.pump();
-
-      final before = tester.getTopLeft(
-        find.byKey(const ValueKey('nudge-drunk-it')),
-      );
-
-      // On a phone, tapping the button blurs the field mid-gesture and
-      // collapses edit mode before the finger lifts. The button must not
-      // move in that transition, or the tap lands on something else.
-      FocusManager.instance.primaryFocus?.unfocus();
-      await tester.pump();
-
-      final after = tester.getTopLeft(
-        find.byKey(const ValueKey('nudge-drunk-it')),
-      );
-      expect(after, before);
-
-      await tester.pump(YourTakeCard.savedIndicatorDuration);
-    });
 
     testWidgets('the Drunk it! button invokes the log-tasting callback', (
       tester,

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -421,35 +421,18 @@ void main() {
       expect(find.text('Show it in My Festival?'), findsNothing);
     });
 
-    testWidgets(
-      'appears while writing a note, as soon as there is draft text',
-      (tester) async {
-        await tester.pumpWidget(buildWidget(onLogTasting: () {}));
+    testWidgets('appears as soon as note editing begins', (tester) async {
+      await tester.pumpWidget(buildWidget(onLogTasting: () {}));
 
-        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
-        await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
 
-        // Empty draft — nothing to classify yet.
-        expect(find.text('Show it in My Festival?'), findsNothing);
-
-        await tester.enterText(
-          find.byKey(const ValueKey('user-notes-field')),
-          'Dave said try this',
-        );
-        await tester.pump();
-
-        // Still editing (field on screen), and the prompt is already there —
-        // a note-only capture must be classifiable at writing time.
-        expect(find.byKey(const ValueKey('user-notes-field')), findsOneWidget);
-        expect(find.text('Show it in My Festival?'), findsOneWidget);
-
-        // Let the pending autosave land so no timer leaks past the test.
-        await tester.pump(
-          YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
-        );
-        await tester.pump(YourTakeCard.savedIndicatorDuration);
-      },
-    );
+      // The prompt is offered at writing time, above the field (below the
+      // field it would be clipped by the keyboard on a phone), so a
+      // note-only capture is classifiable in the moment.
+      expect(find.byKey(const ValueKey('user-notes-field')), findsOneWidget);
+      expect(find.text('Show it in My Festival?'), findsOneWidget);
+    });
 
     testWidgets(
       'is absent while editing a note on an already-signalled drink',

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:cambridge_beer_festival/widgets/your_take_card.dart';
+
+void main() {
+  const product = Product(
+    id: 'drink1',
+    name: 'Test Beer',
+    category: 'beer',
+    dispense: 'cask',
+    abv: 5.0,
+  );
+
+  const producer = Producer(
+    id: 'brewery1',
+    name: 'Test Brewery',
+    location: 'Cambridge, UK',
+    products: [],
+  );
+
+  Drink createSampleDrink({String? notes}) {
+    return Drink(
+      product: product,
+      producer: producer,
+      festivalId: 'cbf2025',
+      userState: notes == null
+          ? null
+          : UserDrinkState(
+              notes: notes,
+              createdAt: DateTime(2025, 6, 10),
+              updatedAt: DateTime(2025, 6, 10),
+            ),
+    );
+  }
+
+  Widget buildWidget({
+    Drink? drink,
+    VoidCallback? onWantToTryTap,
+    ValueChanged<int?>? onRatingChanged,
+    Future<void> Function(String? notes)? onNotesChanged,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: YourTakeCard(
+          drink: drink ?? createSampleDrink(),
+          onWantToTryTap: onWantToTryTap ?? () {},
+          onRatingChanged: onRatingChanged ?? (_) {},
+          onNotesChanged: onNotesChanged ?? (_) async {},
+        ),
+      ),
+    );
+  }
+
+  group('YourTakeCard notes', () {
+    testWidgets('shows a placeholder when there are no notes', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      expect(find.text('Tap to add your notes'), findsOneWidget);
+    });
+
+    testWidgets('shows the note text when notes are present', (tester) async {
+      await tester.pumpWidget(
+        buildWidget(drink: createSampleDrink(notes: 'Lovely and hoppy')),
+      );
+      expect(find.text('Lovely and hoppy'), findsOneWidget);
+      expect(find.text('Tap to add your notes'), findsNothing);
+    });
+
+    testWidgets('tapping the note row opens an inline, prefilled field', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(drink: createSampleDrink(notes: 'Lovely and hoppy')),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+
+      final field = tester.widget<TextField>(
+        find.byKey(const ValueKey('user-notes-field')),
+      );
+      expect(field.controller?.text, 'Lovely and hoppy');
+    });
+
+    testWidgets('does not autosave before the debounce window elapses', (
+      tester,
+    ) async {
+      final calls = <String?>[];
+      await tester.pumpWidget(
+        buildWidget(onNotesChanged: (notes) async => calls.add(notes)),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('user-notes-field')),
+        'Nice IPA',
+      );
+      // Well within the debounce window.
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(calls, isEmpty);
+
+      // Let the pending timer resolve so it doesn't leak past the test body.
+      await tester.pump(YourTakeCard.notesDebounceDuration);
+    });
+
+    testWidgets('autosaves the trimmed text once the debounce elapses', (
+      tester,
+    ) async {
+      final calls = <String?>[];
+      await tester.pumpWidget(
+        buildWidget(onNotesChanged: (notes) async => calls.add(notes)),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('user-notes-field')),
+        '  Nice IPA  ',
+      );
+      await tester.pump(
+        YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+      );
+
+      expect(calls, ['Nice IPA']);
+    });
+
+    testWidgets('whitespace-only text autosaves as null', (tester) async {
+      final calls = <String?>[];
+      await tester.pumpWidget(
+        buildWidget(
+          drink: createSampleDrink(notes: 'Existing'),
+          onNotesChanged: (notes) async => calls.add(notes),
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('user-notes-field')),
+        '   ',
+      );
+      await tester.pump(
+        YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+      );
+
+      expect(calls, [null]);
+    });
+
+    testWidgets('unfocusing before the debounce elapses saves immediately', (
+      tester,
+    ) async {
+      final calls = <String?>[];
+      await tester.pumpWidget(
+        buildWidget(onNotesChanged: (notes) async => calls.add(notes)),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('user-notes-field')),
+        'Quick save',
+      );
+      // Well before the debounce window would otherwise fire.
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+
+      expect(calls, ['Quick save']);
+    });
+
+    testWidgets('the Saved indicator appears after a save and clears itself', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWidget());
+
+      await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey('user-notes-field')),
+        'Nice IPA',
+      );
+      await tester.pump(
+        YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+      );
+      await tester.pump();
+
+      expect(find.text('Saved'), findsOneWidget);
+
+      await tester.pump(YourTakeCard.savedIndicatorDuration);
+      await tester.pump();
+
+      expect(find.text('Saved'), findsNothing);
+    });
+  });
+
+  group('YourTakeCard notes semantics', () {
+    testWidgets('display-mode note row is a labelled button (add state)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWidget());
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label == 'Add your notes for Test Beer' &&
+              widget.properties.button == true,
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('display-mode note row is a labelled button (edit state)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(drink: createSampleDrink(notes: 'Lovely and hoppy')),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label == 'Edit your notes for Test Beer' &&
+              widget.properties.button == true,
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('the Saved indicator is announced as a live region', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(buildWidget());
+
+        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+        await tester.pump();
+        await tester.enterText(
+          find.byKey(const ValueKey('user-notes-field')),
+          'Nice IPA',
+        );
+        await tester.pump(
+          YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+        );
+        await tester.pump();
+
+        final savedNodeFinder = find.byWidgetPredicate(
+          (widget) => widget is Semantics && widget.properties.label == 'Saved',
+        );
+        expect(savedNodeFinder, findsOneWidget);
+
+        final node = tester.getSemantics(savedNodeFinder);
+        expect(node.hasFlag(SemanticsFlag.isLiveRegion), isTrue);
+      } finally {
+        handle.dispose();
+      }
+    });
+  });
+}

--- a/test/widgets/your_take_card_test.dart
+++ b/test/widgets/your_take_card_test.dart
@@ -421,6 +421,53 @@ void main() {
       expect(find.text('Show it in My Festival?'), findsNothing);
     });
 
+    testWidgets(
+      'appears while writing a note, as soon as there is draft text',
+      (tester) async {
+        await tester.pumpWidget(buildWidget(onLogTasting: () {}));
+
+        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+        await tester.pump();
+
+        // Empty draft — nothing to classify yet.
+        expect(find.text('Show it in My Festival?'), findsNothing);
+
+        await tester.enterText(
+          find.byKey(const ValueKey('user-notes-field')),
+          'Dave said try this',
+        );
+        await tester.pump();
+
+        // Still editing (field on screen), and the prompt is already there —
+        // a note-only capture must be classifiable at writing time.
+        expect(find.byKey(const ValueKey('user-notes-field')), findsOneWidget);
+        expect(find.text('Show it in My Festival?'), findsOneWidget);
+
+        // Let the pending autosave land so no timer leaks past the test.
+        await tester.pump(
+          YourTakeCard.notesDebounceDuration + const Duration(milliseconds: 50),
+        );
+        await tester.pump(YourTakeCard.savedIndicatorDuration);
+      },
+    );
+
+    testWidgets(
+      'is absent while editing a note on an already-signalled drink',
+      (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            drink: createSampleDrink(notes: 'Loved it', wantToTry: true),
+            onLogTasting: () {},
+          ),
+        );
+
+        await tester.tap(find.byKey(const ValueKey('user-notes-editor')));
+        await tester.pump();
+
+        expect(find.text('Show it in My Festival?'), findsNothing);
+      },
+    );
+
     testWidgets('chips invoke the want-to-try and log-tasting callbacks', (
       tester,
     ) async {


### PR DESCRIPTION
Makes personal capture on the drink detail screen lightweight, per the design direction in #487: for private, reversible data — autosave + undo, never confirm; edit in place, never in a form. (Steps 1–2 of the issue; the post-tasting composer is deferred to #462 as the issue specifies.)

## Changes

**Inline autosaving notes** (`YourTakeCard`)
- The note now edits in place: tapping the note (or the "Tap to add your notes" placeholder) swaps in a borderless, growing `TextField` — no sheet, no route, no Save/Cancel.
- Autosaves on a 600 ms keystroke debounce and immediately on blur; a quiet "Saved" indicator confirms, announced to screen readers via a conditionally mounted live region, and only shown when the newest text has actually persisted.
- A cleared or whitespace-only note persists as `null` (same normalization as the old sheet), including when the widget is disposed before the debounce fires; a failed save is kept pending and retried instead of being reported as saved.
- Retires `_NotesEditorSheet` (~100 lines of modal chrome removed from the screen).
- The "Drunk it!" FAB hides while the note is being edited — with the keyboard up, the centre-floating FAB otherwise landed on the field.

**Undo instead of confirm for tasting delete** (`drink_detail_screen.dart`)
- The delete-tasting `AlertDialog` is replaced by immediate delete + a floating Undo SnackBar, mirroring the existing log-tasting pattern (shared builder extracted).
- `BeerProvider.addTasting` gains an optional `at` timestamp so Undo restores the exact removed pour rather than re-dating it to "now", and a restore does not fire the new-tasting analytics events.

**Search matches the user's own notes** (`DrinkFilterService`)
- Drink search covered name, brewery, style and the catalogue description but not the user's note, so a personal marker like a friend's name couldn't find the drink again. The (previously duplicated) search predicate is extracted to one helper and now includes `userNotes`. This is what lets a note-only drink be found again — a lightweight capture doesn't get lost.

## Tests
- New `test/widgets/your_take_card_test.dart`: placeholder/display modes, debounce timing, blur flush, whitespace→null, dispose-flush of a cleared note, failed-save retry, in-flight blur keeps typed text visible, Saved-indicator lifecycle and truthfulness under overlapping saves, editing-state callback, semantics (labelled button, text-field node, live region).
- Updated screen tests: no-dialog delete/undo flow, sheet-less notes flow, FAB hidden while editing; provider test pins the `at` passthrough and the no-analytics-on-restore rule; filter-service tests pin user-note search through both `filterBySearch` and `filterDrinks`.
- `./bin/mise run check` green; goldens verified unchanged.

Fixes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBtxAApaJRzaxzpjwZ1U4y