### PR TITLE
refactor(widgets): share festival status badge and sheet handle

### DIFF
--- a/lib/widgets/drink_filter_sheets.dart
+++ b/lib/widgets/drink_filter_sheets.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../domain/models/models.dart';
 import '../providers/providers.dart';
 import '../utils/utils.dart';
+import 'sheet_handle.dart';
 
 /// Shows the category filter as a modal bottom sheet.
 void showCategoryFilter(BuildContext context) {
@@ -32,25 +33,6 @@ void _showSheet(BuildContext context, WidgetBuilder builder) {
   );
 }
 
-/// Drag handle shown at the top of every filter sheet.
-class _SheetHandle extends StatelessWidget {
-  const _SheetHandle();
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Container(
-        width: 32,
-        height: 4,
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.onSurfaceVariant,
-          borderRadius: BorderRadius.circular(2),
-        ),
-      ),
-    );
-  }
-}
-
 /// Single-select category filter sheet.
 class CategoryFilterSheet extends StatelessWidget {
   final BeerProvider provider;
@@ -72,7 +54,7 @@ class CategoryFilterSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const _SheetHandle(),
+          const SheetHandle(),
           const SizedBox(height: 16),
           Text('Filter by Category', style: theme.textTheme.titleLarge),
           const SizedBox(height: 16),
@@ -152,7 +134,7 @@ class SortOptionsSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const _SheetHandle(),
+          const SheetHandle(),
           const SizedBox(height: 16),
           Text('Sort By', style: theme.textTheme.titleLarge),
           const SizedBox(height: 16),
@@ -220,7 +202,7 @@ class StyleFilterSheet extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const _SheetHandle(),
+              const SheetHandle(),
               const SizedBox(height: 16),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -341,7 +323,7 @@ class VisibilityFilterSheet extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const _SheetHandle(),
+              const SheetHandle(),
               const SizedBox(height: 16),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/widgets/festival_header.dart
+++ b/lib/widgets/festival_header.dart
@@ -58,7 +58,7 @@ class FestivalHeader extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(width: 8),
-                    FestivalStatusBadge(status: status),
+                    FestivalStatusBadge(status: status, compact: true),
                   ],
                 ),
               ],
@@ -70,29 +70,46 @@ class FestivalHeader extends StatelessWidget {
   }
 }
 
-/// Small coloured pill summarising a festival's [FestivalStatus]
-/// (LIVE / SOON / RECENT / PAST). Colours adapt to light and dark themes.
+/// Small coloured pill summarising a festival's [FestivalStatus].
+///
+/// [compact] selects both the label wording and the geometry:
+/// - `compact: true` (app-bar header) — short labels (LIVE / SOON / RECENT /
+///   PAST), tighter padding, smaller radius and font.
+/// - `compact: false` (default, festival browser cards) — long labels
+///   (LIVE / COMING SOON / MOST RECENT / PAST), roomier padding, larger
+///   radius and font.
+///
+/// Colours adapt to light and dark themes and are identical for both modes.
 class FestivalStatusBadge extends StatelessWidget {
-  const FestivalStatusBadge({required this.status, super.key});
+  const FestivalStatusBadge({
+    required this.status,
+    this.compact = false,
+    super.key,
+  });
 
   final FestivalStatus status;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final (badgeLabel, _, lightColor, darkColor) = _styleFor(status);
+    final (compactLabel, longLabel, _, lightColor, darkColor) = _styleFor(
+      status,
+    );
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      padding: compact
+          ? const EdgeInsets.symmetric(horizontal: 6, vertical: 1)
+          : const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       decoration: BoxDecoration(
         color: isDark ? darkColor : lightColor,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(compact ? 8 : 12),
       ),
       child: Text(
-        badgeLabel,
-        style: const TextStyle(
+        compact ? compactLabel : longLabel,
+        style: TextStyle(
           color: Colors.white,
-          fontSize: 9,
+          fontSize: compact ? 9 : 10,
           fontWeight: FontWeight.bold,
         ),
       ),
@@ -101,17 +118,27 @@ class FestivalStatusBadge extends StatelessWidget {
 
   /// Spoken form of the status for screen-reader labels (the badge text is
   /// terse and is excluded from semantics at the parent level).
-  static String spokenLabel(FestivalStatus status) => _styleFor(status).$2;
+  static String spokenLabel(FestivalStatus status) => _styleFor(status).$3;
 
-  /// Returns the badge label, spoken label, and (light, dark) background
-  /// colours for [status]. Single source of truth for all status styling.
-  static (String, String, Color, Color) _styleFor(FestivalStatus status) {
+  /// Returns the compact label, long label, spoken label, and (light, dark)
+  /// background colours for [status]. Single source of truth for all status
+  /// styling, shared by the app-bar header and the festival browser cards.
+  static (String, String, String, Color, Color) _styleFor(
+    FestivalStatus status,
+  ) {
     switch (status) {
       case FestivalStatus.live:
-        return const ('LIVE', 'live now', Color(0xFF2E7D32), Color(0xFF4CAF50));
+        return const (
+          'LIVE',
+          'LIVE',
+          'live now',
+          Color(0xFF2E7D32),
+          Color(0xFF4CAF50),
+        );
       case FestivalStatus.upcoming:
         return const (
           'SOON',
+          'COMING SOON',
           'starting soon',
           Color(0xFF1976D2),
           Color(0xFF42A5F5),
@@ -119,12 +146,19 @@ class FestivalStatusBadge extends StatelessWidget {
       case FestivalStatus.mostRecent:
         return const (
           'RECENT',
+          'MOST RECENT',
           'most recent',
           Color(0xFFEF6C00),
           Color(0xFFFF9800),
         );
       case FestivalStatus.past:
-        return const ('PAST', 'past', Color(0xFF616161), Color(0xFF9E9E9E));
+        return const (
+          'PAST',
+          'PAST',
+          'past',
+          Color(0xFF616161),
+          Color(0xFF9E9E9E),
+        );
     }
   }
 }

--- a/lib/widgets/festival_menu_sheets.dart
+++ b/lib/widgets/festival_menu_sheets.dart
@@ -4,6 +4,8 @@ import 'package:provider/provider.dart';
 import '../models/models.dart';
 import '../providers/providers.dart';
 import '../utils/utils.dart';
+import 'festival_header.dart';
+import 'sheet_handle.dart';
 
 /// Shows the festival browser/selector as a modal bottom sheet
 void showFestivalBrowser(BuildContext context) {
@@ -89,17 +91,7 @@ class FestivalSelectorSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Center(
-            child: Container(
-              key: const Key('festival_selector_drag_handle'),
-              width: 32,
-              height: 4,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.onSurfaceVariant,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-          ),
+          const SheetHandle(key: Key('festival_selector_drag_handle')),
           const SizedBox(height: 16),
           Row(
             children: [
@@ -300,7 +292,8 @@ class FestivalCard extends StatelessWidget {
                       children: [
                         Row(
                           children: [
-                            _buildStatusBadge(status),
+                            FestivalStatusBadge(status: status),
+                            const SizedBox(width: 8),
                             Expanded(
                               child: Text(
                                 festival.name,
@@ -422,58 +415,6 @@ class FestivalCard extends StatelessWidget {
       ),
     );
   }
-
-  Widget _buildStatusBadge(FestivalStatus status) {
-    return Builder(
-      builder: (context) {
-        final theme = Theme.of(context);
-        final isDark = theme.brightness == Brightness.dark;
-
-        Color backgroundColor;
-        String label;
-
-        switch (status) {
-          case FestivalStatus.live:
-            backgroundColor = isDark
-                ? const Color(0xFF4CAF50)
-                : const Color(0xFF2E7D32);
-            label = 'LIVE';
-          case FestivalStatus.upcoming:
-            backgroundColor = isDark
-                ? const Color(0xFF42A5F5)
-                : const Color(0xFF1976D2);
-            label = 'COMING SOON';
-          case FestivalStatus.mostRecent:
-            backgroundColor = isDark
-                ? const Color(0xFFFF9800)
-                : const Color(0xFFEF6C00);
-            label = 'MOST RECENT';
-          case FestivalStatus.past:
-            backgroundColor = isDark
-                ? const Color(0xFF9E9E9E)
-                : const Color(0xFF616161);
-            label = 'PAST';
-        }
-
-        return Container(
-          margin: const EdgeInsets.only(right: 8),
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-          decoration: BoxDecoration(
-            color: backgroundColor,
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: Text(
-            label,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 10,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        );
-      },
-    );
-  }
 }
 
 /// Settings bottom sheet with theme selector
@@ -508,17 +449,7 @@ class SettingsSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Center(
-            child: Container(
-              key: const Key('settings_sheet_drag_handle'),
-              width: 32,
-              height: 4,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.onSurfaceVariant,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-          ),
+          const SheetHandle(key: Key('settings_sheet_drag_handle')),
           const SizedBox(height: 16),
           Text('Settings', style: theme.textTheme.titleLarge),
           const SizedBox(height: 16),
@@ -569,17 +500,7 @@ class ThemeSelectorSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Center(
-            child: Container(
-              key: const Key('theme_selector_sheet_drag_handle'),
-              width: 32,
-              height: 4,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.onSurfaceVariant,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-          ),
+          const SheetHandle(key: Key('theme_selector_sheet_drag_handle')),
           const SizedBox(height: 16),
           Text('Theme', style: theme.textTheme.titleLarge),
           const SizedBox(height: 16),

--- a/lib/widgets/festival_menu_sheets.dart
+++ b/lib/widgets/festival_menu_sheets.dart
@@ -91,7 +91,7 @@ class FestivalSelectorSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const SheetHandle(key: Key('festival_selector_drag_handle')),
+          const SheetHandle(handleKey: Key('festival_selector_drag_handle')),
           const SizedBox(height: 16),
           Row(
             children: [
@@ -449,7 +449,7 @@ class SettingsSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const SheetHandle(key: Key('settings_sheet_drag_handle')),
+          const SheetHandle(handleKey: Key('settings_sheet_drag_handle')),
           const SizedBox(height: 16),
           Text('Settings', style: theme.textTheme.titleLarge),
           const SizedBox(height: 16),
@@ -500,7 +500,7 @@ class ThemeSelectorSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const SheetHandle(key: Key('theme_selector_sheet_drag_handle')),
+          const SheetHandle(handleKey: Key('theme_selector_sheet_drag_handle')),
           const SizedBox(height: 16),
           Text('Theme', style: theme.textTheme.titleLarge),
           const SizedBox(height: 16),

--- a/lib/widgets/sheet_handle.dart
+++ b/lib/widgets/sheet_handle.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Drag handle shown at the top of every modal bottom sheet in this app
+/// (filter sheets, festival selector, settings, theme selector).
+///
+/// The key passed to this widget is applied to the inner [Container] rather
+/// than to [SheetHandle] itself, so callers that key the drag handle for
+/// tests (`SheetHandle(key: Key('some_drag_handle'))`) can keep finding a
+/// [Container] with that key — matching the pre-refactor widget tree where
+/// the key lived directly on the hand-rolled `Container`.
+class SheetHandle extends StatelessWidget {
+  const SheetHandle({Key? key}) : _handleKey = key, super(key: null);
+
+  final Key? _handleKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        key: _handleKey,
+        width: 32,
+        height: 4,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/sheet_handle.dart
+++ b/lib/widgets/sheet_handle.dart
@@ -3,21 +3,22 @@ import 'package:flutter/material.dart';
 /// Drag handle shown at the top of every modal bottom sheet in this app
 /// (filter sheets, festival selector, settings, theme selector).
 ///
-/// The key passed to this widget is applied to the inner [Container] rather
-/// than to [SheetHandle] itself, so callers that key the drag handle for
-/// tests (`SheetHandle(key: Key('some_drag_handle'))`) can keep finding a
-/// [Container] with that key — matching the pre-refactor widget tree where
-/// the key lived directly on the hand-rolled `Container`.
+/// [handleKey] is applied to the inner [Container] rather than to this widget,
+/// so callers that key the drag handle for tests keep finding a [Container]
+/// with that key — matching the pre-refactor widget tree, where the key lived
+/// directly on the hand-rolled `Container`. Keying the widget itself via [key]
+/// remains available and behaves normally.
 class SheetHandle extends StatelessWidget {
-  const SheetHandle({Key? key}) : _handleKey = key, super(key: null);
+  const SheetHandle({this.handleKey, super.key});
 
-  final Key? _handleKey;
+  /// Key applied to the inner container, for tests locating the handle.
+  final Key? handleKey;
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: Container(
-        key: _handleKey,
+        key: handleKey,
         width: 32,
         height: 4,
         decoration: BoxDecoration(

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -18,6 +18,7 @@ export 'info_chip.dart';
 export 'overflow_menu.dart';
 export 'page_title.dart';
 export 'section_header.dart';
+export 'sheet_handle.dart';
 export 'star_rating.dart';
 export 'style_hero_panel.dart';
 export 'your_take_card.dart';

--- a/test/widgets/festival_header_test.dart
+++ b/test/widgets/festival_header_test.dart
@@ -14,6 +14,7 @@ void main() {
   group('FestivalStatusBadge', () {
     Widget wrap(
       FestivalStatus status, {
+      bool? compact,
       Brightness brightness = Brightness.light,
     }) {
       // Wrap the badge in an explicit Theme so brightness is deterministic
@@ -22,26 +23,58 @@ void main() {
         home: Theme(
           data: ThemeData(brightness: brightness),
           child: Scaffold(
-            body: Center(child: FestivalStatusBadge(status: status)),
+            body: Center(
+              child: compact == null
+                  ? FestivalStatusBadge(status: status)
+                  : FestivalStatusBadge(status: status, compact: compact),
+            ),
           ),
         ),
       );
     }
 
-    const expectedLabels = {
+    const compactLabels = {
       FestivalStatus.live: 'LIVE',
       FestivalStatus.upcoming: 'SOON',
       FestivalStatus.mostRecent: 'RECENT',
       FestivalStatus.past: 'PAST',
     };
 
-    for (final entry in expectedLabels.entries) {
-      testWidgets('renders ${entry.value} label for ${entry.key}', (
-        tester,
-      ) async {
-        await tester.pumpWidget(wrap(entry.key));
-        expect(find.text(entry.value), findsOneWidget);
-      });
+    const longLabels = {
+      FestivalStatus.live: 'LIVE',
+      FestivalStatus.upcoming: 'COMING SOON',
+      FestivalStatus.mostRecent: 'MOST RECENT',
+      FestivalStatus.past: 'PAST',
+    };
+
+    for (final entry in compactLabels.entries) {
+      testWidgets(
+        'compact: true renders ${entry.value} label for ${entry.key}',
+        (tester) async {
+          await tester.pumpWidget(wrap(entry.key, compact: true));
+          expect(find.text(entry.value), findsOneWidget);
+        },
+      );
+    }
+
+    for (final entry in longLabels.entries) {
+      testWidgets(
+        'compact: false renders ${entry.value} label for ${entry.key}',
+        (tester) async {
+          await tester.pumpWidget(wrap(entry.key, compact: false));
+          expect(find.text(entry.value), findsOneWidget);
+        },
+      );
+    }
+
+    for (final entry in longLabels.entries) {
+      testWidgets(
+        'defaults to the long label (compact not passed) for ${entry.key}',
+        (tester) async {
+          await tester.pumpWidget(wrap(entry.key));
+          expect(find.text(entry.value), findsOneWidget);
+        },
+      );
     }
 
     testWidgets('badge colour adapts to light and dark themes', (tester) async {

--- a/test/widgets/festival_menu_sheets_test.dart
+++ b/test/widgets/festival_menu_sheets_test.dart
@@ -604,6 +604,9 @@ void main() {
       );
 
       expect(find.text('LIVE'), findsOneWidget);
+      // FestivalCard's badge is the shared FestivalStatusBadge (compact:
+      // false, the default), not a bespoke copy — regression guard for #499.
+      expect(find.byType(FestivalStatusBadge), findsOneWidget);
     });
 
     testWidgets('shows COMING SOON badge for an upcoming festival', (

--- a/test/widgets/sheet_handle_test.dart
+++ b/test/widgets/sheet_handle_test.dart
@@ -1,0 +1,68 @@
+import 'package:cambridge_beer_festival/app_theme.dart';
+import 'package:cambridge_beer_festival/widgets/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SheetHandle', () {
+    testWidgets('renders a 32x4 rounded container', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: SheetHandle())),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      expect(
+        container.constraints,
+        const BoxConstraints.tightFor(width: 32, height: 4),
+      );
+
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.borderRadius, BorderRadius.circular(2));
+    });
+
+    testWidgets('centres the handle in its available space', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: SheetHandle())),
+      );
+
+      expect(
+        find.ancestor(
+          of: find.byType(Container),
+          matching: find.byType(Center),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('honours a passed key on the inner container', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: SheetHandle(key: Key('my_drag_handle'))),
+        ),
+      );
+
+      final container = tester.widget<Container>(
+        find.byKey(const Key('my_drag_handle')),
+      );
+      expect(
+        container.constraints,
+        const BoxConstraints.tightFor(width: 32, height: 4),
+      );
+    });
+
+    testWidgets('uses onSurfaceVariant from the current theme', (tester) async {
+      final lightTheme = buildAppTheme(Brightness.light);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: lightTheme,
+          home: const Scaffold(body: SheetHandle()),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.color, lightTheme.colorScheme.onSurfaceVariant);
+    });
+  });
+}

--- a/test/widgets/sheet_handle_test.dart
+++ b/test/widgets/sheet_handle_test.dart
@@ -34,12 +34,16 @@ void main() {
       );
     });
 
-    testWidgets('honours a passed key on the inner container', (tester) async {
+    testWidgets('applies handleKey to the inner container', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: Scaffold(body: SheetHandle(key: Key('my_drag_handle'))),
+          home: Scaffold(body: SheetHandle(handleKey: Key('my_drag_handle'))),
         ),
       );
+
+      // Exactly one match: the key lands on the Container only, never on the
+      // SheetHandle itself, so tester.widget<Container>() stays unambiguous.
+      expect(find.byKey(const Key('my_drag_handle')), findsOneWidget);
 
       final container = tester.widget<Container>(
         find.byKey(const Key('my_drag_handle')),
@@ -47,6 +51,20 @@ void main() {
       expect(
         container.constraints,
         const BoxConstraints.tightFor(width: 32, height: 4),
+      );
+    });
+
+    testWidgets('keys the widget itself normally via key', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: SheetHandle(key: Key('handle_widget'))),
+        ),
+      );
+
+      expect(find.byKey(const Key('handle_widget')), findsOneWidget);
+      expect(
+        tester.widget(find.byKey(const Key('handle_widget'))),
+        isA<SheetHandle>(),
       );
     });
 

--- a/test/widgets/sheet_handle_test.dart
+++ b/test/widgets/sheet_handle_test.dart
@@ -5,12 +5,20 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('SheetHandle', () {
+    // Scoped to SheetHandle's own subtree so the finders stay unambiguous
+    // if the surrounding test scaffolding ever gains its own Containers.
+    final handleContainer = find.descendant(
+      of: find.byType(SheetHandle),
+      matching: find.byType(Container),
+    );
+
     testWidgets('renders a 32x4 rounded container', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(home: Scaffold(body: SheetHandle())),
       );
 
-      final container = tester.widget<Container>(find.byType(Container));
+      expect(handleContainer, findsOneWidget);
+      final container = tester.widget<Container>(handleContainer);
       expect(
         container.constraints,
         const BoxConstraints.tightFor(width: 32, height: 4),
@@ -26,10 +34,7 @@ void main() {
       );
 
       expect(
-        find.ancestor(
-          of: find.byType(Container),
-          matching: find.byType(Center),
-        ),
+        find.ancestor(of: handleContainer, matching: find.byType(Center)),
         findsOneWidget,
       );
     });
@@ -78,7 +83,8 @@ void main() {
         ),
       );
 
-      final container = tester.widget<Container>(find.byType(Container));
+      expect(handleContainer, findsOneWidget);
+      final container = tester.widget<Container>(handleContainer);
       final decoration = container.decoration! as BoxDecoration;
       expect(decoration.color, lightTheme.colorScheme.onSurfaceVariant);
     });


### PR DESCRIPTION
Fixes #499

The festival status badge was implemented twice with byte-identical colours but divergent user-visible labels, and `festival_menu_sheets.dart` did not import `festival_header.dart` at all.

## Decision: keep both label sets

`FestivalStatusBadge` gains a `compact` flag (default `false`) that drives both wording and geometry, so **neither surface changes what the user sees**:

| | `compact: true` (app bar) | `compact: false` (festival cards) |
|---|---|---|
| labels | LIVE / SOON / RECENT / PAST | LIVE / COMING SOON / MOST RECENT / PAST |
| padding | h6 v1 | h8 v2 |
| radius / fontSize | 8 / 9 | 12 / 10 |

`_styleFor` is now the single source of truth, returning `(compactLabel, longLabel, spokenLabel, light, dark)`. The public `spokenLabel()` API and its exact spoken values (`live now`, `starting soon`, `most recent`, `past`) are unchanged.

## Changes

- `FestivalCard._buildStatusBadge` deleted, including the `Builder` it used purely to obtain a `context` that `FestivalCard.build` already had. Its `margin: right 8` became a `SizedBox(width: 8)` at the call site, so card spacing is unchanged.
- The filter sheets' private `_SheetHandle` is promoted to a shared `SheetHandle` in its own file and exported from `widgets.dart`. The three hand-rolled 32×4 drag-handle containers in `festival_menu_sheets.dart` now use it, as do the four existing call sites in `drink_filter_sheets.dart`.
- `SheetHandle` takes an explicit `handleKey` that lands on the inner `Container`. Forwarding the widget's own `key` there instead would make `find.byKey` match two widgets and break the existing `tester.widget<Container>(...)` assertions with `Bad state: Too many elements`; a separate named parameter keeps `key` behaving normally for a shared widget.

## Testing

`./bin/mise run check` green (analyzer clean, full suite passing). Also verified green on the union with #500, which touches the same `widgets.dart` barrel.

- `festival_header_test.dart` — compact vs default-long labels across all four `FestivalStatus` values; existing `FestivalHeader` semantics coverage untouched
- `festival_menu_sheets_test.dart` — the existing `COMING SOON` / `MOST RECENT` and three drag-handle-key assertions pass **unedited**, which is the regression guard for the copy decision; one `FestivalStatusBadge` widget-type assertion added
- `sheet_handle_test.dart` (new) — geometry, centring, `handleKey` forwarding to a single `Container`, normal `key` behaviour, theme colour

Not verified: on-device/browser rendering. The badge geometry is asserted in tests but has not been eyeballed on a real device.

---
_Generated by [Claude Code](https://claude.ai/code/session_017B31wKKL578bV18hcpXyE2)_