### PR TITLE
fix(filters): scope drink facets by all filters but their own

### DIFF
--- a/lib/domain/controllers/drink_filter_controller.dart
+++ b/lib/domain/controllers/drink_filter_controller.dart
@@ -14,6 +14,36 @@ import '../services/services.dart';
 ///
 /// All mutators are synchronous and side-effect free; callers are responsible
 /// for persisting and broadcasting changes.
+///
+/// ## Facet scoping rule
+///
+/// [availableCategories], [categoryCountsMap], [availableStyles],
+/// [styleCountsMap], and [availableAllergens] are all derived by one rule:
+/// **a facet is computed from the source with every *other* structural
+/// filter applied — but never its own.** Structural filters are category,
+/// styles, favourites-only, visibility filters, and excluded allergens. A
+/// facet must not narrow itself, or selecting one of its own options would
+/// hide its siblings and the list would collapse under the user's finger
+/// (e.g. picking one style must not make every other style disappear from
+/// the style picker). See [_scopeFor], the single helper all five getters
+/// share.
+///
+/// Two invariants hold for every facet:
+/// 1. A currently-selected option is always listed, even when its scoped
+///    count is 0 — an active filter (especially an allergen exclusion,
+///    which is a safety filter) must never vanish from the UI the user
+///    would use to clear it.
+/// 2. [availableAllergens] lists only allergens actually present (a
+///    non-zero value) in scope, not merely mentioned with a value of 0 in a
+///    drink's allergens map — matching
+///    [DrinkFilterService.filterByExcludedAllergens]'s own definition of
+///    "absent".
+///
+/// Free-text search is deliberately **excluded** from facet scoping.
+/// `drinks_screen.dart` derives `hasStyleFilter` from
+/// `provider.availableStyles.isNotEmpty` to decide whether to show the Style
+/// button in the filter bar; scoping facets by the search query would make
+/// that button appear and disappear as the user types.
 class DrinkFilterController {
   final DrinkFilterService _filterService;
   final DrinkSortService _sortService;
@@ -55,52 +85,75 @@ class DrinkFilterController {
   /// Drinks after the active filters and sort have been applied.
   List<Drink> get filteredDrinks => _filtered;
 
-  /// Unique categories present in the source drinks, sorted.
+  /// Unique categories present in scope (see class doc), sorted naturally.
+  /// The [selectedCategory], if any, is always included even if its scoped
+  /// count is 0 (invariant 1).
   List<String> get availableCategories {
-    return _source.map((d) => d.category).toSet().toList()..sort();
+    final categories = _scopeFor(
+      _Facet.category,
+    ).map((d) => d.category).toSet();
+    if (_selectedCategory != null) categories.add(_selectedCategory!);
+    return categories.toList()..sort();
   }
 
-  /// Unique styles in the source drinks, narrowed to the selected category when
-  /// one is active, sorted case-insensitively (via
-  /// [StringComparisonHelper.compareCaseInsensitive]) so styles order in a stable,
-  /// human-friendly way regardless of capitalisation. Presentation consumes
-  /// this directly — no sorting in the UI.
+  /// Unique styles in scope (see class doc), sorted case-insensitively (via
+  /// [StringComparisonHelper.compareCaseInsensitive]) so styles order in a
+  /// stable, human-friendly way regardless of capitalisation. Every
+  /// [selectedStyles] entry is always included even if its scoped count is 0
+  /// (invariant 1). Presentation consumes this directly — no sorting in the
+  /// UI.
   List<String> get availableStyles {
-    return _categoryScopedSource()
-        .where((d) => d.style != null && d.style!.isNotEmpty)
-        .map((d) => d.style!)
-        .toSet()
-        .toList()
-      ..sort(StringComparisonHelper.compareCaseInsensitive);
+    final styles =
+        _scopeFor(_Facet.style)
+            .where((d) => d.style != null && d.style!.isNotEmpty)
+            .map((d) => d.style!)
+            .toSet()
+          ..addAll(_selectedStyles);
+    return styles.toList()..sort(StringComparisonHelper.compareCaseInsensitive);
   }
 
-  /// Drink count per category across the full source.
+  /// Drink count per category, scoped per the class doc. A [selectedCategory]
+  /// with no matches in scope is still present, mapped to 0 (invariant 1).
   Map<String, int> get categoryCountsMap {
     final counts = <String, int>{};
-    for (final drink in _source) {
+    for (final drink in _scopeFor(_Facet.category)) {
       counts[drink.category] = (counts[drink.category] ?? 0) + 1;
+    }
+    if (_selectedCategory != null) {
+      counts.putIfAbsent(_selectedCategory!, () => 0);
     }
     return counts;
   }
 
-  /// Drink count per style, narrowed to the selected category when one is
-  /// active.
+  /// Drink count per style, scoped per the class doc. Every entry of
+  /// [selectedStyles] with no matches in scope is still present, mapped to 0
+  /// (invariant 1).
   Map<String, int> get styleCountsMap {
     final counts = <String, int>{};
-    for (final drink in _categoryScopedSource()) {
+    for (final drink in _scopeFor(_Facet.style)) {
       if (drink.style != null && drink.style!.isNotEmpty) {
         counts[drink.style!] = (counts[drink.style!] ?? 0) + 1;
       }
     }
+    for (final style in _selectedStyles) {
+      counts.putIfAbsent(style, () => 0);
+    }
     return counts;
   }
 
-  /// Every allergen key present across the source drinks.
+  /// Allergens actually present (non-zero) on at least one drink in scope
+  /// (see class doc and invariant 2), plus every currently
+  /// [excludedAllergens] entry even if nothing in scope carries it
+  /// (invariant 1) — a ticked allergen exclusion is a safety filter and must
+  /// stay visible so the user can untick it.
   Set<String> get availableAllergens {
     final allergens = <String>{};
-    for (final drink in _source) {
-      allergens.addAll(drink.allergens.keys);
+    for (final drink in _scopeFor(_Facet.allergen)) {
+      for (final entry in drink.allergens.entries) {
+        if (entry.value != 0) allergens.add(entry.key);
+      }
     }
+    allergens.addAll(_excludedAllergens);
     return allergens;
   }
 
@@ -232,10 +285,21 @@ class DrinkFilterController {
     }
   }
 
-  /// Source narrowed to the selected category, or the full source when no
-  /// category is selected.
-  Iterable<Drink> _categoryScopedSource() {
-    if (_selectedCategory == null) return _source;
-    return _source.where((d) => d.category == _selectedCategory);
-  }
+  /// Source filtered by every structural criterion *except* the one
+  /// belonging to [facet] — the single implementation of the facet-scoping
+  /// rule documented on the class. Free-text search is intentionally never
+  /// applied here (see class doc).
+  Iterable<Drink> _scopeFor(_Facet facet) => _filterService.filterDrinks(
+    _source,
+    category: facet == _Facet.category ? null : _selectedCategory,
+    styles: facet == _Facet.style ? const {} : _selectedStyles,
+    favoritesOnly: _showFavoritesOnly,
+    visibilityFilters: _visibilityFilters,
+    excludedAllergens: facet == _Facet.allergen ? const {} : _excludedAllergens,
+    // searchQuery intentionally omitted — see class doc "Facet scoping rule".
+  );
 }
+
+/// Which structural criterion a facet getter must not apply to itself. See
+/// [DrinkFilterController._scopeFor].
+enum _Facet { category, style, allergen }

--- a/test/domain/controllers/drink_filter_controller_test.dart
+++ b/test/domain/controllers/drink_filter_controller_test.dart
@@ -310,17 +310,86 @@ void main() {
       });
     });
 
-    group('facet getters', () {
-      test('availableCategories is unique and sorted', () {
+    // Facet scoping rule under test: each facet is derived from the source
+    // with every *other* structural filter applied, but never its own. See
+    // the class doc on DrinkFilterController for the full statement.
+
+    group('category facet scoping', () {
+      test('availableCategories and categoryCountsMap span the full source '
+          'when no other filter is active', () {
         controller.setSource(_sampleDrinks());
         expect(controller.availableCategories, ['beer', 'cider']);
-      });
-
-      test('categoryCountsMap counts across the full source', () {
-        controller.setSource(_sampleDrinks());
         expect(controller.categoryCountsMap, {'beer': 2, 'cider': 2});
       });
 
+      test('categories narrow when a style filter is active', () {
+        controller
+          ..setSource(_sampleDrinks())
+          ..toggleStyle('IPA'); // IPA only exists on a beer drink.
+        expect(controller.availableCategories, ['beer']);
+        expect(controller.categoryCountsMap, {'beer': 1});
+      });
+
+      test('categories narrow when favourites-only is active', () {
+        final drinks = _sampleDrinks();
+        drinks[0] = drinks[0].copyWith(
+          userState: UserDrinkState.initial().copyWith(wantToTry: true),
+        ); // Alpha Ale (beer) is the only favourite.
+        controller
+          ..setSource(drinks)
+          ..setShowFavoritesOnly(value: true);
+        expect(controller.availableCategories, ['beer']);
+        expect(controller.categoryCountsMap, {'beer': 1});
+      });
+
+      test('categories narrow when a visibility filter is active', () {
+        final drinks = _sampleDrinks();
+        // Mark both beer drinks tasted so the entire category drops out
+        // under the not-tasted filter.
+        drinks[0] = drinks[0].copyWith(
+          userState: UserDrinkState.initial().copyWith(
+            tastingEvents: [DateTime(2026, 5, 18)],
+          ),
+        );
+        drinks[1] = drinks[1].copyWith(
+          userState: UserDrinkState.initial().copyWith(
+            tastingEvents: [DateTime(2026, 5, 18)],
+          ),
+        );
+        controller
+          ..setSource(drinks)
+          ..setVisibilityFilter(DrinkVisibilityFilter.notTasted, active: true);
+        expect(controller.availableCategories, ['cider']);
+        expect(controller.categoryCountsMap, {'cider': 2});
+      });
+
+      test('categories narrow when an allergen exclusion is active', () {
+        controller
+          ..setSource([
+            _drink(
+              id: 'a',
+              name: 'Gluten Pale',
+              category: 'beer',
+              allergens: {'gluten': 1},
+            ),
+            _drink(id: 'b', name: 'Only Cider', category: 'cider'),
+          ])
+          ..setAllergenFilter('gluten', active: true);
+        expect(controller.availableCategories, ['cider']);
+        expect(controller.categoryCountsMap, {'cider': 1});
+      });
+
+      test('category facet does not narrow itself — selecting one category '
+          'still lists the others', () {
+        controller
+          ..setSource(_sampleDrinks())
+          ..setCategory('beer');
+        expect(controller.availableCategories, ['beer', 'cider']);
+        expect(controller.categoryCountsMap, {'beer': 2, 'cider': 2});
+      });
+    });
+
+    group('style facet scoping', () {
       test('availableStyles spans all categories when none selected', () {
         controller.setSource(_sampleDrinks());
         expect(controller.availableStyles, ['Bitter', 'Dry', 'IPA', 'Sweet']);
@@ -353,17 +422,339 @@ void main() {
         expect(controller.styleCountsMap, {'IPA': 1, 'Bitter': 1});
       });
 
-      test('availableAllergens aggregates keys across the source', () {
+      test('styles narrow when favourites-only is active', () {
+        final drinks = _sampleDrinks();
+        drinks[0] = drinks[0].copyWith(
+          userState: UserDrinkState.initial().copyWith(wantToTry: true),
+        ); // Alpha Ale (style IPA) is the only favourite.
+        controller
+          ..setSource(drinks)
+          ..setShowFavoritesOnly(value: true);
+        expect(controller.availableStyles, ['IPA']);
+        expect(controller.styleCountsMap, {'IPA': 1});
+      });
+
+      test('styles narrow when a visibility filter is active', () {
+        final drinks = _sampleDrinks();
+        // Tag every drink except Crisp Cider (style Dry) as tasted.
+        drinks[0] = drinks[0].copyWith(
+          userState: UserDrinkState.initial().copyWith(
+            tastingEvents: [DateTime(2026, 5, 18)],
+          ),
+        );
+        drinks[1] = drinks[1].copyWith(
+          userState: UserDrinkState.initial().copyWith(
+            tastingEvents: [DateTime(2026, 5, 18)],
+          ),
+        );
+        drinks[3] = drinks[3].copyWith(
+          userState: UserDrinkState.initial().copyWith(
+            tastingEvents: [DateTime(2026, 5, 18)],
+          ),
+        );
+        controller
+          ..setSource(drinks)
+          ..setVisibilityFilter(DrinkVisibilityFilter.notTasted, active: true);
+        expect(controller.availableStyles, ['Dry']);
+        expect(controller.styleCountsMap, {'Dry': 1});
+      });
+
+      test('styles narrow when an allergen exclusion is active', () {
+        controller
+          ..setSource([
+            _drink(
+              id: 'a',
+              name: 'Gluten IPA',
+              category: 'beer',
+              style: 'IPA',
+              allergens: {'gluten': 1},
+            ),
+            _drink(
+              id: 'b',
+              name: 'Clean Stout',
+              category: 'beer',
+              style: 'Stout',
+            ),
+          ])
+          ..setAllergenFilter('gluten', active: true);
+        expect(controller.availableStyles, ['Stout']);
+        expect(controller.styleCountsMap, {'Stout': 1});
+      });
+
+      test('style facet does not narrow itself — selecting one style still '
+          'lists the others', () {
+        controller
+          ..setSource(_sampleDrinks())
+          ..toggleStyle('IPA');
+        expect(controller.availableStyles, ['Bitter', 'Dry', 'IPA', 'Sweet']);
+        expect(controller.styleCountsMap, {
+          'IPA': 1,
+          'Bitter': 1,
+          'Dry': 1,
+          'Sweet': 1,
+        });
+      });
+    });
+
+    group('allergen facet scoping', () {
+      test('availableAllergens narrows to the selected category', () {
+        controller
+          ..setSource([
+            _drink(
+              id: 'a',
+              name: 'Gluten Beer',
+              category: 'beer',
+              allergens: {'gluten': 1},
+            ),
+            _drink(
+              id: 'b',
+              name: 'Nutty Cider',
+              category: 'cider',
+              allergens: {'nuts': 1},
+            ),
+          ])
+          ..setCategory('beer');
+        expect(controller.availableAllergens, {'gluten'});
+      });
+
+      test('availableAllergens narrows to the selected style', () {
+        controller
+          ..setSource([
+            _drink(
+              id: 'a',
+              name: 'Gluten IPA',
+              category: 'beer',
+              style: 'IPA',
+              allergens: {'gluten': 1},
+            ),
+            _drink(
+              id: 'b',
+              name: 'Nutty Stout',
+              category: 'beer',
+              style: 'Stout',
+              allergens: {'nuts': 1},
+            ),
+          ])
+          ..toggleStyle('IPA');
+        expect(controller.availableAllergens, {'gluten'});
+      });
+
+      test('availableAllergens narrows when favourites-only is active', () {
+        final favourite =
+            _drink(
+              id: 'a',
+              name: 'Gluten Beer',
+              category: 'beer',
+              allergens: {'gluten': 1},
+            ).copyWith(
+              userState: UserDrinkState.initial().copyWith(wantToTry: true),
+            );
+        controller
+          ..setSource([
+            favourite,
+            _drink(
+              id: 'b',
+              name: 'Nutty Beer',
+              category: 'beer',
+              allergens: {'nuts': 1},
+            ),
+          ])
+          ..setShowFavoritesOnly(value: true);
+        expect(controller.availableAllergens, {'gluten'});
+      });
+
+      test('allergen facet does not narrow itself — excluding one allergen '
+          'still lists the others', () {
+        controller
+          ..setSource([
+            _drink(
+              id: 'a',
+              name: 'Gluten Beer',
+              category: 'beer',
+              allergens: {'gluten': 1},
+            ),
+            _drink(
+              id: 'b',
+              name: 'Nutty Beer',
+              category: 'beer',
+              allergens: {'nuts': 1},
+            ),
+          ])
+          ..setAllergenFilter('gluten', active: true);
+        expect(controller.availableAllergens, {'gluten', 'nuts'});
+      });
+    });
+
+    group('facet invariant: an active filter is never hidden', () {
+      test('selected category with a scoped count of 0 is still listed, with '
+          'count 0', () {
+        controller
+          ..setSource(_sampleDrinks())
+          ..setCategory('cider')
+          ..toggleStyle('IPA'); // IPA has no cider drinks.
+        expect(controller.selectedCategory, 'cider');
+        expect(controller.availableCategories, containsAll(['beer', 'cider']));
+        expect(controller.categoryCountsMap['cider'], 0);
+        expect(controller.categoryCountsMap['beer'], 1);
+      });
+
+      test('selected style with a scoped count of 0 is still listed, with '
+          'count 0', () {
+        controller
+          ..setSource(_sampleDrinks())
+          ..setCategory('cider')
+          ..toggleStyle('IPA'); // IPA has no cider drinks.
+        expect(controller.selectedStyles, {'IPA'});
+        expect(
+          controller.availableStyles,
+          containsAll(['Dry', 'Sweet', 'IPA']),
+        );
+        expect(controller.styleCountsMap['IPA'], 0);
+        expect(controller.styleCountsMap['Dry'], 1);
+        expect(controller.styleCountsMap['Sweet'], 1);
+      });
+
+      test(
+        'excluded allergen with nothing matching in scope is still listed',
+        () {
+          controller
+            ..setSource([_drink(id: 'a', name: 'Clean Beer', category: 'beer')])
+            ..setAllergenFilter('gluten', active: true);
+          expect(controller.excludedAllergens, {'gluten'});
+          expect(controller.availableAllergens, contains('gluten'));
+        },
+      );
+
+      test('ticking a scoped-narrowed category option yields exactly the '
+          'stated count', () {
+        final drinks = _sampleDrinks();
+        drinks[0] = drinks[0].copyWith(
+          userState: UserDrinkState.initial().copyWith(wantToTry: true),
+        ); // Alpha Ale (beer) is the only favourite.
+        controller
+          ..setSource(drinks)
+          ..setShowFavoritesOnly(value: true);
+        expect(controller.categoryCountsMap, {'beer': 1});
+
+        controller.setCategory('beer');
+        expect(controller.filteredDrinks, hasLength(1));
+        expect(controller.filteredDrinks.single.name, 'Alpha Ale');
+      });
+
+      test('ticking a scoped-narrowed style option yields exactly the stated '
+          'count', () {
+        final drinks = _sampleDrinks();
+        drinks[0] = drinks[0].copyWith(
+          userState: UserDrinkState.initial().copyWith(wantToTry: true),
+        ); // Alpha Ale (style IPA) is the only favourite.
+        controller
+          ..setSource(drinks)
+          ..setShowFavoritesOnly(value: true);
+        expect(controller.styleCountsMap, {'IPA': 1});
+
+        controller.toggleStyle('IPA');
+        expect(controller.filteredDrinks, hasLength(1));
+        expect(controller.filteredDrinks.single.name, 'Alpha Ale');
+      });
+
+      test('ticking a scoped-narrowed allergen exclusion yields exactly the '
+          'stated filtered result', () {
+        controller.setSource([
+          _drink(
+            id: 'a',
+            name: 'Gluten Beer',
+            category: 'beer',
+            allergens: {'gluten': 1},
+          ),
+          _drink(id: 'b', name: 'Clean Beer', category: 'beer'),
+        ]);
+        expect(controller.availableAllergens, {'gluten'});
+
+        controller.setAllergenFilter('gluten', active: true);
+        expect(controller.filteredDrinks.map((d) => d.name), ['Clean Beer']);
+      });
+    });
+
+    group('allergen presence (only non-zero counts as present)', () {
+      test('an allergen key present only with value 0 is not listed', () {
+        controller.setSource([
+          _drink(id: 'a', name: 'A', category: 'beer', allergens: {'nuts': 0}),
+        ]);
+        expect(controller.availableAllergens, isNot(contains('nuts')));
+      });
+
+      test('an allergen key is listed once some drink in scope has it '
+          'non-zero', () {
+        controller.setSource([
+          _drink(id: 'a', name: 'A', category: 'beer', allergens: {'nuts': 0}),
+          _drink(id: 'b', name: 'B', category: 'beer', allergens: {'nuts': 1}),
+        ]);
+        expect(controller.availableAllergens, contains('nuts'));
+      });
+
+      test('an allergen key is listed when currently selected even if scope '
+          'only has it zeroed', () {
+        controller
+          ..setSource([
+            _drink(
+              id: 'a',
+              name: 'A',
+              category: 'beer',
+              allergens: {'nuts': 0},
+            ),
+          ])
+          ..setAllergenFilter('nuts', active: true);
+        expect(controller.availableAllergens, contains('nuts'));
+      });
+
+      test('bool and numeric allergen values are honoured by the presence '
+          'check, not just int', () {
+        // Product.fromJson already normalises bool/num allergen values to
+        // int at parse time — confirm the facet respects that normalised
+        // value rather than assuming the raw map is always int-valued.
         controller.setSource([
           _drink(
             id: 'a',
             name: 'A',
             category: 'beer',
-            allergens: {'gluten': 1},
+            allergens: {'gluten': false, 'nuts': 2.0, 'milk': true},
           ),
-          _drink(id: 'b', name: 'B', category: 'beer', allergens: {'nuts': 0}),
         ]);
-        expect(controller.availableAllergens, {'gluten', 'nuts'});
+        expect(controller.availableAllergens, {'nuts', 'milk'});
+      });
+    });
+
+    group('search query does not affect facets', () {
+      test('search narrows filteredDrinks but not category/style facets', () {
+        controller
+          ..setSource(_sampleDrinks())
+          ..setSearchQuery('alpha');
+        expect(controller.filteredDrinks.map((d) => d.name), ['Alpha Ale']);
+        expect(controller.availableCategories, ['beer', 'cider']);
+        expect(controller.categoryCountsMap, {'beer': 2, 'cider': 2});
+        expect(controller.availableStyles, ['Bitter', 'Dry', 'IPA', 'Sweet']);
+        expect(controller.styleCountsMap, {
+          'IPA': 1,
+          'Bitter': 1,
+          'Dry': 1,
+          'Sweet': 1,
+        });
+      });
+
+      test('search narrows filteredDrinks but not the allergen facet', () {
+        controller
+          ..setSource([
+            _drink(
+              id: 'a',
+              name: 'Gluten Beer',
+              category: 'beer',
+              allergens: {'gluten': 1},
+            ),
+            _drink(id: 'b', name: 'Clean Cider', category: 'cider'),
+          ])
+          ..setSearchQuery('clean');
+        expect(controller.filteredDrinks.map((d) => d.name), ['Clean Cider']);
+        expect(controller.availableAllergens, {'gluten'});
       });
     });
 


### PR DESCRIPTION
Replaces three ad-hoc facet-scoping rules in `DrinkFilterController` with one stated rule.

## The problem

The five facet getters each used a different, undocumented scope:

| Getter | Old scope |
|---|---|
| `availableCategories` / `categoryCountsMap` | full `_source` |
| `availableStyles` / `styleCountsMap` | `_categoryScopedSource()` — category only |
| `availableAllergens` | full `_source` |

Filter to cider and the allergen sheet still offered every allergen in the festival, none of which applies to any cider (#317).

## The rule

**A facet is derived from the source with every *other* structural filter applied — but never its own.** Structural filters are category, styles, favourites-only, visibility filters, and excluded allergens. A facet must not narrow itself, or selecting one of its options would hide its siblings and the list would collapse under the user's finger.

One private `_scopeFor(_Facet)` helper reusing `DrinkFilterService.filterDrinks` implements it; all five getters call it and `_categoryScopedSource()` is gone. Counts are now honest — "Stout (12)" really yields 12.

### Two invariants

1. **An active filter is never hidden.** A selected option is always listed even when its scoped count is 0 (and appears in the count map as 0). Non-negotiable for allergens: they are a *safety* filter, and a user who ticked "gluten" then narrowed to cider must still see the row to untick it. `excludedAllergens` is persisted, so this also covers exclusions saved before this change.

2. **`availableAllergens` lists only allergens actually present (non-zero) in scope.** It previously used `drink.allergens.keys`, which includes keys explicitly set to `0` — meaning the allergen is *absent*. This now matches `filterByExcludedAllergens`'s own definition of presence.

### Deliberate deviation

**Free-text search is excluded from facet scoping.** `drinks_screen.dart:140` derives `hasStyleFilter` from `availableStyles.isNotEmpty`, so scoping by the search query would make the Style button appear and disappear from the filter bar as the user types. Pinned by a test so it isn't "fixed" later.

## Measured impact (live cbf2026 feed, 689 drinks)

Invariant 2 turns out to matter more than the issue suggested. Five beer products carry a fully-zeroed allergen declaration, so the sheet offered **14** allergen toggles of which only **5** are ever non-zero anywhere in the festival. Celery, soybeans, lupins, mustard, egg, sesame, molluscs, crustaceans and fish were permanent no-ops.

Combined with scoping:

| View | Allergen toggles before | After |
|---|---|---|
| All drinks | 14 | 5 (gluten, sulphites, milk, peanuts, nuts) |
| Beer | 14 | 5 |
| Wine | 14 | 1 (sulphites) |
| Cider | 14 | 0 — section disappears |

## Scope

Domain layer only — no UI, provider, or persistence changes. Behaviour visible in the existing sheets improves because they receive better data.

Multi-select categories (#319) and grouping styles by category (#318) are a follow-up PR stacked on this one.

## Testing

`./bin/mise run check` clean. Controller tests go from 30 to 55, adding per-facet scoping coverage, "does not narrow itself" tests per facet, both invariants, bool/num allergen-value variants, and assertions that ticking a scoped option yields exactly the stated count.

One existing test changed: `availableAllergens aggregates keys across the source` asserted the old behaviour of listing a zero-valued key, and was replaced by the allergen-presence group.

Fixes #317


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAH3GddJ8yxSvc4MyANCgz)_