### PR TITLE
fix(filters): make sort sheet options dense like the other sheets

### DIFF
--- a/lib/widgets/drink_filter_sheets.dart
+++ b/lib/widgets/drink_filter_sheets.dart
@@ -188,6 +188,9 @@ class SortOptionsSheet extends StatelessWidget {
                       child: ListTile(
                         leading: Radio<DrinkSort>(value: sort),
                         title: Text(sortLabel),
+                        // Matches the CheckboxListTile rows in the category,
+                        // style, and visibility sheets, which are all dense.
+                        dense: true,
                         onTap: () {
                           provider.setSort(sort);
                           Navigator.pop(context);

--- a/test/widgets/drink_filter_sheets_test.dart
+++ b/test/widgets/drink_filter_sheets_test.dart
@@ -189,6 +189,47 @@ void main() {
         expect(find.text('ABV (High to Low)'), findsOneWidget);
       });
 
+      testWidgets(
+        'SortOptionsSheet option rows are the same height as the other '
+        'sheets (regression: #507)',
+        (tester) async {
+          await tester.pumpWidget(
+            directHost(SortOptionsSheet(provider: provider)),
+          );
+          await tester.pumpAndSettle();
+
+          final sortTiles = tester
+              .widgetList<ListTile>(find.byType(ListTile))
+              .toList();
+          expect(sortTiles, isNotEmpty);
+          for (final tile in sortTiles) {
+            expect(
+              tile.dense,
+              isTrue,
+              reason:
+                  'Sort options must be dense to match the category, style, '
+                  'and visibility sheets.',
+            );
+          }
+
+          // The user-visible symptom was row pitch, not the flag: measure the
+          // rendered height and compare it against a sheet that was always
+          // dense, so this stays honest if Material changes its metrics.
+          final sortRowHeight = tester
+              .getSize(find.widgetWithText(ListTile, 'Name (A-Z)'))
+              .height;
+
+          await tester.pumpWidget(directHost(const CategoryFilterSheet()));
+          await tester.pumpAndSettle();
+
+          final categoryRowHeight = tester
+              .getSize(find.widgetWithText(CheckboxListTile, 'Beer (2)'))
+              .height;
+
+          expect(sortRowHeight, categoryRowHeight);
+        },
+      );
+
       testWidgets('StyleFilterSheet shows styles in case-insensitive order', (
         tester,
       ) async {


### PR DESCRIPTION
## Summary

`SortOptionsSheet` built its options with a plain `ListTile` and omitted `dense: true`, while the category, style, and visibility sheets in the same file all pass it on their `CheckboxListTile`s. With no `ListTileTheme` anywhere in `lib/`, the sort tile fell back to the Material 3 default of styling its title from `bodyLarge` (~16sp) — a 48px row pitch against 40px everywhere else. The result read as a different, larger font in the sort picker.

Adding `dense: true` brings it in line.

## Changes

| File | Change |
|---|---|
| `lib/widgets/drink_filter_sheets.dart` | `dense: true` on the `ListTile` in `SortOptionsSheet` |
| `test/widgets/drink_filter_sheets_test.dart` | Regression test for the row density |

## On the `controlAffinity` question in the issue

The issue asked whether the radio-vs-checkbox `controlAffinity` also wants aligning. It does not: `ListTile` has no `controlAffinity` parameter, and passing `leading: Radio<DrinkSort>(...)` already *is* leading affinity — consistent with the explicit `ListTileControlAffinity.leading` on the other sheets. No change made.

## Testing

The new test asserts two things: that every sort-option `ListTile` is dense, and that the rendered height of a sort row equals the rendered height of a category row. The second assertion is deliberately self-calibrating against a sheet that was always dense rather than hardcoding a pixel constant, so it stays honest if Material changes its metrics.

Verified the test is a real guard — with the one-line fix stashed it fails, and passes with it restored:

```
00:01 +3 -1: SortOptionsSheet option rows are the same height as the other sheets (regression: #507) [E]
  Expected: true
    Actual: <null>
```

`./bin/mise run check` is green: 1314 tests pass (baseline 1313), analyzer clean, formatter clean.

## Scope notes

- Restyle only — the widget tree shape is unchanged, no restructure mixed in.
- No goldens affected; `test/goldens/` covers the brewery, drink-detail, and style screens only, no filter sheets. No golden regeneration was run.
- `Semantics` wrapper and labels untouched. The issue notes this is cosmetic with no accessibility defect, and that remains true.

Not verifiable by an agent: the visual result in a real browser or on device. Worth a glance at the sort sheet next to the style sheet on the Pages preview.

Fixes #507

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5nhJiJuRjtP3q7mTrsXBt)_