### PR TITLE
fix(web): guard URL strategy import on js_interop, not html

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,8 +14,11 @@ import 'services/services.dart';
 import 'utils/utils.dart';
 import 'widgets/widgets.dart';
 import 'firebase_options.dart';
+// Guarded on dart.library.js_interop, not dart.library.html: `dart:html` is
+// only provided by dart2js, so a `--wasm` build would silently fall through to
+// the no-op stub and revert to hash routing (see ADR 0004, issue #525).
 import 'url_strategy_stub.dart'
-    if (dart.library.html) 'package:flutter_web_plugins/url_strategy.dart';
+    if (dart.library.js_interop) 'package:flutter_web_plugins/url_strategy.dart';
 
 void main() async {
   // coverage:ignore-start


### PR DESCRIPTION
Fixes #525

## What changed

`lib/main.dart` — the URL-strategy conditional import is now guarded on `dart.library.js_interop` instead of `dart.library.html`.

`dart:html` is only provided by dart2js. Under dart2wasm the condition is false, so `usePathUrlStrategy()` resolved to the no-op in `lib/url_strategy_stub.dart` and path-based URLs silently reverted to hash routing — the outcome ADR 0004 rejected. No compile error, no runtime warning; the first symptom would be `#`-prefixed URLs in production.

`dart.library.js_interop` is the supported "compiling for the web" condition on both backends (Flutter's recommendation since 3.22). `kIsWeb` already gates the call itself, so nothing else changes.

## Verification

A conditional-import probe compiled by both backends, resolving the same two guards against distinguishable marker libraries:

| Compiler | `dart.library.html` | `dart.library.js_interop` |
|---|---|---|
| dart2js | real branch ✅ | real branch ✅ |
| dart2wasm | **stub branch ❌** | real branch ✅ |

That reproduces the reported bug and confirms the fix. The dart2js row also shows the change is a no-op on the current release path.

`./bin/mise run check` passes (1309 tests, analyzer clean) and `./bin/mise run build:web` succeeds.

Not verified here: a live browser check of the served build. Flutter's CDN assets are blocked by this environment's network policy, so the engine cannot boot headlessly — the Playwright routing suite (which asserts exact `#`-free URLs) will exercise this in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMHccczbGhncKUK2ectnoG)_