### PR TITLE
fix(worker): make npm run typecheck work on a fresh checkout

### DIFF
--- a/.claude/skills/api-contract/SKILL.md
+++ b/.claude/skills/api-contract/SKILL.md
@@ -204,26 +204,48 @@ only `starRating` + `wouldRecommend`, no `etag`/optimistic concurrency, no
 `is_favourite`/`note`/`pours`, no soft delete (its `DELETE` does a real SQL
 `DELETE FROM reviews` and returns `{}`), no `BatchUpdate`. This predates the
 `DrinkEntry` consolidation (PR #429) and has not been reconciled since.
-Concretely verified in this sandbox (2026-07-02): `reviews.ts` does
-`import type { components } from "./src/api-types"` and pulls out
-`Review`/`ReviewSummary`/`ListReviewsResponse`/`ListReviewSummariesResponse`
-— but no `.proto` file defines any message named `Review` or `ReviewSummary`
-anywhere (`grep -rn "message Review" proto/` finds nothing). `src/api-types.ts`
-is gitignored and wasn't present in this checkout; running
-`npx tsc --noEmit` in `cloudflare-worker/` failed immediately with
-`Cannot find module './src/api-types'`, while `npm test` (vitest) passed all
-86 tests unmodified — because `import type` is erased by esbuild/vite at
-transpile time and only matters to `tsc`. **CI's `cloudflare-worker.yml`
-`test-worker` job runs only `npm test`, not `npm run typecheck`**, so this
-gap has never blocked a merge or deploy; the base mise task `test:worker`
-(`npm ci && npm run typecheck && npm test`) *would* fail on a fresh checkout
-until `MISE_ENV=dev ./bin/mise run proto:clients:types` has been run at least
-once to produce `src/api-types.ts` — and even then, regenerating from the
-current proto would almost certainly rename or drop the `Review`/
-`ReviewSummary` types entirely (they don't exist in the contract), which
-`reviews.ts` would then fail to import. Don't assume `npm test` passing means
-the worker matches the proto — it only means the worker's own hand-written
-logic is internally consistent.
+No `.proto` file defines any message named `Review` or `ReviewSummary`
+anywhere (`grep -rn "message Review" proto/` finds nothing).
+
+**How `reviews.ts` types itself against a contract that lacks its resources
+(since #545).** It still does `import type { components } from
+"./src/api-types"`, but it no longer names `Review`/`ReviewSummary`/
+`ListReviewsResponse`/`ListReviewSummariesResponse` schemas — those never
+existed in the generated types, so the import used to fail `tsc` even after
+generation. Instead it derives its shapes field-by-field from the schemas that
+*do* exist:
+
+```ts
+type Review = Required<Pick<DrinkEntry, "name" | "updateTime">> &
+  Pick<DrinkEntry, "starRating" | "wouldRecommend">;
+type ReviewSummary = Required<Pick<DrinkSummary, "name" | "ratingCount" | ...>>;
+```
+
+so a rename of a *shared* field in the proto still breaks the worker build,
+while the fields the worker doesn't serve (`isFavourite`, `note`, `pours`,
+`etag`, `tasterCount`, `totalPours`) simply aren't picked. The two list
+wrappers have no contract counterpart at all (the proto's List RPCs return
+`DrinkEntry`/`DrinkSummary` collections) and are declared as local interfaces.
+**If you reconcile the surfaces, delete these derivations — don't extend
+them.** They are a bridge, not a design.
+
+`src/api-types.ts` and `docs/code/api/openapi/openapi.yaml` are both gitignored
+and absent on a fresh checkout. Since #545 that no longer breaks
+`npm run typecheck`: `proto:clients:types` and `proto:clients:dart` both
+`depends = ["proto:generate"]`, and a `pretypecheck` npm script
+(`cloudflare-worker/scripts/ensure-api-types.mjs`) runs `proto:clients:types`
+when `src/api-types.ts` is missing — so the whole chain bootstraps from the
+proto sources. It needs `buf`; if that can't be fetched (the 403 above) the
+script exits with the command to run by hand rather than letting `tsc` report
+a confusing module-resolution error. `./bin/mise run test:worker`
+(`npm ci && npm run typecheck && npm test`) is green on a clean clone.
+
+**CI's `cloudflare-worker.yml` `test-worker` job still runs only `npm test`,
+not `npm run typecheck`**, and `npm test` (vitest, 91 tests as of #545) passes
+regardless of the type situation — `import type` is erased by esbuild/vite at
+transpile time and only matters to `tsc`. So don't assume `npm test` passing
+means the worker matches the proto; it only means the worker's own
+hand-written logic is internally consistent.
 
 ### Deployed `/v1alpha` Review API (`reviews.ts`)
 
@@ -343,10 +365,10 @@ cat proto/.api-linter.yaml proto/buf.yaml
 # Confirm no Review/ReviewSummary message exists yet in the proto (the drift this skill flags):
 grep -rn "^message Review" proto/
 
-# Confirm the api-types.ts / typecheck gap is still real (needs `cd cloudflare-worker && npm ci` first):
-ls cloudflare-worker/src/api-types.ts 2>&1   # expect: No such file (until proto:clients:types has run)
-(cd cloudflare-worker && npx tsc --noEmit)   # expect: fails on missing ./src/api-types if not yet generated
-(cd cloudflare-worker && npm test)           # expect: passes regardless (86 tests, 5 files as of writing)
+# Confirm the fresh-checkout bootstrap still works (needs `cd cloudflare-worker && npm ci` first):
+rm -rf cloudflare-worker/src docs/code/api/openapi
+(cd cloudflare-worker && npm run typecheck)  # expect: pretypecheck regenerates both, then tsc passes
+(cd cloudflare-worker && npm test)           # expect: passes regardless (91 tests, 6 files as of writing)
 
 # CI job wiring still matches (job names, triggers):
 grep -n "proto:" -A 15 .github/workflows/ci.yml | head -25

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,7 @@
 build/
 android/
 ios/
+
+# Generated from proto via proto:clients:types — never hand-formatted.
+# Now reachable locally because `npm run typecheck` generates it on demand.
+cloudflare-worker/src/

--- a/cloudflare-worker/package.json
+++ b/cloudflare-worker/package.json
@@ -8,6 +8,7 @@
     "dev": "wrangler dev",
     "pretest": "cp ../data/festivals.json ./festivals.json",
     "test": "vitest run",
+    "pretypecheck": "node scripts/ensure-api-types.mjs",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/cloudflare-worker/reviews.ts
+++ b/cloudflare-worker/reviews.ts
@@ -9,10 +9,16 @@
  *   GET    /v1alpha/festivals/{f}/reviewSummaries/{d} aggregate for one drink
  *   GET    /v1alpha/festivals/{f}/reviewSummaries     list aggregates (paginated)
  *
- * Response shapes are typed against the generated OpenAPI types in
- * src/api-types.ts (generated from proto via proto:clients:types). TypeScript
- * enforces that every response field matches the proto contract — a field
- * rename in the proto surfaces here as a compile error.
+ * Response shapes are derived from the generated OpenAPI types in
+ * src/api-types.ts (generated from proto via proto:clients:types), so a rename
+ * of a shared field in the proto surfaces here as a compile error.
+ *
+ * The derivation is deliberate rather than a direct import: this worker still
+ * serves the older Review/ReviewSummary pair, which the proto contract
+ * replaced with the wider DrinkEntry/DrinkSummary resources in PR #429. No
+ * `Review` message exists in proto/ any more, so the field-level Pick below is
+ * the strongest link to the contract available until the two surfaces are
+ * reconciled. Reconciliation is My Festival work, not a typing change here.
  *
  * Caller identity comes from the X-Device-Id request header (anonymous phase).
  * It never appears in resource names, so the sign-in upgrade is transparent.
@@ -31,12 +37,43 @@ import {
   resolvePageSize,
 } from "./shared.js";
 
-// Response shapes enforced by the proto contract.
-type Review = components["schemas"]["Review"];
-type ReviewSummary = components["schemas"]["ReviewSummary"];
-type ListReviewsResponse = components["schemas"]["ListReviewsResponse"];
-type ListReviewSummariesResponse =
-  components["schemas"]["ListReviewSummariesResponse"];
+// Response shapes, pinned field-by-field to the proto contract where the
+// deployed surface and the contract still overlap (see the file header).
+type DrinkEntry = components["schemas"]["DrinkEntry"];
+type DrinkSummary = components["schemas"]["DrinkSummary"];
+
+// The caller's own signals for one drink: the subset of DrinkEntry this
+// worker persists. `starRating`/`wouldRecommend` stay optional — absent means
+// the caller has not answered, matching the contract's semantics.
+type Review = Required<Pick<DrinkEntry, "name" | "updateTime">> &
+  Pick<DrinkEntry, "starRating" | "wouldRecommend">;
+
+// The aggregate across all callers: the subset of DrinkSummary computable from
+// the reviews table (no pour data, so no tasterCount/totalPours).
+type ReviewSummary = Required<
+  Pick<
+    DrinkSummary,
+    | "name"
+    | "ratingCount"
+    | "averageRating"
+    | "responseCount"
+    | "recommendCount"
+    | "recommendRate"
+  >
+>;
+
+// List wrappers have no contract counterpart — the proto's List RPCs return
+// DrinkEntry/DrinkSummary collections — so they are defined locally, following
+// the AIP-158 shape (collection + nextPageToken, plus totalSize where cheap).
+interface ListReviewsResponse {
+  reviews: Review[];
+  nextPageToken: string;
+}
+interface ListReviewSummariesResponse {
+  reviewSummaries: ReviewSummary[];
+  nextPageToken: string;
+  totalSize: number;
+}
 
 const MAX_ID_LENGTH = 200;
 

--- a/cloudflare-worker/scripts/ensure-api-types.mjs
+++ b/cloudflare-worker/scripts/ensure-api-types.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * npm `pretypecheck` guard: make sure src/api-types.ts exists before tsc runs.
+ *
+ * reviews.ts imports ./src/api-types, which is generated from the proto
+ * contract (proto -> docs/code/api/openapi/openapi.yaml -> src/api-types.ts)
+ * and gitignored. On a fresh checkout nothing has produced it yet, so
+ * `npm run typecheck` used to fail with a bare "Cannot find module
+ * './src/api-types'" that looks like a broken checkout (#545).
+ *
+ * This script runs the mise task that generates it. That task now depends on
+ * proto:generate, so the whole chain bootstraps from the proto sources.
+ *
+ * Generation needs `buf`, which is a dev-env tool fetched from GitHub
+ * releases; if that is unavailable (offline, or the sandbox 403 documented in
+ * mise.dev.toml) we exit non-zero with the command to run by hand rather than
+ * letting tsc report a confusing module-resolution error.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const workerDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(workerDir, "..");
+const apiTypes = resolve(workerDir, "src/api-types.ts");
+const task = "proto:clients:types";
+
+if (existsSync(apiTypes)) process.exit(0);
+
+// proto:* tasks live in mise.dev.toml, so the `dev` env has to be selected.
+// On Claude Code Web .miserc.toml already selects it (plus claude-code-web);
+// setting MISE_ENV there would override that file and drop the Node pin, so
+// only set it when nothing has selected an env already.
+const env = { ...process.env };
+if (!env.MISE_ENV && env.CLAUDE_CODE_REMOTE !== "true") env.MISE_ENV = "dev";
+
+console.log(`api-types.ts missing — running \`mise run ${task}\`...`);
+const result = spawnSync("./bin/mise", ["run", task], {
+  cwd: repoRoot,
+  env,
+  stdio: "inherit",
+});
+
+if (result.status !== 0 || !existsSync(apiTypes)) {
+  const prefix = env.MISE_ENV ? `MISE_ENV=${env.MISE_ENV} ` : "";
+  console.error(
+    `\nCould not generate cloudflare-worker/src/api-types.ts.\n` +
+      `Generate it from the proto contract by running, from the repo root:\n` +
+      `  ${prefix}./bin/mise run ${task}\n` +
+      `That needs \`buf\` (see mise.dev.toml for the install caveats).\n`,
+  );
+  process.exit(1);
+}

--- a/cloudflare-worker/scripts/ensure-api-types.mjs
+++ b/cloudflare-worker/scripts/ensure-api-types.mjs
@@ -33,8 +33,10 @@ if (existsSync(apiTypes)) process.exit(0);
 // On Claude Code Web .miserc.toml already selects it (plus claude-code-web);
 // setting MISE_ENV there would override that file and drop the Node pin, so
 // only set it when nothing has selected an env already.
+const selectDevEnv =
+  !process.env.MISE_ENV && process.env.CLAUDE_CODE_REMOTE !== "true";
 const env = { ...process.env };
-if (!env.MISE_ENV && env.CLAUDE_CODE_REMOTE !== "true") env.MISE_ENV = "dev";
+if (selectDevEnv) env.MISE_ENV = "dev";
 
 console.log(`api-types.ts missing — running \`mise run ${task}\`...`);
 const result = spawnSync("./bin/mise", ["run", task], {
@@ -44,7 +46,10 @@ const result = spawnSync("./bin/mise", ["run", task], {
 });
 
 if (result.status !== 0 || !existsSync(apiTypes)) {
-  const prefix = env.MISE_ENV ? `MISE_ENV=${env.MISE_ENV} ` : "";
+  // Built from the boolean above, never by interpolating an environment
+  // value into the message — that reads to CodeQL as clear-text logging of
+  // the process environment.
+  const prefix = selectDevEnv ? "MISE_ENV=dev " : "";
   console.error(
     `\nCould not generate cloudflare-worker/src/api-types.ts.\n` +
       `Generate it from the proto contract by running, from the repo root:\n` +

--- a/mise.dev.toml
+++ b/mise.dev.toml
@@ -82,6 +82,10 @@ depends = ["proto:clients:types", "proto:clients:dart"]
 
 [tasks."proto:clients:types"]
 description = "Generate TypeScript types for the Cloudflare Worker from OpenAPI"
+# openapi.yaml is generated and gitignored, so on a fresh checkout it does not
+# exist until proto:generate has run. Declaring the dependency makes the chain
+# self-bootstrapping from the proto sources instead of failing with ENOENT (#545).
+depends = ["proto:generate"]
 run = """
 npx --prefix cloudflare-worker openapi-typescript \
   docs/code/api/openapi/openapi.yaml \
@@ -90,6 +94,8 @@ npx --prefix cloudflare-worker openapi-typescript \
 
 [tasks."proto:clients:dart"]
 description = "Generate Dart/Dio client for Flutter from OpenAPI (requires Java)"
+# Same generated-input dependency as proto:clients:types above (#545).
+depends = ["proto:generate"]
 env = { OPENAPI_GENERATOR_JAR = "${HOME}/.cache/openapi-generator/openapi-generator-cli-7.13.0.jar" }
 run = """
 mkdir -p "${HOME}/.cache/openapi-generator"


### PR DESCRIPTION
Fixes #545

## The issue as filed

`cloudflare-worker/reviews.ts` imports `./src/api-types`, which is generated and gitignored, and nothing declared how to build it. `proto:clients:types` consumed `docs/code/api/openapi/openapi.yaml` without depending on the task that produces it, so the only working path was knowing to run the full proto chain by hand.

- `mise.dev.toml`: `proto:clients:types` and `proto:clients:dart` now both `depends = ["proto:generate"]`, so the chain is self-bootstrapping from the proto sources. (`proto:clients:dart` had the same latent defect.)
- `cloudflare-worker/package.json`: a `pretypecheck` script runs `cloudflare-worker/scripts/ensure-api-types.mjs`, which invokes `proto:clients:types` when `src/api-types.ts` is missing. It selects the `dev` env only when nothing has already selected one, so it does not shadow `.miserc.toml` on Claude Code Web. If `buf` can't be fetched, it exits with the command to run by hand rather than letting `tsc` report a confusing module-resolution error.

## The part the issue didn't know about

Fixing the generation chain was necessary but **not sufficient**. With `src/api-types.ts` generated from the current proto, `tsc` still failed — with four different errors:

```
reviews.ts(35,37): error TS2339: Property 'Review' does not exist on type '{ BatchUpdateDrinkEntriesRequest: ... }'
reviews.ts(36,44): error TS2339: Property 'ReviewSummary' does not exist ...
reviews.ts(37,50): error TS2339: Property 'ListReviewsResponse' does not exist ...
reviews.ts(39,25): error TS2339: Property 'ListReviewSummariesResponse' does not exist ...
```

The worker still serves the older `Review`/`ReviewSummary` pair, which the proto contract replaced with the wider `DrinkEntry`/`DrinkSummary` resources in #429. No `.proto` file defines a `Review` message any more, so those four schemas have never existed in the generated types. Without this second fix, #545's stated goal — a contributor running a declared npm script and not getting a confusing error — would not have been met; the error would just have changed shape.

`reviews.ts` now derives its response types field-by-field from the schemas that do exist:

```ts
type Review = Required<Pick<DrinkEntry, "name" | "updateTime">> &
  Pick<DrinkEntry, "starRating" | "wouldRecommend">;
type ReviewSummary = Required<Pick<DrinkSummary, "name" | "ratingCount" | ...>>;
```

`Pick`'s key is constrained to `keyof T`, so a rename of a field both surfaces share still breaks the build — the compile-time link to the contract is real, just narrowed to the overlap. The two list wrappers have no contract counterpart (the proto's List RPCs return `DrinkEntry`/`DrinkSummary` collections) and are declared as local interfaces. No runtime behaviour or wire shape changes.

**Reconciling the two surfaces properly remains My Festival work and is deliberately out of scope here.** The derivations are a bridge, not a design; the file header and the `api-contract` skill both say so.

## Verification

- `./bin/mise run check` — green (analyzer clean, 1289 tests).
- `./bin/mise run test:worker` (`npm ci && npm run typecheck && npm test`) — green, 91 tests. This task failed on a fresh checkout before.
- Fresh-checkout path exercised directly: `rm -rf cloudflare-worker/src docs/code/api/openapi && cd cloudflare-worker && npm run typecheck` regenerates both artifacts via `buf generate` → `openapi-typescript` and exits 0.
- `npx prettier --check` clean on the new script.

Not verified: the guard script's `buf`-unavailable error path was reasoned through, not reproduced (`buf` installed fine in this sandbox).

## Docs

`.claude/skills/api-contract/SKILL.md` §6 documented the old behaviour in detail ("`test:worker` *would* fail on a fresh checkout…"), so it is updated to describe the bootstrap and the type derivation, with re-verification commands that match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUssnfm5piLGkrVc2NDjnP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUssnfm5piLGkrVc2NDjnP)_