### PR TITLE
refactor(drinks): narrow DrinksScreen to per-concern provider selects

### DIFF
--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -92,28 +92,27 @@ class _DrinksScreenState extends State<DrinksScreen> {
       (p) => p.currentSort,
     );
 
-    // The filter-criteria getters aren't selector-safe as whole Sets:
     // selectedCategories/visibilityFilters/excludedAllergens each return a
-    // fresh Set.unmodifiable(...) wrapper on every call (a selector on them
-    // always sees "changed", which is wasteful but harmless), while
-    // selectedStyles returns the raw field, mutated in place (a selector on
-    // it would never fire — a real correctness bug, not just a missed
-    // optimisation). Select derived primitives instead; the actual Set
-    // contents (needed for the formatted label text) are read directly off
-    // `provider` inside the builder methods below, which is safe because
+    // fresh Set.unmodifiable(...) wrapper on every call, so a selector on the
+    // whole Set always sees "changed" — wasteful, but harmless. Selecting
+    // derived primitives keeps those reads able to actually skip.
+    //
+    // (selectedStyles is different: DrinkFilterController reassigns
+    // _selectedStyles to a new Set on every mutation rather than mutating in
+    // place, so Dart's identity == makes it genuinely selector-safe as a whole
+    // Set. Primitives are used below for consistency, not necessity.)
+    //
+    // The actual Set contents, needed for the formatted label text, are read
+    // directly off `provider` inside the builder methods below — safe because
     // that read isn't used as a change-detection comparison.
-    final selectedCategoriesEmpty = context.select<BeerProvider, bool>(
-      (p) => p.selectedCategories.isEmpty,
-    );
     final selectedCategoriesLength = context.select<BeerProvider, int>(
       (p) => p.selectedCategories.length,
     );
-    final selectedStylesEmpty = context.select<BeerProvider, bool>(
-      (p) => p.selectedStyles.isEmpty,
-    );
+    final selectedCategoriesEmpty = selectedCategoriesLength == 0;
     final selectedStylesLength = context.select<BeerProvider, int>(
       (p) => p.selectedStyles.length,
     );
+    final selectedStylesEmpty = selectedStylesLength == 0;
     final selectedStylesFirst = context.select<BeerProvider, String?>(
       (p) => p.selectedStyles.isEmpty ? null : p.selectedStyles.first,
     );

--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../domain/models/models.dart';
+import '../models/models.dart';
 import '../providers/providers.dart';
 import '../utils/utils.dart';
 import '../widgets/widgets.dart';
@@ -39,19 +40,97 @@ class _DrinksScreenState extends State<DrinksScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.watch<BeerProvider>();
+    // Narrow per-concern selects instead of a bare watch<BeerProvider>() —
+    // each select only rebuilds this screen when the specific value it reads
+    // actually changes, rather than on every notifyListeners() (e.g. a
+    // theme-mode change this screen doesn't render). A single context.read
+    // below covers action callbacks, which never need to subscribe to
+    // rebuilds.
+    //
     // Festival-flash guard: the router schedules setFestival in a post-frame
     // callback, so a URL-driven festival change (cross-festival deep link on a
     // warm app, browser back/forward, the post-init redirect in main.dart)
     // would otherwise render one frame of the previous festival's name and
     // drinks before the provider catches up (issue #397). Keep it first in
-    // build(), as in MyFestivalScreen.
-    if (provider.currentFestival.id != widget.festivalId) {
+    // build(), as in MyFestivalScreen. Festival.== is id-scoped by design, so
+    // this selects the id specifically rather than the whole Festival object
+    // (selecting the object would swallow an in-place metadata refresh).
+    final currentFestivalId = context.select<BeerProvider, String>(
+      (p) => p.currentFestival.id,
+    );
+    if (currentFestivalId != widget.festivalId) {
       return buildLoadingScaffold();
     }
 
+    final currentFestivalName = context.select<BeerProvider, String>(
+      (p) => p.currentFestival.name,
+    );
+
+    // provider.drinks (the filtered list) is a cached field on
+    // DrinkFilterController, reassigned only by recompute() — nothing
+    // theme/loading-related calls recompute(), so selecting the whole
+    // List<Drink> here is safe today. This is an implementation artifact of
+    // the controller, not a documented contract.
+    final drinks = context.select<BeerProvider, List<Drink>>((p) => p.drinks);
+    final isLoading = context.select<BeerProvider, bool>((p) => p.isLoading);
+    final error = context.select<BeerProvider, String?>((p) => p.error);
+    final isRefreshing = context.select<BeerProvider, bool>(
+      (p) => p.isRefreshing,
+    );
+    final refreshNotice = context.select<BeerProvider, String?>(
+      (p) => p.refreshNotice,
+    );
+    // Test against the unfiltered list so an active filter (favourites only,
+    // search query with no matches) doesn't hide the refresh indicator.
+    final hasData = context.select<BeerProvider, bool>(
+      (p) => p.allDrinks.isNotEmpty,
+    );
+    final searchQuery = context.select<BeerProvider, String>(
+      (p) => p.searchQuery,
+    );
+    final currentSort = context.select<BeerProvider, DrinkSort>(
+      (p) => p.currentSort,
+    );
+
+    // The filter-criteria getters aren't selector-safe as whole Sets:
+    // selectedCategories/visibilityFilters/excludedAllergens each return a
+    // fresh Set.unmodifiable(...) wrapper on every call (a selector on them
+    // always sees "changed", which is wasteful but harmless), while
+    // selectedStyles returns the raw field, mutated in place (a selector on
+    // it would never fire — a real correctness bug, not just a missed
+    // optimisation). Select derived primitives instead; the actual Set
+    // contents (needed for the formatted label text) are read directly off
+    // `provider` inside the builder methods below, which is safe because
+    // that read isn't used as a change-detection comparison.
+    final selectedCategoriesEmpty = context.select<BeerProvider, bool>(
+      (p) => p.selectedCategories.isEmpty,
+    );
+    final selectedCategoriesLength = context.select<BeerProvider, int>(
+      (p) => p.selectedCategories.length,
+    );
+    final selectedStylesEmpty = context.select<BeerProvider, bool>(
+      (p) => p.selectedStyles.isEmpty,
+    );
+    final selectedStylesLength = context.select<BeerProvider, int>(
+      (p) => p.selectedStyles.length,
+    );
+    final selectedStylesFirst = context.select<BeerProvider, String?>(
+      (p) => p.selectedStyles.isEmpty ? null : p.selectedStyles.first,
+    );
+    final visibilityFiltersLength = context.select<BeerProvider, int>(
+      (p) => p.visibilityFilters.length,
+    );
+    final excludedAllergensLength = context.select<BeerProvider, int>(
+      (p) => p.excludedAllergens.length,
+    );
+    final hasStyleFilter = context.select<BeerProvider, bool>(
+      (p) => p.availableStyles.isNotEmpty,
+    );
+
+    final provider = context.read<BeerProvider>();
+
     return PageTitle(
-      pageTitle: provider.currentFestival.name,
+      pageTitle: currentFestivalName,
       child: Scaffold(
         body: Column(
           children: [
@@ -63,29 +142,53 @@ class _DrinksScreenState extends State<DrinksScreen> {
                     SliverAppBar(
                       floating: true,
                       snap: true,
-                      title: FestivalHeader(provider: provider),
+                      title: const FestivalHeader(),
                       actions: [buildOverflowMenu(context)],
                     ),
                     SliverToBoxAdapter(
-                      child: FestivalBanner(
-                        provider: provider,
-                        festivalId: widget.festivalId,
-                      ),
+                      child: FestivalBanner(festivalId: widget.festivalId),
                     ),
                     SliverToBoxAdapter(
-                      child: _buildRefreshStatus(context, provider),
+                      child: _buildRefreshStatus(
+                        context,
+                        provider,
+                        hasData: hasData,
+                        isRefreshing: isRefreshing,
+                        refreshNotice: refreshNotice,
+                      ),
                     ),
                     if (_showSearch)
                       SliverToBoxAdapter(
                         child: _buildSearchBar(context, provider),
                       ),
-                    _buildDrinksListSliver(context, provider),
+                    _buildDrinksListSliver(
+                      context,
+                      provider,
+                      drinks: drinks,
+                      isLoading: isLoading,
+                      error: error,
+                      searchQuery: searchQuery,
+                      selectedCategoriesEmpty: selectedCategoriesEmpty,
+                    ),
                   ],
                 ),
               ),
             ),
             // Bottom controls for filtering, sorting, and search - thumb friendly
-            _buildBottomControls(context, provider),
+            _buildBottomControls(
+              context,
+              provider,
+              hasStyleFilter: hasStyleFilter,
+              selectedCategoriesEmpty: selectedCategoriesEmpty,
+              selectedCategoriesLength: selectedCategoriesLength,
+              selectedStylesEmpty: selectedStylesEmpty,
+              selectedStylesLength: selectedStylesLength,
+              selectedStylesFirst: selectedStylesFirst,
+              visibilityFiltersLength: visibilityFiltersLength,
+              excludedAllergensLength: excludedAllergensLength,
+              currentSort: currentSort,
+              searchQuery: searchQuery,
+            ),
           ],
         ),
       ),
@@ -141,25 +244,39 @@ class _DrinksScreenState extends State<DrinksScreen> {
     );
   }
 
-  Widget _buildBottomControls(BuildContext context, BeerProvider provider) {
-    final hasStyleFilter = provider.availableStyles.isNotEmpty;
-    final styleLabel = provider.selectedStyles.isEmpty
+  Widget _buildBottomControls(
+    BuildContext context,
+    BeerProvider provider, {
+    required bool hasStyleFilter,
+    required bool selectedCategoriesEmpty,
+    required int selectedCategoriesLength,
+    required bool selectedStylesEmpty,
+    required int selectedStylesLength,
+    required String? selectedStylesFirst,
+    required int visibilityFiltersLength,
+    required int excludedAllergensLength,
+    required DrinkSort currentSort,
+    required String searchQuery,
+  }) {
+    final styleLabel = selectedStylesEmpty
         ? 'Style'
-        : provider.selectedStyles.length == 1
-        ? provider.selectedStyles.first
-        : '${provider.selectedStyles.length} styles';
+        : selectedStylesLength == 1
+        ? selectedStylesFirst!
+        : '$selectedStylesLength styles';
     // Formatted and sorted so the screen reader announces the same names a
-    // sighted user sees, in a deterministic order (a Set has none).
+    // sighted user sees, in a deterministic order (a Set has none). Reads the
+    // live Set off `provider` (context.read, not a selector) — the rebuild
+    // itself is already gated by the primitive selects above.
     final formattedCategories =
         provider.selectedCategories
             .map(BeverageTypeHelper.formatBeverageType)
             .toList()
           ..sort();
-    final categoryLabel = provider.selectedCategories.isEmpty
+    final categoryLabel = selectedCategoriesEmpty
         ? 'Category'
-        : formattedCategories.length == 1
+        : selectedCategoriesLength == 1
         ? formattedCategories.first
-        : '${formattedCategories.length} categories';
+        : '$selectedCategoriesLength categories';
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
@@ -173,7 +290,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
                   : 'Filter by category: ${formattedCategories.join(', ')}',
               icon: Icons.filter_list,
               onPressed: () => showCategoryFilter(context),
-              isActive: provider.selectedCategories.isNotEmpty,
+              isActive: !selectedCategoriesEmpty,
             ),
           ),
           if (hasStyleFilter) ...[
@@ -181,20 +298,20 @@ class _DrinksScreenState extends State<DrinksScreen> {
             Expanded(
               child: FilterButton(
                 label: styleLabel,
-                semanticLabel: provider.selectedStyles.isEmpty
+                semanticLabel: selectedStylesEmpty
                     ? 'Filter by style'
                     : 'Filter by style: ${provider.selectedStyles.join(', ')}',
                 icon: Icons.style,
                 onPressed: () => showStyleFilter(context),
-                isActive: provider.selectedStyles.isNotEmpty,
+                isActive: !selectedStylesEmpty,
               ),
             ),
           ],
           const SizedBox(width: 6),
           Expanded(
             child: FilterButton(
-              label: provider.currentSort.label,
-              semanticLabel: 'Sort drinks by ${provider.currentSort.label}',
+              label: currentSort.label,
+              semanticLabel: 'Sort drinks by ${currentSort.label}',
               icon: Icons.sort,
               onPressed: () => showSortOptions(context),
               isActive: false,
@@ -202,15 +319,13 @@ class _DrinksScreenState extends State<DrinksScreen> {
           ),
           const SizedBox(width: 6),
           VisibilityFilterButton(
-            activeCount:
-                provider.visibilityFilters.length +
-                provider.excludedAllergens.length,
+            activeCount: visibilityFiltersLength + excludedAllergensLength,
             onPressed: () => showVisibilityFilter(context),
           ),
           const SizedBox(width: 6),
           SearchButton(
             isActive: _showSearch,
-            hasQuery: provider.searchQuery.isNotEmpty,
+            hasQuery: searchQuery.isNotEmpty,
             onPressed: () {
               // Collapsing the search bar clears the query; expanding it does
               // not. As with the clear button, setState keeps only the
@@ -238,13 +353,16 @@ class _DrinksScreenState extends State<DrinksScreen> {
 
   /// Thin progress bar while a background refresh runs with data on screen, or
   /// a dismissible notice when a refresh failed but cached data remains shown.
-  Widget _buildRefreshStatus(BuildContext context, BeerProvider provider) {
+  Widget _buildRefreshStatus(
+    BuildContext context,
+    BeerProvider provider, {
+    required bool hasData,
+    required bool isRefreshing,
+    required String? refreshNotice,
+  }) {
     final theme = Theme.of(context);
-    // Test against the unfiltered list so an active filter (favourites only,
-    // search query with no matches) doesn't hide the refresh indicator.
-    final hasData = provider.allDrinks.isNotEmpty;
 
-    if (provider.refreshNotice != null && hasData) {
+    if (refreshNotice != null && hasData) {
       return Material(
         color: theme.colorScheme.secondaryContainer,
         child: Padding(
@@ -259,7 +377,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  provider.refreshNotice!,
+                  refreshNotice,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSecondaryContainer,
                   ),
@@ -286,7 +404,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
       );
     }
 
-    if (provider.isRefreshing && hasData) {
+    if (isRefreshing && hasData) {
       return Semantics(
         label: 'Refreshing drinks',
         liveRegion: true,
@@ -297,8 +415,16 @@ class _DrinksScreenState extends State<DrinksScreen> {
     return const SizedBox.shrink();
   }
 
-  Widget _buildDrinksListSliver(BuildContext context, BeerProvider provider) {
-    if (provider.isLoading && provider.drinks.isEmpty) {
+  Widget _buildDrinksListSliver(
+    BuildContext context,
+    BeerProvider provider, {
+    required List<Drink> drinks,
+    required bool isLoading,
+    required String? error,
+    required String searchQuery,
+    required bool selectedCategoriesEmpty,
+  }) {
+    if (isLoading && drinks.isEmpty) {
       return SliverFillRemaining(
         hasScrollBody: false,
         child: Center(
@@ -314,7 +440,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
       );
     }
 
-    if (provider.error != null && provider.drinks.isEmpty) {
+    if (error != null && drinks.isEmpty) {
       return SliverFillRemaining(
         child: Center(
           child: Column(
@@ -331,7 +457,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
                 style: Theme.of(context).textTheme.titleLarge,
               ),
               const SizedBox(height: 8),
-              Text(provider.error!, textAlign: TextAlign.center),
+              Text(error, textAlign: TextAlign.center),
               const SizedBox(height: 16),
               Semantics(
                 label: 'Retry loading drinks',
@@ -349,7 +475,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
       );
     }
 
-    if (provider.drinks.isEmpty) {
+    if (drinks.isEmpty) {
       return SliverFillRemaining(
         child: Center(
           child: Column(
@@ -370,7 +496,7 @@ class _DrinksScreenState extends State<DrinksScreen> {
               ),
               const SizedBox(height: 8),
               const Text('Try adjusting your filters'),
-              if (provider.selectedCategories.isNotEmpty) ...[
+              if (!selectedCategoriesEmpty) ...[
                 const SizedBox(height: 16),
                 Semantics(
                   label: 'Clear all category filters',
@@ -393,15 +519,15 @@ class _DrinksScreenState extends State<DrinksScreen> {
       padding: const EdgeInsets.only(bottom: 16),
       sliver: SliverList(
         delegate: SliverChildBuilderDelegate((context, index) {
-          final drink = provider.drinks[index];
+          final drink = drinks[index];
           return DrinkCard(
             key: ValueKey(drink.id),
             drink: drink,
-            searchQuery: provider.searchQuery,
+            searchQuery: searchQuery,
             onTap: () => _navigateToDetail(context, drink.id, drink.category),
             onFavoriteTap: () => provider.toggleFavorite(drink),
           );
-        }, childCount: provider.drinks.length),
+        }, childCount: drinks.length),
       ),
     );
   }

--- a/lib/screens/drinks_screen.dart
+++ b/lib/screens/drinks_screen.dart
@@ -267,6 +267,13 @@ class _DrinksScreenState extends State<DrinksScreen> {
     // sighted user sees, in a deterministic order (a Set has none). Reads the
     // live Set off `provider` (context.read, not a selector) — the rebuild
     // itself is already gated by the primitive selects above.
+    //
+    // That gating holds only because every category mutation changes the
+    // Set's length: toggleCategory adds or removes exactly one entry, and
+    // clearCategories empties it. A bulk setter that swapped one category for
+    // another would keep the length identical, fire no select, and leave this
+    // label stale — add a content-based select (e.g. the sorted joined names,
+    // as _canonicalCategoryFilter already does) if one is ever introduced.
     final formattedCategories =
         provider.selectedCategories
             .map(BeverageTypeHelper.formatBeverageType)

--- a/lib/widgets/drink_card.dart
+++ b/lib/widgets/drink_card.dart
@@ -26,8 +26,19 @@ class DrinkCard extends StatelessWidget {
     this.searchQuery = '',
   });
 
+  /// Counts calls to [build] — assert-gated, so it's stripped entirely in
+  /// profile/release builds and costs nothing in production. Test-only
+  /// instrumentation for proving a narrowed provider select actually skips
+  /// unrelated rebuilds (see test/drinks_screen_rebuild_test.dart).
+  @visibleForTesting
+  static int debugBuildCount = 0;
+
   @override
   Widget build(BuildContext context) {
+    assert(() {
+      debugBuildCount++;
+      return true;
+    }());
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final accent = CategoryColorHelper.getAccentColor(

--- a/lib/widgets/festival_banner.dart
+++ b/lib/widgets/festival_banner.dart
@@ -1,33 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import '../providers/providers.dart';
 import '../utils/utils.dart';
 
 /// Tappable banner under the app bar showing the current festival's dates and
 /// location. Hidden when the festival has neither. Tapping opens festival info.
 class FestivalBanner extends StatelessWidget {
-  const FestivalBanner({
-    required this.provider,
-    required this.festivalId,
-    super.key,
-  });
+  const FestivalBanner({required this.festivalId, super.key});
 
-  final BeerProvider provider;
   final String festivalId;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final festival = provider.currentFestival;
+    // Select the individual fields, never the whole Festival: Festival.== is
+    // id-scoped by design and would swallow an in-place metadata refresh.
+    final formattedDates = context.select<BeerProvider, String>(
+      (p) => p.currentFestival.formattedDates,
+    );
+    final location = context.select<BeerProvider, String?>(
+      (p) => p.currentFestival.location,
+    );
 
     // Only show banner if festival has dates or location
-    if (festival.formattedDates.isEmpty && festival.location == null) {
+    if (formattedDates.isEmpty && location == null) {
       return const SizedBox.shrink();
     }
 
     final semanticLabel = [
-      if (festival.formattedDates.isNotEmpty) festival.formattedDates,
-      if (festival.location != null) festival.location,
+      if (formattedDates.isNotEmpty) formattedDates,
+      ?location,
     ].join(', ');
 
     return Material(
@@ -48,7 +51,7 @@ class FestivalBanner extends StatelessWidget {
                     spacing: 16,
                     runSpacing: 4,
                     children: [
-                      if (festival.formattedDates.isNotEmpty)
+                      if (formattedDates.isNotEmpty)
                         Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
@@ -59,12 +62,12 @@ class FestivalBanner extends StatelessWidget {
                             ),
                             const SizedBox(width: 4),
                             Text(
-                              festival.formattedDates,
+                              formattedDates,
                               style: theme.textTheme.bodySmall,
                             ),
                           ],
                         ),
-                      if (festival.location != null)
+                      if (location != null)
                         Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
@@ -74,10 +77,7 @@ class FestivalBanner extends StatelessWidget {
                               color: theme.colorScheme.onSurfaceVariant,
                             ),
                             const SizedBox(width: 4),
-                            Text(
-                              festival.location!,
-                              style: theme.textTheme.bodySmall,
-                            ),
+                            Text(location, style: theme.textTheme.bodySmall),
                           ],
                         ),
                     ],

--- a/lib/widgets/festival_header.dart
+++ b/lib/widgets/festival_header.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../models/models.dart';
 import '../providers/providers.dart';
 import '../utils/utils.dart';
@@ -6,18 +7,24 @@ import '../utils/utils.dart';
 /// App-bar title for the drinks screen: app icon, current festival name, the
 /// drink count, and a coloured status badge.
 class FestivalHeader extends StatelessWidget {
-  const FestivalHeader({required this.provider, super.key});
-
-  final BeerProvider provider;
+  const FestivalHeader({super.key});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final status = Festival.getStatusInContext(
-      provider.currentFestival,
-      provider.sortedFestivals,
+    final festivalName = context.select<BeerProvider, String>(
+      (p) => p.currentFestival.name,
     );
-    final drinkCount = provider.drinks.length;
+    // Select the derived enum rather than currentFestival/sortedFestivals
+    // directly: Festival.== is id-scoped by design (would swallow an
+    // in-place metadata refresh), and sortedFestivals is a derived List with
+    // no stable identity across rebuilds.
+    final status = context.select<BeerProvider, FestivalStatus>(
+      (p) => Festival.getStatusInContext(p.currentFestival, p.sortedFestivals),
+    );
+    final drinkCount = context.select<BeerProvider, int>(
+      (p) => p.drinks.length,
+    );
     final drinkCountLabel = StringFormattingHelper.drinkCountLabel(drinkCount);
 
     // Fold the status into the label and exclude child semantics so screen
@@ -25,7 +32,7 @@ class FestivalHeader extends StatelessWidget {
     // badge separately. Matches the pattern in DrinkCard, DrinkHeroPanel, etc.
     return Semantics(
       label:
-          'Current festival: ${provider.currentFestival.name}, '
+          'Current festival: $festivalName, '
           '$drinkCountLabel, ${FestivalStatusBadge.spokenLabel(status)}',
       excludeSemantics: true,
       child: Row(
@@ -39,7 +46,7 @@ class FestivalHeader extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
-                  provider.currentFestival.name,
+                  festivalName,
                   style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),

--- a/test/drinks_screen_rebuild_test.dart
+++ b/test/drinks_screen_rebuild_test.dart
@@ -1,0 +1,197 @@
+// Regression/proof test for issue #523: DrinksScreen used to
+// context.watch<BeerProvider>() as a whole, so a change to any provider
+// field — including one DrinksScreen never renders, like themeMode —
+// rebuilt the entire screen and, with it, every DrinkCard in the visible
+// list. Narrowing to per-concern context.select calls means an unrelated
+// notifyListeners() no longer touches DrinksScreen.build() at all.
+//
+// DrinkCard.debugBuildCount (assert-gated, lib/widgets/drink_card.dart) is
+// the direct proof: it counts real calls to DrinkCard.build(), not a proxy
+// state variable.
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:cambridge_beer_festival/providers/providers.dart';
+import 'package:cambridge_beer_festival/screens/screens.dart';
+import 'package:cambridge_beer_festival/services/services.dart';
+import 'package:cambridge_beer_festival/widgets/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'provider_test.mocks.dart';
+
+void main() {
+  group('DrinksScreen narrowed rebuilds (#523)', () {
+    late MockDrinkRepository mockDrinkRepository;
+    late MockFestivalRepository mockFestivalRepository;
+    late MockAnalyticsService mockAnalyticsService;
+    late BeerProvider provider;
+
+    final testDrinks = [
+      Drink(
+        product: const Product(
+          id: 'drink1',
+          name: 'Alpha IPA',
+          abv: 5.5,
+          category: 'beer',
+          dispense: 'cask',
+          style: 'IPA',
+        ),
+        producer: const Producer(
+          id: 'brewery1',
+          name: 'Test Brewery',
+          location: 'Cambridge',
+          products: [],
+        ),
+        festivalId: 'cbf2025',
+      ),
+      Drink(
+        product: const Product(
+          id: 'drink2',
+          name: 'Beta Bitter',
+          abv: 4.2,
+          category: 'beer',
+          dispense: 'cask',
+          style: 'Bitter',
+        ),
+        producer: const Producer(
+          id: 'brewery1',
+          name: 'Test Brewery',
+          location: 'Cambridge',
+          products: [],
+        ),
+        festivalId: 'cbf2025',
+      ),
+      Drink(
+        product: const Product(
+          id: 'drink3',
+          name: 'Gamma Stout',
+          abv: 6.0,
+          category: 'beer',
+          dispense: 'keg',
+          style: 'Stout',
+        ),
+        producer: const Producer(
+          id: 'brewery2',
+          name: 'Another Brewery',
+          location: 'London',
+          products: [],
+        ),
+        festivalId: 'cbf2025',
+      ),
+    ];
+
+    setUp(() async {
+      DrinkCard.debugBuildCount = 0;
+      SharedPreferences.setMockInitialValues({});
+      mockDrinkRepository = MockDrinkRepository();
+      mockFestivalRepository = MockFestivalRepository();
+      mockAnalyticsService = MockAnalyticsService();
+
+      const testFestival = Festival(
+        id: 'cbf2025',
+        name: 'Cambridge Beer Festival 2025',
+        dataBaseUrl: 'https://test.example.com/cbf2025',
+      );
+      final festivalsResponse = FestivalsResponse(
+        festivals: [testFestival],
+        defaultFestivalId: 'cbf2025',
+        baseUrl: 'https://example.com',
+        version: '1.0.0',
+      );
+      when(
+        mockFestivalRepository.getFestivals(),
+      ).thenAnswer((_) async => festivalsResponse);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => testDrinks);
+
+      provider = BeerProvider(
+        drinkRepository: mockDrinkRepository,
+        festivalRepository: mockFestivalRepository,
+        analyticsService: mockAnalyticsService,
+      );
+      await provider.initialize();
+      await provider.loadDrinks();
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    Widget createTestWidget() {
+      final router = GoRouter(
+        initialLocation: '/cbf2025',
+        routes: [
+          GoRoute(
+            path: '/cbf2025',
+            builder: (context, state) =>
+                ChangeNotifierProvider<BeerProvider>.value(
+                  value: provider,
+                  child: const DrinksScreen(festivalId: 'cbf2025'),
+                ),
+          ),
+          // Stub for any internal context.go('/') — see validation-and-qa.
+          GoRoute(path: '/', builder: (_, _) => const Scaffold()),
+        ],
+      );
+      return MaterialApp.router(routerConfig: router);
+    }
+
+    testWidgets(
+      'a provider change DrinksScreen does not render leaves DrinkCard '
+      'build count unchanged',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Alpha IPA'), findsOneWidget);
+        final countBefore = DrinkCard.debugBuildCount;
+        expect(
+          countBefore,
+          greaterThan(0),
+          reason: 'Test setup check: cards must have built at least once',
+        );
+
+        // themeMode is never read by DrinksScreen or any of its selects.
+        await provider.setThemeMode(ThemeMode.dark);
+        await tester.pump();
+
+        expect(
+          DrinkCard.debugBuildCount,
+          countBefore,
+          reason:
+              'An unrelated provider field change must not rebuild '
+              'DrinkCard — this is the literal acceptance bar for #523',
+        );
+      },
+    );
+
+    testWidgets(
+      'control: a change that narrows the drink list does increase the '
+      'build count',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final countBefore = DrinkCard.debugBuildCount;
+        expect(countBefore, greaterThan(0));
+
+        // setSearchQuery changes provider.drinks (selected by DrinksScreen),
+        // so this must rebuild the list — proves the counter isn't dead and
+        // narrowing selects didn't over-suppress real updates.
+        provider.setSearchQuery('Alpha');
+        await tester.pumpAndSettle();
+
+        expect(find.text('Alpha IPA'), findsOneWidget);
+        expect(find.text('Beta Bitter'), findsNothing);
+        expect(DrinkCard.debugBuildCount, greaterThan(countBefore));
+      },
+    );
+  });
+}

--- a/test/widgets/drink_filter_sheets_test.dart
+++ b/test/widgets/drink_filter_sheets_test.dart
@@ -501,7 +501,7 @@ void main() {
         'location', (tester) async {
       // The test festival has neither dates nor a location.
       await tester.pumpWidget(
-        directHost(FestivalBanner(provider: provider, festivalId: 'cbf2025')),
+        directHost(const FestivalBanner(festivalId: 'cbf2025')),
       );
       await tester.pumpAndSettle();
 

--- a/test/widgets/festival_header_test.dart
+++ b/test/widgets/festival_header_test.dart
@@ -162,9 +162,7 @@ void main() {
         ChangeNotifierProvider<BeerProvider>.value(
           value: provider,
           child: MaterialApp(
-            home: Scaffold(
-              appBar: AppBar(title: FestivalHeader(provider: provider)),
-            ),
+            home: Scaffold(appBar: AppBar(title: const FestivalHeader())),
           ),
         ),
       );


### PR DESCRIPTION
## Summary

`DrinksScreen` opened `build()` with a bare `context.watch<BeerProvider>()`, so any of the provider's 28 `notifyListeners()` call sites rebuilt the whole screen — including the `SliverChildBuilderDelegate` and every visible `DrinkCard`. A theme-mode change rebuilt every card.

This narrows `DrinksScreen`, `FestivalHeader`, and `FestivalBanner` to per-concern `context.select` reads, and adds a rebuild-count test that proves the win.

Pure data-flow restructure: no layout, colour, or `Semantics` change. No goldens diffed.

## Changes

- **`drinks_screen.dart`** — bare `watch` replaced with narrow selects (festival id and name as separate `String` selects, `drinks`, `isLoading`, `error`, `isRefreshing`, `refreshNotice`, `searchQuery`, `currentSort`, and derived primitives for the filter-button counts). One `context.read` covers all action callbacks. The festival-flash guard keeps its exact shape.
- **`festival_header.dart` / `festival_banner.dart`** — dropped the constructor-injected `BeerProvider`; both are now `const`-constructible and select what they need at their own build boundary. This is required, not cosmetic: `FestivalHeader`'s status badge depends on `sortedFestivals`, which `DrinksScreen`'s build never reads, so narrowing the screen alone would have left the header stale after a background festival-registry refresh.
- **`drink_card.dart`** — assert-gated `@visibleForTesting debugBuildCount`. `assert` bodies are stripped in profile/release, so this is zero production cost.
- **`drinks_screen_rebuild_test.dart`** (new) — asserts a `setThemeMode` change causes **zero** additional `DrinkCard` builds, plus a control case where `setSearchQuery` *does* rebuild (and asserts the visible outcome), so the test cannot pass via a dead counter.

## Selector equality

`Festival.==` is id-scoped by design (`festival.dart:151`), so no select returns a whole `Festival` — individual fields and a derived `FestivalStatus` enum are selected instead. Selecting the whole object would reproduce the shape of the #306/#362 staleness bug.

On the filter getters, `selectedCategories` / `visibilityFilters` / `excludedAllergens` return a fresh `Set.unmodifiable(...)` wrapper per call, so a selector on the whole `Set` always sees "changed" — wasteful but harmless. Derived primitives (`.length`, `.isEmpty`, `.first`) are selected instead so those reads can actually skip.

> **Correction.** An earlier revision of this description and a code comment claimed `selectedStyles` is mutated in place and therefore unsafe to select. That was wrong, as [Copilot pointed out](https://github.com/richardthe3rd/cambridge-beer-festival-app/pull/550#discussion_r3778616056). `DrinkFilterController` reassigns `_selectedStyles` to a new `Set` on every mutation, so Dart's identity `==` makes it genuinely selector-safe as a whole `Set` — the most selector-safe of the four, not the least. Fixed in 4fae6b5; the primitives are kept for consistency, not necessity.

Two invariants that hold today but are not contracts are recorded as comments at their call sites: `provider.drinks` being identity-stable across unrelated notifications, and the category label's reliance on every mutation changing the Set's length.

## Verification

`./bin/mise run check` green — analyzer clean, 1322 tests pass (1320 before, +2 new). No golden diffs.

## Scope

One screen, per the issue's own "incremental, not a sweep". Still outstanding on #523: the six other screens with the same bare `watch` (`brewery`, `drink_detail`, `style`, `my_festival`, `about`, `festival_info`).

Deliberately not touched here:
- The modal sheets — `FestivalSelectorSheet` carries a documented `ListenableBuilder` design decision because a modal route isn't rebuilt by its opener, and whether `context.select` behaves correctly through `showModalBottomSheet` needs its own investigation rather than an assumption that this pattern transfers.
- The style filter's `semanticLabel` joins an unsorted `Set`, so the screen-reader announcement order is non-deterministic (categories are sorted). Pre-existing on `main`, not introduced here — changing a `Semantics` label would contradict this PR's zero-behaviour-change claim, so it belongs in its own change.

Fixes #523