### PR TITLE
refactor(app): narrow app-level provider watches to selects

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,7 +87,13 @@ class BeerFestivalApp extends StatelessWidget {
       create: (_) => BeerProvider(),
       child: Builder(
         builder: (context) {
-          final themeMode = context.watch<BeerProvider>().themeMode;
+          // select, not watch: MaterialApp.router is above every screen, so a
+          // whole-provider subscription rebuilds it on all 28 of
+          // BeerProvider's notifyListeners() call sites even though themeMode
+          // is the only value it reads here (issue #551).
+          final themeMode = context.select<BeerProvider, ThemeMode>(
+            (p) => p.themeMode,
+          );
           return MaterialApp.router(
             title: 'Cambridge Beer Festival',
             debugShowCheckedModeBanner: false,

--- a/lib/widgets/provider_initializer.dart
+++ b/lib/widgets/provider_initializer.dart
@@ -13,6 +13,18 @@ class ProviderInitializer extends StatefulWidget {
 
   const ProviderInitializer({super.key, required this.child});
 
+  /// Counts calls to this widget's `build()`, for rebuild-scope regression
+  /// tests (issue #551). Incremented inside an `assert`, whose body is
+  /// stripped in profile and release builds, so this costs nothing in
+  /// production. Mirrors `DrinkCard.debugBuildCount`.
+  ///
+  /// Instrumenting the widget itself is necessary rather than counting a
+  /// descendant's builds: `build()` returns `widget.child`, the same widget
+  /// instance every time, so Flutter's diffing skips the subtree and a
+  /// child-side counter would never observe a rebuild here.
+  @visibleForTesting
+  static int debugBuildCount = 0;
+
   @override
   State<ProviderInitializer> createState() => _ProviderInitializerState();
 }
@@ -159,10 +171,27 @@ class _ProviderInitializerState extends State<ProviderInitializer>
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.watch<BeerProvider>();
+    assert(() {
+      ProviderInitializer.debugBuildCount++;
+      return true;
+    }());
+
+    // select, not watch: this widget wraps every route but renders from one
+    // composite flag, so watching the whole provider rebuilt it on every
+    // notification (issue #551).
+    //
+    // The derived bool is selected rather than allDrinks itself: _replaceDrink
+    // mutates _allDrinks in place (`_allDrinks[idx] = updated`), so the List's
+    // identity never changes on a personal-state write and a selector on it
+    // would be blind. `.isEmpty` is unaffected by that element swap and does
+    // change when _setAllDrinks reassigns, which is exactly the transition
+    // this guard cares about.
+    final showLoading = context.select<BeerProvider, bool>(
+      (p) => p.isLoading && p.allDrinks.isEmpty,
+    );
 
     // Show loading screen until provider is initialized
-    if (provider.isLoading && provider.allDrinks.isEmpty) {
+    if (showLoading) {
       return const Scaffold(
         body: Center(
           child: Column(

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -355,6 +357,79 @@ void main() {
 
       // refreshIfStale was called and found stale data — a reload was triggered
       expect(getDrinksCalls, 1);
+    });
+
+    // Issue #551: ProviderInitializer wraps every route but renders from a
+    // single composite flag. It used to context.watch the whole provider, so
+    // all 28 notifyListeners() call sites rebuilt it.
+    group('ProviderInitializer rebuild scope (#551)', () {
+      Future<void> pumpInitializer(WidgetTester tester) async {
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: const MaterialApp(
+              home: ProviderInitializer(child: Scaffold(body: Text('Test'))),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('a provider change it does not render causes no rebuild', (
+        WidgetTester tester,
+      ) async {
+        await pumpInitializer(tester);
+
+        ProviderInitializer.debugBuildCount = 0;
+
+        // searchQuery is not read anywhere in ProviderInitializer.build().
+        provider.setSearchQuery('ipa');
+        await tester.pump();
+
+        expect(
+          ProviderInitializer.debugBuildCount,
+          0,
+          reason:
+              'An unrelated provider field must not rebuild ProviderInitializer',
+        );
+      });
+
+      testWidgets('control: the flag it does render still rebuilds it', (
+        WidgetTester tester,
+      ) async {
+        // Hold the initial load open so the widget starts in the loading
+        // state, then let it complete — that flips isLoading && allDrinks
+        // .isEmpty, the one value build() selects.
+        final gate = Completer<List<Drink>>();
+        when(mockDrinkRepository.getDrinks(any)).thenAnswer((_) => gate.future);
+
+        await tester.pumpWidget(
+          ChangeNotifierProvider<BeerProvider>.value(
+            value: provider,
+            child: const MaterialApp(
+              home: ProviderInitializer(child: Scaffold(body: Text('Test'))),
+            ),
+          ),
+        );
+        // Plain pumps, not pumpAndSettle: the loading state shows a
+        // CircularProgressIndicator, which animates forever and would make
+        // pumpAndSettle time out. Two pumps let initialize()'s microtasks
+        // flush and loadDrinks() reach the pending gate.
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Loading festival data...'), findsOneWidget);
+        ProviderInitializer.debugBuildCount = 0;
+
+        gate.complete(<Drink>[]);
+        await tester.pumpAndSettle();
+
+        // Proves the counter is live and the selector didn't over-suppress:
+        // the guard's own value changing must still rebuild.
+        expect(ProviderInitializer.debugBuildCount, greaterThan(0));
+        expect(find.text('Loading festival data...'), findsNothing);
+        expect(find.text('Test'), findsOneWidget);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

`MaterialApp.router` and `ProviderInitializer` both sit above every screen, and each renders from a single value — but both subscribed to the whole of `BeerProvider` via `context.watch`, so all 28 `notifyListeners()` call sites rebuilt them.

Same fix shape as #550, applied to the two app-level sites that issue #523 doesn't cover.

## Changes

- **`main.dart:90`** — `context.watch<BeerProvider>().themeMode` → `context.select<BeerProvider, ThemeMode>((p) => p.themeMode)`.
- **`provider_initializer.dart:162`** — the whole `build()` reads exactly one composite flag (audited: no other `provider.` reference in the method, which then returns `widget.child`). Now selects that bool directly.
- **`provider_initializer.dart`** — assert-gated `@visibleForTesting debugBuildCount`, mirroring `DrinkCard.debugBuildCount` from #550. `assert` bodies are stripped in profile and release, so this is zero production cost.
- **`test/main_test.dart`** — new `ProviderInitializer rebuild scope (#551)` group.

## Why the counter had to go on the widget itself

`build()` returns `widget.child` — the same widget instance every time. Flutter's diffing skips an identical subtree, so a counter on a descendant would never observe this widget rebuilding, and a test built that way would pass no matter what. The counter has to be on `ProviderInitializer`.

## Why the composite bool, not `allDrinks`

`_replaceDrink` mutates the list in place (`_allDrinks[idx] = updated`, `beer_provider.dart:806`), so `_allDrinks`'s identity never changes on a favourite/rating/tasted/notes write — a selector on the list itself would be blind to those. `.isEmpty` is unaffected by that element swap and does change when `_setAllDrinks` reassigns, which is precisely the transition this loading guard cares about. Selecting the composite is semantically identical to the previous watch-then-evaluate.

(This is the same trap that makes `provider.drinks` select-safe while `provider.allDrinks` is not: `_replaceDrink` calls `_filter.recompute()`, which reassigns `_filtered`.)

## Verification

`./bin/mise run check` green — analyzer clean, 1322 tests pass (1320 before, +2 new).

The zero-rebuild test was confirmed to be a real guard rather than a vacuous pass: with the `context.watch` temporarily restored, `'a provider change it does not render causes no rebuild'` fails while the control case still passes. The control case itself asserts that the flag this widget *does* render still rebuilds it, so the test cannot pass via a dead counter.

Note the control case uses plain `pump()` rather than `pumpAndSettle()` while the loading state is on screen — `CircularProgressIndicator` animates indefinitely and would make `pumpAndSettle` time out.

Fixes #551

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDwLmn1bwD3mDRZANHbpXe)_