### PR TITLE
refactor(brewery,style): narrow provider selects on the brewery and style screens

### DIFF
--- a/lib/providers/beer_provider.dart
+++ b/lib/providers/beer_provider.dart
@@ -102,6 +102,19 @@ class BeerProvider extends ChangeNotifier {
   // Getters
   List<Drink> get drinks => _filter.filteredDrinks;
   List<Drink> get allDrinks => _allDrinks;
+
+  /// Bumped by [_setAllDrinks] on every catalogue load, refresh, or festival
+  /// switch.
+  int get catalogueRevision => _catalogueRevision;
+
+  /// Bumped by [_replaceDrink] on every personal-state write (favourite,
+  /// rating, tasted, notes). [allDrinks] is mutated **in place** by that same
+  /// method (`_allDrinks[idx] = updated`), so `context.select((p) =>
+  /// p.allDrinks)` never observes a personal-state change — the List
+  /// reference is identical before and after. Select this alongside
+  /// [catalogueRevision] as a change trigger, then read [allDrinks] via
+  /// `context.read` once already rebuilding.
+  int get personalStateRevision => _personalStateRevision;
   List<Festival> get festivals => _festivalController.festivals;
 
   /// Get festivals sorted by date (live/upcoming first, then past in reverse chronological order)

--- a/lib/screens/brewery_screen.dart
+++ b/lib/screens/brewery_screen.dart
@@ -49,20 +49,43 @@ class _BreweryScreenState extends State<BreweryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.watch<BeerProvider>();
-
+    // Narrow per-concern selects instead of a bare watch<BeerProvider>() —
+    // see DrinksScreen (#523/#550) for the established pattern.
+    //
     // Festival-flash guard: on a URL-driven festival change the provider
     // switches in a post-frame callback, so without this the screen would
     // resolve its content against the PREVIOUS festival's catalogue for a
     // frame — showing the wrong entity or a spurious "not found" (#397).
-    if (provider.currentFestival.id != widget.festivalId) {
+    // Festival.== is id-scoped by design, so this selects the id
+    // specifically rather than the whole Festival object.
+    final currentFestivalId = context.select<BeerProvider, String>(
+      (p) => p.currentFestival.id,
+    );
+    if (currentFestivalId != widget.festivalId) {
       return buildLoadingScaffold();
     }
 
     // Show loading state while drinks are being fetched
-    if (provider.isLoading) {
+    final isLoading = context.select<BeerProvider, bool>((p) => p.isLoading);
+    if (isLoading) {
       return buildLoadingScaffold();
     }
+
+    final currentFestivalName = context.select<BeerProvider, String>(
+      (p) => p.currentFestival.name,
+    );
+
+    // allDrinks cannot be selected directly — _replaceDrink mutates it in
+    // place on every favourite/rating/tasted/notes write, so the List
+    // reference never changes and a selector on it would never fire (see
+    // BeerProvider.personalStateRevision doc). Subscribe to catalogue
+    // reloads and personal-state writes via the revision counters instead;
+    // the tuple itself is discarded, this call exists only to subscribe.
+    context.select<BeerProvider, (int, int)>(
+      (p) => (p.catalogueRevision, p.personalStateRevision),
+    );
+
+    final provider = context.read<BeerProvider>();
 
     // Get all drinks from this brewery
     final breweryDrinks = provider.allDrinks
@@ -89,7 +112,7 @@ class _BreweryScreenState extends State<BreweryScreen> {
 
     return PageTitle(
       pageTitle: producer.name,
-      contextLabel: provider.currentFestival.name,
+      contextLabel: currentFestivalName,
       child: Scaffold(
         body: CustomScrollView(
           controller: _scrollController,
@@ -98,7 +121,7 @@ class _BreweryScreenState extends State<BreweryScreen> {
             // once the hero card below scrolls off.
             CollapsingDetailAppBar(
               scrollController: _scrollController,
-              contextTitle: provider.currentFestival.name,
+              contextTitle: currentFestivalName,
               collapsedTitle: producer.name,
               leading: buildHomeLeadingButton(context, widget.festivalId),
               actions: [buildDrinksListAction(context, widget.festivalId)],

--- a/lib/screens/style_screen.dart
+++ b/lib/screens/style_screen.dart
@@ -39,20 +39,43 @@ class _StyleScreenState extends State<StyleScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.watch<BeerProvider>();
-
+    // Narrow per-concern selects instead of a bare watch<BeerProvider>() —
+    // see DrinksScreen (#523/#550) for the established pattern.
+    //
     // Festival-flash guard: on a URL-driven festival change the provider
     // switches in a post-frame callback, so without this the screen would
     // resolve its content against the PREVIOUS festival's catalogue for a
     // frame — showing the wrong entity or a spurious "not found" (#397).
-    if (provider.currentFestival.id != widget.festivalId) {
+    // Festival.== is id-scoped by design, so this selects the id
+    // specifically rather than the whole Festival object.
+    final currentFestivalId = context.select<BeerProvider, String>(
+      (p) => p.currentFestival.id,
+    );
+    if (currentFestivalId != widget.festivalId) {
       return buildLoadingScaffold();
     }
 
     // Show loading state while drinks are being fetched
-    if (provider.isLoading) {
+    final isLoading = context.select<BeerProvider, bool>((p) => p.isLoading);
+    if (isLoading) {
       return buildLoadingScaffold();
     }
+
+    final currentFestivalName = context.select<BeerProvider, String>(
+      (p) => p.currentFestival.name,
+    );
+
+    // allDrinks cannot be selected directly — _replaceDrink mutates it in
+    // place on every favourite/rating/tasted/notes write, so the List
+    // reference never changes and a selector on it would never fire (see
+    // BeerProvider.personalStateRevision doc). Subscribe to catalogue
+    // reloads and personal-state writes via the revision counters instead;
+    // the tuple itself is discarded, this call exists only to subscribe.
+    context.select<BeerProvider, (int, int)>(
+      (p) => (p.catalogueRevision, p.personalStateRevision),
+    );
+
+    final provider = context.read<BeerProvider>();
 
     // Get all drinks with this style
     final styleDrinks = provider.allDrinks
@@ -85,7 +108,7 @@ class _StyleScreenState extends State<StyleScreen> {
 
     return PageTitle(
       pageTitle: displayStyle,
-      contextLabel: provider.currentFestival.name,
+      contextLabel: currentFestivalName,
       child: Scaffold(
         body: CustomScrollView(
           controller: _scrollController,
@@ -94,7 +117,7 @@ class _StyleScreenState extends State<StyleScreen> {
             // the hero card below scrolls off.
             CollapsingDetailAppBar(
               scrollController: _scrollController,
-              contextTitle: provider.currentFestival.name,
+              contextTitle: currentFestivalName,
               collapsedTitle: displayStyle,
               leading: buildHomeLeadingButton(context, widget.festivalId),
               actions: [buildDrinksListAction(context, widget.festivalId)],

--- a/test/beer_provider_test.dart
+++ b/test/beer_provider_test.dart
@@ -1028,6 +1028,81 @@ void main() {
       });
     });
 
+    group('catalogueRevision and personalStateRevision (#523)', () {
+      // These two counters are the change-trigger for screens (BreweryScreen,
+      // StyleScreen) that must subscribe to catalogue reloads and
+      // personal-state writes without selecting provider.allDrinks directly —
+      // see BeerProvider.personalStateRevision's doc comment for why a
+      // selector on allDrinks itself never fires.
+      setUp(() async {
+        provider = BeerProvider(
+          drinkRepository: mockDrinkRepository,
+          festivalRepository: mockFestivalRepository,
+          analyticsService: mockAnalyticsService,
+        );
+        await provider.initialize();
+        when(
+          mockDrinkRepository.getDrinks(any),
+        ).thenAnswer((_) async => createSampleDrinks());
+      });
+
+      test('both counters start at 0', () {
+        expect(provider.catalogueRevision, 0);
+        expect(provider.personalStateRevision, 0);
+      });
+
+      test('loadDrinks() bumps catalogue only', () async {
+        await provider.loadDrinks();
+
+        expect(provider.catalogueRevision, 1);
+        expect(provider.personalStateRevision, 0);
+      });
+
+      test('toggleFavorite() bumps personal only', () async {
+        await provider.loadDrinks();
+        final catalogueRevisionAfterLoad = provider.catalogueRevision;
+        final drink = provider.allDrinks.first;
+        when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer(
+          (_) async => UserDrinkState(
+            wantToTry: true,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+
+        await provider.toggleFavorite(drink);
+
+        expect(provider.catalogueRevision, catalogueRevisionAfterLoad);
+        expect(provider.personalStateRevision, 1);
+      });
+
+      test(
+        'a second load bumps catalogue again without touching personal',
+        () async {
+          await provider.loadDrinks();
+          final drink = provider.allDrinks.first;
+          when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer(
+            (_) async => UserDrinkState(
+              wantToTry: true,
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            ),
+          );
+          await provider.toggleFavorite(drink);
+          final personalStateRevisionAfterToggle =
+              provider.personalStateRevision;
+
+          await provider.loadDrinks();
+
+          expect(provider.catalogueRevision, 2);
+          expect(
+            provider.personalStateRevision,
+            personalStateRevisionAfterToggle,
+          );
+        },
+      );
+    });
+
     group('hide unavailable filter', () {
       test('setHideUnavailable filters out sold out drinks', () async {
         provider = BeerProvider(

--- a/test/brewery_screen_rebuild_test.dart
+++ b/test/brewery_screen_rebuild_test.dart
@@ -1,0 +1,172 @@
+// Regression/proof test for issue #523: BreweryScreen used to
+// context.watch<BeerProvider>() as a whole, so a change to any provider
+// field — including one BreweryScreen never renders, like themeMode —
+// rebuilt the entire screen and, with it, every DrinkCard in the brewery's
+// drink list. Narrowing to per-concern context.select calls (plus the
+// catalogueRevision/personalStateRevision tuple select, since allDrinks
+// itself can't be selected directly — see BeerProvider.personalStateRevision)
+// means an unrelated notifyListeners() no longer touches
+// BreweryScreen.build() at all.
+//
+// DrinkCard.debugBuildCount (assert-gated, lib/widgets/drink_card.dart) is
+// the direct proof: it counts real calls to DrinkCard.build(), not a proxy
+// state variable.
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:cambridge_beer_festival/providers/providers.dart';
+import 'package:cambridge_beer_festival/screens/screens.dart';
+import 'package:cambridge_beer_festival/services/services.dart';
+import 'package:cambridge_beer_festival/widgets/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'provider_test.mocks.dart';
+
+void main() {
+  group('BreweryScreen narrowed rebuilds (#523)', () {
+    late MockDrinkRepository mockDrinkRepository;
+    late MockFestivalRepository mockFestivalRepository;
+    late MockAnalyticsService mockAnalyticsService;
+    late BeerProvider provider;
+
+    const producer1 = Producer(
+      id: 'brewery1',
+      name: 'Test Brewery',
+      location: 'Cambridge',
+      products: [],
+    );
+
+    final drink1 = Drink(
+      product: const Product(
+        id: 'drink1',
+        name: 'Alpha IPA',
+        abv: 5.5,
+        category: 'beer',
+        dispense: 'cask',
+        style: 'IPA',
+      ),
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
+    final drink2 = Drink(
+      product: const Product(
+        id: 'drink2',
+        name: 'Beta Bitter',
+        abv: 4.2,
+        category: 'beer',
+        dispense: 'cask',
+        style: 'Bitter',
+      ),
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
+
+    setUp(() async {
+      DrinkCard.debugBuildCount = 0;
+      SharedPreferences.setMockInitialValues({});
+      mockDrinkRepository = MockDrinkRepository();
+      mockFestivalRepository = MockFestivalRepository();
+      mockAnalyticsService = MockAnalyticsService();
+
+      const testFestival = Festival(
+        id: 'cbf2025',
+        name: 'Cambridge Beer Festival 2025',
+        dataBaseUrl: 'https://test.example.com/cbf2025',
+      );
+      final festivalsResponse = FestivalsResponse(
+        festivals: [testFestival],
+        defaultFestivalId: 'cbf2025',
+        baseUrl: 'https://example.com',
+        version: '1.0.0',
+      );
+      when(
+        mockFestivalRepository.getFestivals(),
+      ).thenAnswer((_) async => festivalsResponse);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2]);
+
+      provider = BeerProvider(
+        drinkRepository: mockDrinkRepository,
+        festivalRepository: mockFestivalRepository,
+        analyticsService: mockAnalyticsService,
+      );
+      await provider.initialize();
+      await provider.loadDrinks();
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    Widget createTestWidget() {
+      return ChangeNotifierProvider<BeerProvider>.value(
+        value: provider,
+        child: const MaterialApp(
+          home: BreweryScreen(festivalId: 'cbf2025', breweryId: 'brewery1'),
+        ),
+      );
+    }
+
+    testWidgets(
+      'a provider change BreweryScreen does not render leaves DrinkCard '
+      'build count unchanged',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Alpha IPA'), findsOneWidget);
+        final countBefore = DrinkCard.debugBuildCount;
+        expect(
+          countBefore,
+          greaterThan(0),
+          reason: 'Test setup check: cards must have built at least once',
+        );
+
+        // themeMode is never read by BreweryScreen or any of its selects.
+        await provider.setThemeMode(ThemeMode.dark);
+        await tester.pump();
+
+        expect(
+          DrinkCard.debugBuildCount,
+          countBefore,
+          reason:
+              'An unrelated provider field change must not rebuild '
+              'DrinkCard — this is the literal acceptance bar for #523',
+        );
+      },
+    );
+
+    testWidgets(
+      'control: toggling a favourite on a brewery drink does increase the '
+      'build count',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final countBefore = DrinkCard.debugBuildCount;
+        expect(countBefore, greaterThan(0));
+
+        // allDrinks is mutated in place by _replaceDrink, so this exercises
+        // the trap the plan calls out: a naive
+        // context.select((p) => p.allDrinks) would never rebuild here.
+        when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer(
+          (_) async => UserDrinkState(
+            wantToTry: true,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+        await provider.toggleFavorite(drink1);
+        await tester.pumpAndSettle();
+
+        expect(DrinkCard.debugBuildCount, greaterThan(countBefore));
+      },
+    );
+  });
+}

--- a/test/style_screen_rebuild_test.dart
+++ b/test/style_screen_rebuild_test.dart
@@ -1,0 +1,172 @@
+// Regression/proof test for issue #523: StyleScreen used to
+// context.watch<BeerProvider>() as a whole, so a change to any provider
+// field — including one StyleScreen never renders, like themeMode —
+// rebuilt the entire screen and, with it, every DrinkCard in the style's
+// drink list. Narrowing to per-concern context.select calls (plus the
+// catalogueRevision/personalStateRevision tuple select, since allDrinks
+// itself can't be selected directly — see BeerProvider.personalStateRevision)
+// means an unrelated notifyListeners() no longer touches StyleScreen.build()
+// at all.
+//
+// DrinkCard.debugBuildCount (assert-gated, lib/widgets/drink_card.dart) is
+// the direct proof: it counts real calls to DrinkCard.build(), not a proxy
+// state variable.
+import 'package:cambridge_beer_festival/models/models.dart';
+import 'package:cambridge_beer_festival/providers/providers.dart';
+import 'package:cambridge_beer_festival/screens/screens.dart';
+import 'package:cambridge_beer_festival/services/services.dart';
+import 'package:cambridge_beer_festival/widgets/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'provider_test.mocks.dart';
+
+void main() {
+  group('StyleScreen narrowed rebuilds (#523)', () {
+    late MockDrinkRepository mockDrinkRepository;
+    late MockFestivalRepository mockFestivalRepository;
+    late MockAnalyticsService mockAnalyticsService;
+    late BeerProvider provider;
+
+    const producer1 = Producer(
+      id: 'brewery1',
+      name: 'Test Brewery',
+      location: 'Cambridge',
+      products: [],
+    );
+
+    final drink1 = Drink(
+      product: const Product(
+        id: 'drink1',
+        name: 'Test IPA 1',
+        abv: 5.0,
+        category: 'beer',
+        style: 'IPA',
+        dispense: 'cask',
+      ),
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
+    final drink2 = Drink(
+      product: const Product(
+        id: 'drink2',
+        name: 'Test IPA 2',
+        abv: 6.5,
+        category: 'beer',
+        style: 'IPA',
+        dispense: 'keg',
+      ),
+      producer: producer1,
+      festivalId: 'cbf2025',
+    );
+
+    setUp(() async {
+      DrinkCard.debugBuildCount = 0;
+      SharedPreferences.setMockInitialValues({});
+      mockDrinkRepository = MockDrinkRepository();
+      mockFestivalRepository = MockFestivalRepository();
+      mockAnalyticsService = MockAnalyticsService();
+
+      const testFestival = Festival(
+        id: 'cbf2025',
+        name: 'Cambridge Beer Festival 2025',
+        dataBaseUrl: 'https://test.example.com/cbf2025',
+      );
+      final festivalsResponse = FestivalsResponse(
+        festivals: [testFestival],
+        defaultFestivalId: 'cbf2025',
+        baseUrl: 'https://example.com',
+        version: '1.0.0',
+      );
+      when(
+        mockFestivalRepository.getFestivals(),
+      ).thenAnswer((_) async => festivalsResponse);
+      when(
+        mockFestivalRepository.getSelectedFestivalId(),
+      ).thenAnswer((_) async => null);
+      when(
+        mockDrinkRepository.getDrinks(any),
+      ).thenAnswer((_) async => [drink1, drink2]);
+
+      provider = BeerProvider(
+        drinkRepository: mockDrinkRepository,
+        festivalRepository: mockFestivalRepository,
+        analyticsService: mockAnalyticsService,
+      );
+      await provider.initialize();
+      await provider.loadDrinks();
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    Widget createTestWidget() {
+      return ChangeNotifierProvider<BeerProvider>.value(
+        value: provider,
+        child: const MaterialApp(
+          home: StyleScreen(festivalId: 'cbf2025', style: 'ipa'),
+        ),
+      );
+    }
+
+    testWidgets(
+      'a provider change StyleScreen does not render leaves DrinkCard '
+      'build count unchanged',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Test IPA 1'), findsOneWidget);
+        final countBefore = DrinkCard.debugBuildCount;
+        expect(
+          countBefore,
+          greaterThan(0),
+          reason: 'Test setup check: cards must have built at least once',
+        );
+
+        // themeMode is never read by StyleScreen or any of its selects.
+        await provider.setThemeMode(ThemeMode.dark);
+        await tester.pump();
+
+        expect(
+          DrinkCard.debugBuildCount,
+          countBefore,
+          reason:
+              'An unrelated provider field change must not rebuild '
+              'DrinkCard — this is the literal acceptance bar for #523',
+        );
+      },
+    );
+
+    testWidgets(
+      'control: toggling a favourite on a style drink does increase the '
+      'build count',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final countBefore = DrinkCard.debugBuildCount;
+        expect(countBefore, greaterThan(0));
+
+        // allDrinks is mutated in place by _replaceDrink, so this exercises
+        // the trap the plan calls out: a naive
+        // context.select((p) => p.allDrinks) would never rebuild here.
+        when(mockDrinkRepository.toggleFavorite(any, any)).thenAnswer(
+          (_) async => UserDrinkState(
+            wantToTry: true,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+        await provider.toggleFavorite(drink1);
+        await tester.pumpAndSettle();
+
+        expect(DrinkCard.debugBuildCount, greaterThan(countBefore));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

`BreweryScreen` and `StyleScreen` both opened `build()` with a bare `context.watch<BeerProvider>()`, so any of the provider's 28 `notifyListeners()` call sites rebuilt the whole screen — and both render lists of `DrinkCard` via `DrinkListSection`, so this is where the remaining card-rebuild surface from #523 was concentrated.

Follows the pattern established in #550. Pure data-flow restructure: no layout, colour or `Semantics` change, and no golden diffs.

## The trap this had to work around

Unlike `drinks_screen`, these screens read `provider.allDrinks` — and **`allDrinks` is not selector-safe**.

`_replaceDrink` (`beer_provider.dart:806`) does `_allDrinks[idx] = updated`, an *in-place* mutation, so the `List`'s identity never changes on a favourite/rating/tasted/notes write. A `context.select((p) => p.allDrinks)` is therefore blind to exactly those updates.

That in-place mutation is deliberate, not a bug: `DrinkFilterController.setSource` stores the reference (`_source = drinks`), so `_allDrinks` and `_filter._source` are the same object, and `recompute()` exists specifically to re-run over a list that mutated underneath it. Reassigning `_allDrinks` to a copy would desync `_filter._source` and force a full `_personalState.setSource` map rebuild on every toggle — so the workaround belongs at the call site, not in the write path.

These screens also can't switch to the safe `provider.drinks`: that's the *filtered* list, and they need every drink for the brewery/style regardless of the user's active filters.

**The fix:** expose the `catalogueRevision` and `personalStateRevision` counters that already exist privately (`beer_provider.dart:52-53`) and already back the `myFestivalEntries` memoisation (`:181-182`). Each screen selects the pair as a change trigger, then reads `allDrinks` via `context.read` once the rebuild is already underway.

## Changes

- **`beer_provider.dart`** — two additive public getters. No signature changes; nothing can break.
- **`brewery_screen.dart` / `style_screen.dart`** — bare `watch` replaced with narrow selects: `currentFestival.id` and `.name` as separate `String` selects (never the whole `Festival` — `Festival.==` is id-scoped by design, `festival.dart:151`), `isLoading`, and the revision tuple. `DrinkListSection.buildSlivers` and `initState` are untouched; both already used `context.read`.
- **`test/beer_provider_test.dart`** — new group covering both getters: independent incrementing, catalogue vs personal-state isolation.
- **`test/brewery_screen_rebuild_test.dart` / `test/style_screen_rebuild_test.dart`** (new) — a `setThemeMode` change leaves `DrinkCard.debugBuildCount` unchanged; a `toggleFavorite` control case increases it.

## Verification

`./bin/mise run check` green — analyzer clean, **1330 tests pass** (1322 before, +8 new). No golden diffs; `goldens:update` was never run.

**The new tests were proven non-vacuous.** The naive `context.select((p) => p.allDrinks)` implementation was written deliberately and the suite re-run: `test/brewery_screen_test.dart`'s `'reflects favorite state as a status badge on the card'` went **red**, and the new `toggleFavorite` control case went **red** too — both correctly failing to observe the favourite change. Restoring the revision-tuple select returned both to green.

That matters because the failure mode here is a favourite silently not updating on screen, which a passing suite can otherwise conceal.

## Note on the discarded select

```dart
context.select<BeerProvider, (int, int)>(
  (p) => (p.catalogueRevision, p.personalStateRevision),
);
```

The tuple's value is intentionally unused — the call exists only to subscribe. Assigning it to a local would trip the fatal `unused_local_variable` lint, so the bare statement is the correct form. This is a new idiom in this codebase, hence the comment at each call site.

Refs #523

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDwLmn1bwD3mDRZANHbpXe)_